### PR TITLE
fix bevel gear geometry for high gear ratios

### DIFF
--- a/lib/geargen/bevelgear.md
+++ b/lib/geargen/bevelgear.md
@@ -38,9 +38,17 @@ Driving Gear Bore Diameter: user-specified positive number, default 0mm. Only co
 
 Pinion Gear Bore Diameter: user-specified positive number, default 0mm. Only consulted when Enable Bore is checked. A value of 0 means "auto-calculate" — use `Pinion Gear Pitch Diameter / 4` as the bore diameter.
 
-Face Width: User-specified positive number. If unspecified, calculate from (Cone Distance / 6).
+Face Width: User-specified positive number. If unspecified, default to (Cone Distance / 6). In **every** case (default or user-specified) the Face Width is bounded by the Maximum Face Width (defined below):
+- If unspecified, use `min(Cone Distance / 6, Maximum Face Width)`.
+- If the user specifies a value greater than the Maximum Face Width, this is an error: reject it with a message stating the maximum, rather than proceeding (the gear-body revolve in "Create the Pinion Gear" would otherwise fail — see the Maximum Face Width rationale).
 
 Cone Distance: calculated number. `sqrt((Module * Driving Gear Teeth Number)**2 + (Module * Pinion Gear Teeth Number)**2)`.
+
+Maximum Face Width: a geometric upper bound that cannot be evaluated until the Gear Profiles sketch points A, B, C, D, H, J exist (see §2 — apply the bound there). It is `0.95 *` the smaller of:
+- the perpendicular distance from point A to the line through C and H (the Pinion Gear Dedendum line, i.e. Apex2->C extended), and
+- the perpendicular distance from point B to the line through D and J (the Driving Gear Dedendum line, i.e. Apex2->D extended).
+
+Rationale (do not drop this when regenerating): the toe line M->N is C->H offset *toward the Apex* by Face Width, with N pinned to line A->Apex2; its mirror O->P is D->J offset toward the Apex by Face Width, with P pinned to line B->Apex2. When the offset reaches the perpendicular distance from A to line C->H, point N lands exactly on A; any larger value drives N **past** A, across the gear's own shaft axis (Apex->A). The frustum profile (hexagon A, G, H, C, M, N, built here in §2 and revolved later in "Create the Pinion Gear") is revolved about that shaft axis, so a profile that has crossed the axis self-intersects the axis of revolution and Fusion aborts the revolve (`RuntimeError ... ASM_WIRE_X_AXIS ... the profile crosses the axis of revolution`). The pinion side is normally the binding one (its smaller pitch radius gives the smaller distance), but compute both and take the minimum so the bound holds for any Shaft Angle. The `0.95` factor keeps N clearly off A, since a near-coincident N≈A degenerates the toe edge even before it strictly crosses. At Shaft Angle 90° this limit equals `Pinion Gear Pitch Diameter**2 / (2 * Cone Distance)`, so the naive `Cone Distance / 6` default exceeds it — and the gear fails to generate — for any gear ratio above roughly √2 (e.g. Driving 31 / Pinion 17).
 
 ## Instructions
 
@@ -121,7 +129,9 @@ Draw a construction line away from Apex, starting from point G. This new line sh
 
 Draw a construction line from point C to K. Constrain both ends appropriately. C->K should be colinear with Apex2->C.
 
-Create line starting from Apex->C up to line A->Apex2. The new line should be parallel to C->H. The line should have a dimensional constraint against C->H, with a dimension equal to Face Width.
+At this point all of A, B, C, D, H, J exist, so resolve the **Maximum Face Width** (see the Parameters section) and apply it before using Face Width below: cap the auto default to it, and reject a user value that exceeds it. Skipping this makes the M->N line below push point N across the shaft axis for gear ratios above ~√2, which fails the gear-body revolve in "Create the Pinion Gear".
+
+Create line starting from Apex->C up to line A->Apex2. The new line should be parallel to C->H. The line should have a dimensional constraint against C->H, with a dimension equal to Face Width. (N is pinned to line A->Apex2; the Maximum Face Width above is exactly the value at which N would reach A, so the capped Face Width keeps N between Apex2 and A.)
 
 Let the beginning of this new line to be point M, let the end of of this line be point N. Draw a line from M to C. Draw a line from N to A.
 

--- a/lib/geargen/bevelgear.py
+++ b/lib/geargen/bevelgear.py
@@ -780,16 +780,51 @@ class BevelGearGenerator:
         constraints.addCoincident(cToK.startSketchPoint, pointC)
         constraints.addCoincident(cToK.endSketchPoint, pointK)
 
+        # Geometric upper bound on Face Width. The toe line M->N (and its
+        # driving-side mirror O->P) is parallel to the heel dedendum line
+        # C->H, offset toward the apex by Face Width, with N pinned to lineA2
+        # (A->Apex2) and P pinned to lineB2 (B->Apex2). Once that offset
+        # reaches the perpendicular distance from A to the C->H line, N lands
+        # exactly on A; any larger value pushes N across the gear's shaft
+        # axis, so the revolved hexagon self-intersects the rotation axis and
+        # Fusion aborts the revolve (RuntimeError "ASM_WIRE_X_AXIS ... profile
+        # crosses the axis of revolution"). The pinion is the binding side
+        # (its smaller pitch radius gives the smaller bound), but we compute
+        # both and take the min so the cap holds for any Shaft Angle. This is
+        # what made e.g. driving=31 / pinion=17 fail with the default width:
+        # the bound is exceeded for any ratio above ~sqrt(2) at Σ = 90°.
+        pinionDedUx = pinionDedDx / pinionDedLen
+        pinionDedUy = pinionDedDy / pinionDedLen
+        pinionFaceWidthMax_cm = abs(
+            (pointA.geometry.x - pointC.geometry.x) * pinionDedUy
+            - (pointA.geometry.y - pointC.geometry.y) * pinionDedUx)
+        drivingDedUx = drivingDedDx / drivingDedLen
+        drivingDedUy = drivingDedDy / drivingDedLen
+        drivingFaceWidthMax_cm = abs(
+            (pointB.geometry.x - pointD.geometry.x) * drivingDedUy
+            - (pointB.geometry.y - pointD.geometry.y) * drivingDedUx)
+        # 0.95 leaves a margin so N stays clearly off A (a near-coincident
+        # N≈A degenerates the toe edge even before it crosses).
+        faceWidthLimit_cm = 0.95 * min(
+            pinionFaceWidthMax_cm, drivingFaceWidthMax_cm)
+
         # Face Width resolution: user value if > 0, else (Cone Distance)/6.
         # The doc's "Cone Distance = hypot(DPD, PPD)" is exactly 2R at
         # Σ = 90°. Generalized to any Σ, the equivalent length along the
         # pitch line from apex to heel is R = cone_R_cm; doubling that
         # preserves the original default magnitude for Σ = 90° so existing
-        # configurations pick the same face width they always did.
+        # configurations pick the same face width they always did. Both the
+        # default and a user value are capped by faceWidthLimit_cm above.
         if self._faceWidth_cm > 0:
             faceWidth_cm = self._faceWidth_cm
+            if faceWidth_cm > faceWidthLimit_cm:
+                raise Exception(
+                    'Face Width {:.2f} mm is too large for these tooth '
+                    'counts and shaft angle: the pinion toe would cross its '
+                    'shaft axis. Maximum is {:.2f} mm.'.format(
+                        faceWidth_cm * 10.0, faceWidthLimit_cm * 10.0))
         else:
-            faceWidth_cm = (2.0 * cone_R_cm) / 6.0
+            faceWidth_cm = min((2.0 * cone_R_cm) / 6.0, faceWidthLimit_cm)
 
         # Doc line 115: a new line from pinionRootAxis (Apex->C) to lineA2
         # (A->Apex2), parallel to C->H. M on pinionRootAxis, N on lineA2.

--- a/lib/geargen/bevelgear.py
+++ b/lib/geargen/bevelgear.py
@@ -1519,7 +1519,12 @@ class BevelGearGenerator:
         # The doc asks for a post-draw rotation around the axis created below.
         # The drawer's built-in `angle` kwarg produces the same final
         # geometry (rotated tooth around the anchor) without needing a
-        # separate Move feature, so we use it here.
+        # separate Move feature, so we use it here. This equivalence relies on
+        # every tooth entity -- including the root-to-involute connecting lines
+        # -- being constrained to rotate with the tooth; see the radial pin in
+        # SpurGearInvoluteToothDesignGenerator.drawTooth.drawRootToInvoluteLine.
+        # (Without it, non-embedded virtual teeth -- e.g. the pinion at
+        # driving=31/pinion=17 -- left those two lines behind when rotated.)
         drawer.draw(anchorPoint, angle=math.radians(rotationDegrees))
 
         # Construction axis through anchorPoint perpendicular to the tooth

--- a/lib/geargen/spurgear.py
+++ b/lib/geargen/spurgear.py
@@ -251,6 +251,17 @@ class SpurGearInvoluteToothDesignGenerator():
 
             line = sketch.sketchCurves.sketchLines.addByTwoPoints(point, inv.startSketchPoint)
             constraints.addCoincident(line.startSketchPoint, root)
+            # Pin the root end radially. The root point, the involute start and
+            # the gear center are collinear by construction (they share one
+            # polar angle), so constrain the center onto this line's infinite
+            # extension. Without it the root point keeps only its
+            # on-root-circle constraint -- one free DOF -- so when the tooth is
+            # later rotated (drawTooth's `angle`, used by the bevel virtual
+            # tooth profiles) the involute end swings around the center while
+            # the root point stays put, leaving these two connecting lines
+            # skewed and detached from the tooth. At angle=0 the point was
+            # already drawn in the right place, just under-constrained.
+            constraints.addCoincident(anchorPoint, line)
             return line
 
 #        if rootCircleRadius > baseCircleRadius:


### PR DESCRIPTION
- Cap Face Width to a geometric maximum so the frustum revolve no longer crosses its own shaft axis; previously failed for gear ratios above ~√2 (e.g. driving 31 / pinion 17).
- Reject an over-large user Face Width with a clear message instead of the raw revolve error.
- Pin the tooth root-to-involute connecting lines so they rotate with the tooth; fixes the skewed pinion profile for non-embedded virtual teeth (same 31/17 case).
- Document the Face Width bound in `bevelgear.md` so a regeneration keeps the guard.
