### PR TITLE
add configurable tooth spacing to bevel gear

### DIFF
--- a/lib/geargen/bevelgear.md
+++ b/lib/geargen/bevelgear.md
@@ -52,6 +52,8 @@ Maximum Face Width: a geometric upper bound that cannot be evaluated until the G
 
 Rationale (do not drop this when regenerating): the toe line M->N is C->H offset *toward the Apex* by Face Width, with N pinned to line A->Apex2; its mirror O->P is D->J offset toward the Apex by Face Width, with P pinned to line B->Apex2. When the offset reaches the perpendicular distance from A to line C->H, point N lands exactly on A; any larger value drives N **past** A, across the gear's own shaft axis (Apex->A). The frustum profile (hexagon A, G, H, C, M, N, built here in §2 and revolved later in "Create the Pinion Gear") is revolved about that shaft axis, so a profile that has crossed the axis self-intersects the axis of revolution and Fusion aborts the revolve (`RuntimeError ... ASM_WIRE_X_AXIS ... the profile crosses the axis of revolution`). The pinion side is normally the binding one (its smaller pitch radius gives the smaller distance), but compute both and take the minimum so the bound holds for any Shaft Angle. The `0.95` factor keeps N clearly off A, since a near-coincident N≈A degenerates the toe edge even before it strictly crosses. At Shaft Angle 90° this limit equals `Pinion Gear Pitch Diameter**2 / (2 * Cone Distance)`, so the naive `Cone Distance / 6` default exceeds it — and the gear fails to generate — for any gear ratio above roughly √2 (e.g. Driving 31 / Pinion 17).
 
+Tooth Spacing: user-specified non-negative number in mm, default 0mm. A single value applied to **both** gears. It is a clearance offset that shifts each virtual spur tooth profile's **center** radially outward along the dedendum line — *away from the lower corner* (the rim corner opposite the Apex: point C for the pinion, point D for the driving gear), i.e. in the C->K direction beyond K (and D->L beyond L) — by this distance, **while the tooth itself is still drawn at the original virtual pitch radius** (virtual tooth number × Module / 2; the virtual tooth number is unchanged). At 0 (the default) the tooth center sits exactly at K / L and the generated geometry is byte-for-byte the prior behavior; a positive value moves the center farther from the rim, loosening the mesh so 3D-printed teeth have more clearance. Applied in §3; see "Gear Tooth Profiles".
+
 ### Exact input ids and parameter-name strings
 
 These literal strings are part of the reproduced surface. Use them verbatim. The dialog **display
@@ -74,6 +76,7 @@ numeric/bool fields. Module-level constants name the input ids (`INPUT_ID_PLANE 
 | 11 | Driving Gear Bore Diameter | `drivingBore` | `addValueInput` | `mm` | `createByReal(to_cm(0))` | — |
 | 12 | Pinion Gear Bore Diameter | `pinionBore` | `addValueInput` | `mm` | `createByReal(to_cm(0))` | — |
 | 13 | Face Width | `faceWidth` | `addValueInput` | `mm` | `createByReal(to_cm(0))` | — |
+| 14 | Tooth Spacing | `toothSpacing` | `addValueInput` | `mm` | `createByReal(to_cm(0))` | — |
 
 Selection filters and limit-1 are set per PLAYBOOK; the Parent selection pre-selects
 `get_design().rootComponent`. The numeric `mm`/`deg` defaults are passed in internal units
@@ -86,7 +89,7 @@ under a prefix. Every value (pitch diameters, cone distance, base heights, bore 
 tooth counts, face width) is **precomputed in Python in internal cm** and written into geometry
 numerically — sketch dimensions via `dimension.parameter.value = <number>` and feature inputs via
 `ValueInput.createByReal(<number>)`. There are therefore no `PARAM_*` name strings to reproduce;
-the only module-level constants are the 13 `INPUT_ID_*` strings. (See PLAYBOOK, "all-Python-
+the only module-level constants are the 14 `INPUT_ID_*` strings. (See PLAYBOOK, "all-Python-
 precomputed mode".)
 
 **Reading the raw numbers.** Read each numeric/angle input by evaluating its expression with units
@@ -94,7 +97,8 @@ precomputed mode".)
 regardless of the unit string (see PLAYBOOK).
 
 **Units — critical (Module is unitless mm; everything else is already internal):**
-- The `'mm'` inputs (Driving/Pinion Base Height, Driving/Pinion Bore Diameter, Face Width) and the
+- The `'mm'` inputs (Driving/Pinion Base Height, Driving/Pinion Bore Diameter, Face Width, Tooth
+  Spacing) and the
   `'deg'` input (Shaft Angle) come back from `evaluateExpression(expr, 'mm'|'deg')` **already in
   internal units** (cm / radians). Use them as-is; do **not** `to_cm` them again.
 - **`Module` is read with unit `''`, so it comes back as a raw number that means *millimetres*** (a
@@ -108,7 +112,7 @@ regardless of the unit string (see PLAYBOOK).
   Module-derived Maximum Face Width) without this conversion makes the gear come out ~10× off and
   the Face-Width bound meaningless. The boolean Enable-Bore input is read with
 `get_boolean` (or `input.value`). Read all inputs up front in a single `_readInputs` pass that
-validates ranges (teeth ≥ 3, shaft angle 30–150°, non-negative heights/bores/width) and returns the
+validates ranges (teeth ≥ 3, shaft angle 30–150°, non-negative heights/bores/width/tooth-spacing) and returns the
 primary values, stashing the rest on `self`.
 
 ## Architecture
@@ -118,7 +122,7 @@ Bevel uses a **standalone generator** — it does **not** subclass `base.Generat
 the first and third by name):
 
 1. **`BevelGearCommandInputsConfigurator`** — `@classmethod def configure(cls, cmd)` that adds the
-   13 dialog inputs above in display order.
+   14 dialog inputs above in display order.
 2. **`BevelGearGenerator`** — `__init__(self, design)` (stores `self.design`, `self.bevelOccurrence
    = None`); `generate(inputs)`; `deleteComponent()`. Creates the occurrence tree directly with
    `parent.occurrences.addNewComponent(...)` — it does **not** use `getOccurrence` / `addParameter`
@@ -135,7 +139,7 @@ Bevel carries **no `GenerationContext` object.** State is threaded three ways: (
 returns a 7-tuple `(parentComponent, targetPlane, centerPoint, module, drivingTeeth, pinionTeeth,
 shaftAngle_deg)` and stashes the rest as instance attributes (`self._drivingBaseHeight_cm`,
 `self._pinionBaseHeight_cm`, `self._boreEnable`, `self._drivingBore_cm`, `self._pinionBore_cm`,
-`self._faceWidth_cm`); (b) the ~30 geometric anchors (Apex, Apex2, points A–P, K, L, the two shaft
+`self._faceWidth_cm`, `self._toothSpacing_cm`); (b) the ~30 geometric anchors (Apex, Apex2, points A–P, K, L, the two shaft
 axes, the cone-cutter faces, the two tooth sketches, the per-gear bodies) are passed as locals /
 return values between `_buildGearProfiles` and the per-gear helpers; (c) `self.bevelOccurrence`
 holds the top occurrence for cleanup. A regenerated bevel must not introduce a `ctx` object.
@@ -332,6 +336,8 @@ Constrain Point I with center point.
 
 Draw a construction line away from Apex, starting from point G, extending along Apex->A, and call its end point K. Then **pin K with two point-on-line coincident constraints** — `addCoincident(K, line Apex->A)` and `addCoincident(K, the Pinion Dedendum line Apex2->C extended)` — rather than `addCollinear` on the connecting lines. By the time K is added, G and C are already fixed, so an `addCollinear` here over-constrains the sketch and Fusion errors; the two point-on-line coincidents locate K exactly (intersection of the two lines) without over-constraining. Draw a construction line from point C to K for reference.
 
+**Tooth-center point K′ (Tooth Spacing offset).** The §3 spur tooth is centered not at K but at a tooth-center point **K′**, obtained by shifting K outward along the dedendum line by **Tooth Spacing**, *away from the lower corner C*. **When Tooth Spacing is 0 (the default), do NOT build anything here — set K′ ≡ K and reuse the C->K reference line**, so the output stays byte-identical to the no-spacing build (a zero-length dimensioned line would be degenerate). When Tooth Spacing > 0: draw a construction line starting at K with its far end seeded on the *far side of K from C* along the dedendum direction; pin its far end **the same way K is pinned to its line** — `addCoincident(start, K)` and `addCoincident(K′, the Pinion Dedendum line Apex2->C extended)` to keep K′ on the dedendum line — then add a **length dimension on this line = Tooth Spacing** (do **not** use `addCollinear`, for the same over-constraint reason as K). The far end is K′. Build it **here, inside the Gear Profiles sketch, before that sketch's end-of-step full-constraint gate**, so the gate covers it. Finally draw the **tooth-center reference line C->K′** (from the lower corner C to K′) for §3 to use in place of C->K. Only the tooth's center moves; the virtual tooth number and drawn tooth size are unchanged (see §3).
+
 At this point all of A, B, C, D, H, J exist **and are solved**, so resolve the **Maximum Face Width** (see the Parameters section) from their solved `.geometry` (NOT the seed coordinates — see that section) and apply it before using Face Width below: cap the auto default to it, and reject a user value that exceeds it. Skipping this — or computing it from seeds — makes the M->N / O->P line push N/P across the shaft axis for asymmetric tooth counts (either gear can be the smaller, binding side), which fails the gear-body revolve with `ASM_WIRE_X_AXIS`.
 
 Create line M->N. **Seed it near its solved position** (the solver is seed-sensitive — see PLAYBOOK): seed M at roughly the **midpoint of Apex->C**, and seed N by sliding from that M-seed **along the C->H direction far enough to roughly reach line A->Apex2** (e.g. by the distance from the M-seed to A). Do NOT seed M/N just `Face Width` away from C/H — that starts N near H, far from its constraint target (line A->Apex2), and the solve fails to converge. Then apply **exactly these constraints** — all four are required, and the two coincident pins are what make the Maximum-Face-Width guarantee real (N reaches A exactly at the cap):
@@ -346,6 +352,8 @@ Let the beginning of this new line be point M, the end be point N. Draw a line f
 
 Draw a construction line away from Apex, starting from point I, extending along Apex->B, and call its end point L. **Pin L the same way as K** — `addCoincident(L, line Apex->B)` and `addCoincident(L, the Driving Dedendum line Apex2->D extended)`; do not use `addCollinear`. Draw a construction line from point D to L for reference.
 
+**Tooth-center point L′ (Tooth Spacing offset).** Build the driving-side tooth center **L′** exactly as K′ on the pinion side: when Tooth Spacing is 0, set L′ ≡ L and reuse the D->L reference line; when Tooth Spacing > 0, draw a construction line from L seeded on the far side of L from D along the driving dedendum direction, pin its far end with `addCoincident(start, L)` and `addCoincident(L′, the Driving Dedendum line Apex2->D extended)`, add a length dimension on it = Tooth Spacing (no `addCollinear`), and draw the tooth-center reference line **D->L′** for §3. Same single Tooth Spacing value as the pinion; same full-constraint and "byte-identical at 0" guarantees.
+
 Create line O->P, the mirror of M->N on the driving side. Seed it the same way (O near the midpoint of Apex->D, P slid along D->J toward line B->Apex2), then apply the same four constraints:
 - `addCoincident(O, Driving Root Axis)` — O on the Apex->D root axis;
 - `addCoincident(P, line B->Apex2)` — P on the B->Apex2 line, i.e. the perpendicular DROP line of length DPD/2 drawn "From B, perpendicular to the Driving Gear Shaft Axis" — **NOT the Apex->B shaft axis** (same trap as N above; pinning P to the shaft axis puts it on the axis of revolution and breaks the cut);
@@ -359,21 +367,23 @@ Let the beginning of this new line be point O, the end be point P. Draw a line f
 **API note for this whole section:** pass the relevant **sketch line directly** to `setByAngle` and
 `setByDistanceOnPath`; never wrap it in `Path.create` first (see PLAYBOOK).
 
-Compute the pinion's virtual (back-cone / Tredgold) tooth number from the closed form, **not** by measuring Apex2->K (K is still used as the tooth's center point, below): virtual pitch radius = `(Pinion Gear Pitch Diameter / 2) / cos(γ_p)`, where `γ_p` is the pinion pitch-cone half-angle from §2 (`tan γ_p = sin Σ · PPD / (DPD + PPD · cos Σ)`). Virtual tooth number = `floor(2 · virtualPitchRadius / Module)`, as an int. (Module here is the raw mm value; the radius is a length — keep the unit handling consistent, see the Units note.)
+**Throughout this section the tooth center is the §2 tooth-center point K′ (pinion) / L′ (driving) and the center reference line is C->K′ / D->L′ — which equal K / L and C->K / D->L exactly when Tooth Spacing is 0.** The virtual tooth number below is computed from the pitch diameter and is **independent of Tooth Spacing**; the spacing offset moves only the center, not the tooth size.
 
-Create a new plane that includes line C->K. Use setByAngle to make this plane perpendicular to the Gear Profiles sketch plane.
+Compute the pinion's virtual (back-cone / Tredgold) tooth number from the closed form, **not** by measuring Apex2->K′ (the tooth-center point K′ is used as the tooth's center, below): virtual pitch radius = `(Pinion Gear Pitch Diameter / 2) / cos(γ_p)`, where `γ_p` is the pinion pitch-cone half-angle from §2 (`tan γ_p = sin Σ · PPD / (DPD + PPD · cos Σ)`). Virtual tooth number = `floor(2 · virtualPitchRadius / Module)`, as an int. (Module here is the raw mm value; the radius is a length — keep the unit handling consistent, see the Units note.)
 
-Using the new plane and point K as the center point, create a spur gear tooth profile with module and the virtual tooth number obtained from the previous step. Draw it **already rotated 180°** by passing `angle=math.radians(180)` to the spur tooth generator's `draw(anchorPoint, angle=…)` (see Dependencies) — the generator rotates the whole tooth by that angle; do not draw it flat and rotate the sketch afterward. **After `draw()` returns, assert the tooth sketch is fully constrained: `_assertFullyConstrained(toothSketch)`** — like every other sketch, the tooth sketch must reach zero DOF (the spur generator pins the `angle != 0` reference line; if this raises, the gap is in `spurgear.md`).
+Create a new plane that includes line C->K′. Use setByAngle to make this plane perpendicular to the Gear Profiles sketch plane.
 
-Create a construction axis through point K, normal to the plane the tooth profile was drawn on, via `setByTwoPlanes` (`setByPerpendicularAtPoint` would need a `BRepFace`). The two planes are: the **Gear Profiles plane** and a **helper plane built `setByDistanceOnPath(C->K line, 1.0)`** (perpendicular to C->K at its far end, K); their intersection is the line through K normal to the tooth plane.
+Using the new plane and point K′ as the center point, create a spur gear tooth profile with module and the virtual tooth number obtained from the previous step. Draw it **already rotated 180°** by passing `angle=math.radians(180)` to the spur tooth generator's `draw(anchorPoint, angle=…)` (see Dependencies) — the generator rotates the whole tooth by that angle; do not draw it flat and rotate the sketch afterward. **After `draw()` returns, assert the tooth sketch is fully constrained: `_assertFullyConstrained(toothSketch)`** — like every other sketch, the tooth sketch must reach zero DOF (the spur generator pins the `angle != 0` reference line; if this raises, the gap is in `spurgear.md`).
 
-Compute the driving gear's virtual tooth number the same way (L is still the tooth center): virtual pitch radius = `(Driving Gear Pitch Diameter / 2) / cos(γ_g)`, where `γ_g = Σ − γ_p` is the driving pitch-cone half-angle from §2. Virtual tooth number = `floor(2 · virtualPitchRadius / Module)`, as an int.
+Create a construction axis through point K′, normal to the plane the tooth profile was drawn on, via `setByTwoPlanes` (`setByPerpendicularAtPoint` would need a `BRepFace`). The two planes are: the **Gear Profiles plane** and a **helper plane built `setByDistanceOnPath(C->K′ line, 1.0)`** (perpendicular to C->K′ at its far end, K′); their intersection is the line through K′ normal to the tooth plane.
 
-Create a new plane that includes line D->L. Use setByAngle to make this plane perpendicular to the Gear Profiles sketch plane.
+Compute the driving gear's virtual tooth number the same way (the tooth-center point L′ is used as the tooth center): virtual pitch radius = `(Driving Gear Pitch Diameter / 2) / cos(γ_g)`, where `γ_g = Σ − γ_p` is the driving pitch-cone half-angle from §2. Virtual tooth number = `floor(2 · virtualPitchRadius / Module)`, as an int.
 
-Using the new plane and point L as the center point, create a spur gear tooth profile with module and the virtual tooth number obtained from the previous step. Draw it **already rotated 180°** by passing `angle=math.radians(180)` to the spur tooth generator's `draw(anchorPoint, angle=…)` (see Dependencies), exactly as for the pinion. **After `draw()` returns, assert the tooth sketch is fully constrained: `_assertFullyConstrained(toothSketch)`** (same as the pinion).
+Create a new plane that includes line D->L′. Use setByAngle to make this plane perpendicular to the Gear Profiles sketch plane.
 
-Create a construction axis through point L, normal to the tooth plane, via `setByTwoPlanes`: the **Gear Profiles plane** intersected with a **helper plane `setByDistanceOnPath(D->L line, 1.0)`**.
+Using the new plane and point L′ as the center point, create a spur gear tooth profile with module and the virtual tooth number obtained from the previous step. Draw it **already rotated 180°** by passing `angle=math.radians(180)` to the spur tooth generator's `draw(anchorPoint, angle=…)` (see Dependencies), exactly as for the pinion. **After `draw()` returns, assert the tooth sketch is fully constrained: `_assertFullyConstrained(toothSketch)`** (same as the pinion).
+
+Create a construction axis through point L′, normal to the tooth plane, via `setByTwoPlanes`: the **Gear Profiles plane** intersected with a **helper plane `setByDistanceOnPath(D->L′ line, 1.0)`**.
 
 ## Create the Pinion Gear
 

--- a/lib/geargen/bevelgear.py
+++ b/lib/geargen/bevelgear.py
@@ -8,11 +8,10 @@ import adsk.core, adsk.fusion
 
 
 # ---------------------------------------------------------------------------
-# Dialog input ids (the only module-level constants -- bevel registers no user
-# parameters; every value is precomputed in Python in internal cm).
+# Dialog input ids (the 14 reproduced surface strings, verbatim)
 # ---------------------------------------------------------------------------
 INPUT_ID_PLANE = 'targetPlane'
-INPUT_ID_CENTER_POINT = 'centerPoint'
+INPUT_ID_CENTER = 'centerPoint'
 INPUT_ID_PARENT = 'parentComponent'
 INPUT_ID_MODULE = 'module'
 INPUT_ID_SHAFT_ANGLE = 'shaftAngle'
@@ -24,10 +23,11 @@ INPUT_ID_BORE_ENABLE = 'boreEnable'
 INPUT_ID_DRIVING_BORE = 'drivingBore'
 INPUT_ID_PINION_BORE = 'pinionBore'
 INPUT_ID_FACE_WIDTH = 'faceWidth'
+INPUT_ID_TOOTH_SPACING = 'toothSpacing'
 
-# Pressure angle is not a bevel dialog input; bevel hardcodes the standard 20 deg.
-_PRESSURE_ANGLE_RAD = math.radians(20)
-_INVOLUTE_STEPS = 15
+# Hardcoded pressure angle for the virtual spur teeth (bevel is not a dialog input).
+PRESSURE_ANGLE_RAD = math.radians(20)
+INVOLUTE_STEPS = 15
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +38,7 @@ class BevelGearCommandInputsConfigurator:
     def configure(cls, cmd):
         inputs = cmd.commandInputs
 
-        # 1. Target Plane (selection -- FIRST so it wins Fusion's auto-focus).
+        # 1. Target Plane (selection) -- first so it wins Fusion auto-focus.
         planeInput = inputs.addSelectionInput(
             INPUT_ID_PLANE, 'Target Plane',
             'Select the plane the bottom of the driving gear sits flush against')
@@ -46,15 +46,15 @@ class BevelGearCommandInputsConfigurator:
         planeInput.addSelectionFilter(adsk.core.SelectionCommandInput.PlanarFaces)
         planeInput.setSelectionLimits(1, 1)
 
-        # 2. Center Point (selection).
+        # 2. Center Point (selection)
         centerInput = inputs.addSelectionInput(
-            INPUT_ID_CENTER_POINT, 'Center Point',
+            INPUT_ID_CENTER, 'Center Point',
             'Select the point the driving bevel gear is centered on')
         centerInput.addSelectionFilter(adsk.core.SelectionCommandInput.ConstructionPoints)
         centerInput.addSelectionFilter(adsk.core.SelectionCommandInput.SketchPoints)
         centerInput.setSelectionLimits(1, 1)
 
-        # 3. Parent Component (selection -- pre-selected to the root component).
+        # 3. Parent Component (selection) -- root pre-selected.
         parentInput = inputs.addSelectionInput(
             INPUT_ID_PARENT, 'Parent Component',
             'Select the parent component for the new bevel gear pair')
@@ -63,95 +63,105 @@ class BevelGearCommandInputsConfigurator:
         parentInput.setSelectionLimits(1, 1)
         parentInput.addSelection(get_design().rootComponent)
 
-        # 4. Module (unitless).
+        # 4. Module
         inputs.addValueInput(
             INPUT_ID_MODULE, 'Module', '', adsk.core.ValueInput.createByReal(1))
 
-        # 5. Shaft Angle (deg).
+        # 5. Shaft Angle
         inputs.addValueInput(
             INPUT_ID_SHAFT_ANGLE, 'Shaft Angle', 'deg',
             adsk.core.ValueInput.createByString('90 deg'))
 
-        # 6. Driving Gear Teeth Number.
+        # 6. Driving Gear Teeth
         inputs.addValueInput(
             INPUT_ID_DRIVING_TEETH, 'Driving Gear Teeth', '',
             adsk.core.ValueInput.createByReal(31))
 
-        # 7. Pinion Gear Teeth Number.
+        # 7. Pinion Gear Teeth
         inputs.addValueInput(
             INPUT_ID_PINION_TEETH, 'Pinion Gear Teeth', '',
             adsk.core.ValueInput.createByReal(31))
 
-        # 8. Driving Gear Base Height (mm).
+        # 8. Driving Gear Base Height
         inputs.addValueInput(
             INPUT_ID_DRIVING_BASE_HEIGHT, 'Driving Gear Base Height', 'mm',
             adsk.core.ValueInput.createByReal(to_cm(0)))
 
-        # 9. Pinion Gear Base Height (mm).
+        # 9. Pinion Gear Base Height
         inputs.addValueInput(
             INPUT_ID_PINION_BASE_HEIGHT, 'Pinion Gear Base Height', 'mm',
             adsk.core.ValueInput.createByReal(to_cm(0)))
 
-        # 10. Enable Bore (checkbox).
+        # 10. Enable Bore (checkbox)
         inputs.addBoolValueInput(
             INPUT_ID_BORE_ENABLE, 'Enable Bore', True, '', True)
 
-        # 11. Driving Gear Bore Diameter (mm).
+        # 11. Driving Gear Bore Diameter
         inputs.addValueInput(
             INPUT_ID_DRIVING_BORE, 'Driving Gear Bore Diameter', 'mm',
             adsk.core.ValueInput.createByReal(to_cm(0)))
 
-        # 12. Pinion Gear Bore Diameter (mm).
+        # 12. Pinion Gear Bore Diameter
         inputs.addValueInput(
             INPUT_ID_PINION_BORE, 'Pinion Gear Bore Diameter', 'mm',
             adsk.core.ValueInput.createByReal(to_cm(0)))
 
-        # 13. Face Width (mm).
+        # 13. Face Width
         inputs.addValueInput(
             INPUT_ID_FACE_WIDTH, 'Face Width', 'mm',
             adsk.core.ValueInput.createByReal(to_cm(0)))
 
+        # 14. Tooth Spacing
+        inputs.addValueInput(
+            INPUT_ID_TOOTH_SPACING, 'Tooth Spacing', 'mm',
+            adsk.core.ValueInput.createByReal(to_cm(0)))
+
 
 # ---------------------------------------------------------------------------
-# Virtual spur proxy -- a fake spur `parent` so the borrowed spur tooth
-# generator runs without registering Fusion user parameters.
+# Value-wrapper + virtual spur proxy (fake parent for the borrowed spur drawer)
 # ---------------------------------------------------------------------------
 class _Val:
-    """Tiny value-wrapper exposing `.value`, matching UserParameter's surface."""
+    """Tiny wrapper exposing a `.value` attribute, mimicking a UserParameter."""
     def __init__(self, value):
         self.value = value
 
 
 class _VirtualSpurProxy:
-    """Precomputes (in internal cm) exactly the keys the spur tooth drawer reads.
+    """A fake spur `parent` so SpurGearInvoluteToothDesignGenerator can read the
+    parameters it needs (via parent.getParameter(name).value) without registering
+    any real Fusion user parameters.
 
-    The spur generator reads parameters via `parent.getParameter(name).value`.
-    Module arrives in raw mm and the standard spur formulas are applied, then the
-    resulting circle radii/diameters are `to_cm`'d (they must be in cm to match
-    what the spur tooth generator expects)."""
-
+    module_mm is the raw-mm Module value; virtualTeeth is the Tredgold/back-cone
+    virtual tooth number. All served circle radii/diameters are in internal cm.
+    """
     def __init__(self, module_mm, virtualTeeth):
-        alpha = _PRESSURE_ANGLE_RAD
-        pitch_mm = module_mm * virtualTeeth
-        base_mm = pitch_mm * math.cos(alpha)
-        root_mm = pitch_mm - 2.5 * module_mm
-        tip_mm = pitch_mm + 2.0 * module_mm
+        moduleCm = to_cm(module_mm)
+        teeth = int(virtualTeeth)
+
+        pitchDiameter = moduleCm * teeth
+        pitchRadius = pitchDiameter / 2
+        baseDiameter = pitchDiameter * math.cos(PRESSURE_ANGLE_RAD)
+        baseRadius = baseDiameter / 2
+        rootDiameter = pitchDiameter - 2.5 * moduleCm
+        rootRadius = rootDiameter / 2
+        tipDiameter = pitchDiameter + 2 * moduleCm
+        tipRadius = tipDiameter / 2
 
         self._values = {
-            'Module': module_mm,
-            'ToothNumber': virtualTeeth,
-            'PressureAngle': alpha,
-            'InvoluteSteps': _INVOLUTE_STEPS,
-            'PitchCircleDiameter': to_cm(pitch_mm),
-            'PitchCircleRadius': to_cm(pitch_mm / 2),
-            'BaseCircleDiameter': to_cm(base_mm),
-            'BaseCircleRadius': to_cm(base_mm / 2),
-            'RootCircleDiameter': to_cm(root_mm),
-            'RootCircleRadius': to_cm(root_mm / 2),
-            'TipCircleDiameter': to_cm(tip_mm),
-            'TipCircleRadius': to_cm(tip_mm / 2),
+            'Module': moduleCm,
+            'ToothNumber': teeth,
+            'PressureAngle': PRESSURE_ANGLE_RAD,
+            'PitchCircleDiameter': pitchDiameter,
+            'PitchCircleRadius': pitchRadius,
+            'BaseCircleDiameter': baseDiameter,
+            'BaseCircleRadius': baseRadius,
+            'RootCircleDiameter': rootDiameter,
+            'RootCircleRadius': rootRadius,
+            'TipCircleDiameter': tipDiameter,
+            'TipCircleRadius': tipRadius,
+            'InvoluteSteps': INVOLUTE_STEPS,
         }
-        # The spur tooth generator records embedded-ness here.
+        # The spur drawer records embedded-ness on the parent; absorb it here.
         self._lastToothEmbedded = False
 
     def getParameter(self, name):
@@ -159,35 +169,47 @@ class _VirtualSpurProxy:
 
 
 # ---------------------------------------------------------------------------
-# Bevel gear generator (standalone -- does NOT subclass base.Generator).
+# Bevel gear generator (standalone -- does NOT subclass base.Generator)
 # ---------------------------------------------------------------------------
 class BevelGearGenerator:
     def __init__(self, design: adsk.fusion.Design):
         self.design = design
         self.bevelOccurrence = None
 
-        # Stashed inputs (filled by _readInputs).
+        # Stashed inputs (set in _readInputs).
         self._drivingBaseHeight_cm = 0.0
         self._pinionBaseHeight_cm = 0.0
         self._boreEnable = True
         self._drivingBore_cm = 0.0
         self._pinionBore_cm = 0.0
         self._faceWidth_cm = 0.0
+        self._toothSpacing_cm = 0.0
+        self._faceWidthSpecified = False
 
-        # Stashed anchor-sketch projected center point (set in _buildAnchorSketch).
+        # Stashed center sketch point from the Anchor Sketch (re-projected in §2).
         self._anchorCenterPoint = None
 
-    # ===================================================================
-    # input reading
-    # ===================================================================
-    def _readInputs(self, inputs: adsk.core.CommandInputs):
+    # ----- error rollback -----
+    def deleteComponent(self):
+        if self.bevelOccurrence:
+            self.bevelOccurrence.deleteMe()
+            self.bevelOccurrence = None
+
+    # ----- full-constraint gate -----
+    def _assertFullyConstrained(self, sketch, name):
+        if not sketch.isFullyConstrained:
+            raise Exception(
+                f'Sketch "{name}" is not fully constrained (free DOF remain)')
+
+    # ----- input reading + validation -----
+    def _readInputs(self, inputs):
         unitsManager = self.design.unitsManager
 
-        def evalExpr(input_id, units):
-            inp = inputs.itemById(input_id)
+        def rawValue(id, units):
+            inp = inputs.itemById(id)
             return unitsManager.evaluateExpression(inp.expression, units)
 
-        # Selections.
+        # --- selections ---
         (parents, _) = get_selection(inputs, INPUT_ID_PARENT)
         if len(parents) != 1:
             raise Exception('Exactly one parent component must be selected')
@@ -204,57 +226,80 @@ class BevelGearGenerator:
             raise Exception('Exactly one target plane must be selected')
         targetPlane = planes[0]
 
-        (centers, _) = get_selection(inputs, INPUT_ID_CENTER_POINT)
+        (centers, _) = get_selection(inputs, INPUT_ID_CENTER)
         if len(centers) != 1:
             raise Exception('Exactly one center point must be selected')
         centerPoint = centers[0]
 
-        # Module: unit '' -> raw number meaning millimetres.
-        module = evalExpr(INPUT_ID_MODULE, '')
+        # --- Module: read with unit '' -> raw number meaning millimetres ---
+        module = rawValue(INPUT_ID_MODULE, '')
+        if module <= 0:
+            raise Exception('Module must be a positive number')
 
-        # Shaft angle: comes back in radians; convert to degrees for range check.
-        shaftAngle_rad = evalExpr(INPUT_ID_SHAFT_ANGLE, 'deg')
+        # --- Teeth ---
+        drivingTeeth = int(round(rawValue(INPUT_ID_DRIVING_TEETH, '')))
+        pinionTeeth = int(round(rawValue(INPUT_ID_PINION_TEETH, '')))
+        if drivingTeeth < 3:
+            raise Exception('Driving gear must have at least 3 teeth')
+        if pinionTeeth < 3:
+            raise Exception('Pinion gear must have at least 3 teeth')
+
+        # --- Shaft angle: comes back in radians; convert to degrees to range-check ---
+        shaftAngle_rad = rawValue(INPUT_ID_SHAFT_ANGLE, 'deg')
         shaftAngle_deg = math.degrees(shaftAngle_rad)
         if shaftAngle_deg < 30 or shaftAngle_deg > 150:
-            raise Exception(
-                f'Shaft Angle must be between 30 and 150 degrees (got {shaftAngle_deg:.3f})')
+            raise Exception('Shaft angle must be between 30 and 150 degrees')
 
-        drivingTeeth = int(round(evalExpr(INPUT_ID_DRIVING_TEETH, '')))
-        pinionTeeth = int(round(evalExpr(INPUT_ID_PINION_TEETH, '')))
-        if drivingTeeth < 3 or pinionTeeth < 3:
-            raise Exception('Tooth numbers must be at least 3')
+        # --- 'mm' inputs: already in internal cm -- use as-is ---
+        self._drivingBaseHeight_cm = rawValue(INPUT_ID_DRIVING_BASE_HEIGHT, 'mm')
+        self._pinionBaseHeight_cm = rawValue(INPUT_ID_PINION_BASE_HEIGHT, 'mm')
+        self._drivingBore_cm = rawValue(INPUT_ID_DRIVING_BORE, 'mm')
+        self._pinionBore_cm = rawValue(INPUT_ID_PINION_BORE, 'mm')
+        self._faceWidth_cm = rawValue(INPUT_ID_FACE_WIDTH, 'mm')
+        self._toothSpacing_cm = rawValue(INPUT_ID_TOOTH_SPACING, 'mm')
 
-        # 'mm' inputs come back already in internal cm -- use as-is, do NOT to_cm again.
-        self._drivingBaseHeight_cm = evalExpr(INPUT_ID_DRIVING_BASE_HEIGHT, 'mm')
-        self._pinionBaseHeight_cm = evalExpr(INPUT_ID_PINION_BASE_HEIGHT, 'mm')
-        (self._boreEnable, _) = get_boolean(inputs, INPUT_ID_BORE_ENABLE)
-        self._drivingBore_cm = evalExpr(INPUT_ID_DRIVING_BORE, 'mm')
-        self._pinionBore_cm = evalExpr(INPUT_ID_PINION_BORE, 'mm')
-        self._faceWidth_cm = evalExpr(INPUT_ID_FACE_WIDTH, 'mm')
+        (boreEnable, _) = get_boolean(inputs, INPUT_ID_BORE_ENABLE)
+        self._boreEnable = boreEnable
 
-        if (self._drivingBaseHeight_cm < 0 or self._pinionBaseHeight_cm < 0
-                or self._drivingBore_cm < 0 or self._pinionBore_cm < 0
-                or self._faceWidth_cm < 0):
-            raise Exception('Base heights, bore diameters and face width must be non-negative')
+        if self._drivingBaseHeight_cm < 0:
+            raise Exception('Driving gear base height must be non-negative')
+        if self._pinionBaseHeight_cm < 0:
+            raise Exception('Pinion gear base height must be non-negative')
+        if self._drivingBore_cm < 0:
+            raise Exception('Driving gear bore diameter must be non-negative')
+        if self._pinionBore_cm < 0:
+            raise Exception('Pinion gear bore diameter must be non-negative')
+        if self._faceWidth_cm < 0:
+            raise Exception('Face width must be non-negative')
+        if self._toothSpacing_cm < 0:
+            raise Exception('Tooth spacing must be non-negative')
 
-        return (parentComponent, targetPlane, centerPoint,
-                module, drivingTeeth, pinionTeeth, shaftAngle_deg)
+        # Face width "unspecified" means default (0).
+        self._faceWidthSpecified = self._faceWidth_cm > 0
 
-    # ===================================================================
-    # small helpers
-    # ===================================================================
-    def _assertFullyConstrained(self, sketch, name):
-        if not sketch.isFullyConstrained:
-            raise Exception(f'Sketch "{name}" is not fully constrained (free DOF remain)')
+        return (parentComponent, targetPlane, centerPoint, module,
+                drivingTeeth, pinionTeeth, shaftAngle_deg)
 
-    def _pointWorldGeometry(self, point):
-        """World Point3D for a SketchPoint (.worldGeometry) or ConstructionPoint (.geometry)."""
-        if point.objectType == adsk.fusion.SketchPoint.classType():
-            return point.worldGeometry
-        return point.geometry
+    # ----- helpers -----
+    def _pointWorldGeometry(self, entity):
+        """World Point3D for a SketchPoint (worldGeometry) or ConstructionPoint (geometry)."""
+        if entity.objectType == adsk.fusion.SketchPoint.classType():
+            return entity.worldGeometry
+        return entity.geometry
+
+    def _perpDistancePointToLine(self, p, a, b):
+        """Perpendicular distance (2-D x/y) from point p to the line through a, b."""
+        ax, ay = a.x, a.y
+        bx, by = b.x, b.y
+        px, py = p.x, p.y
+        dx = bx - ax
+        dy = by - ay
+        denom = math.hypot(dx, dy)
+        if denom == 0:
+            return math.hypot(px - ax, py - ay)
+        return abs(dx * (ay - py) - (ax - px) * dy) / denom
 
     def _surfaceDistance(self, surface, worldPoint):
-        """Distance from worldPoint to the infinite surface; None if unevaluable."""
         evaluator = surface.evaluator
         (ok, param) = evaluator.getParameterAtPoint(worldPoint)
         if not ok:
@@ -262,69 +307,112 @@ class BevelGearGenerator:
         (ok2, projected) = evaluator.getPointAtParameter(param)
         if not ok2:
             return None
-        return worldPoint.distanceTo(projected)
+        return projected.distanceTo(worldPoint)
 
-    # ===================================================================
-    # §1 anchor sketch
-    # ===================================================================
-    def _buildAnchorSketch(self, designComp, targetPlane, centerPoint):
-        # Start the sketch DIRECTLY on the user-selected target plane (no re-derive/offset).
-        sketch = designComp.sketches.add(targetPlane)
+    # ----- main entry -----
+    def generate(self, inputs):
+        (parentComponent, targetPlane, centerPoint, module,
+         drivingTeeth, pinionTeeth, shaftAngle_deg) = self._readInputs(inputs)
+
+        # Resolve pitch diameters (cm) and bores (cm).
+        drivingPitchDiameter_cm = to_cm(module * drivingTeeth)
+        pinionPitchDiameter_cm = to_cm(module * pinionTeeth)
+
+        if self._drivingBore_cm > 0:
+            drivingBore_cm = self._drivingBore_cm
+        else:
+            drivingBore_cm = drivingPitchDiameter_cm / 4
+        if self._pinionBore_cm > 0:
+            pinionBore_cm = self._pinionBore_cm
+        else:
+            pinionBore_cm = pinionPitchDiameter_cm / 4
+
+        # --- Component tree: Bevel Gear under parent, Design under Bevel Gear ---
+        bevelOccurrence = parentComponent.occurrences.addNewComponent(
+            adsk.core.Matrix3D.create())
+        bevelOccurrence.component.name = 'Bevel Gear'
+        self.bevelOccurrence = bevelOccurrence
+        bevelComponent = bevelOccurrence.component
+
+        designOccurrence = bevelComponent.occurrences.addNewComponent(
+            adsk.core.Matrix3D.create())
+        designOccurrence.component.name = 'Design'
+        designComponent = designOccurrence.component
+
+        # --- §1 Anchor Sketch ---
+        anchorLine = self._buildAnchorSketch(designComponent, targetPlane, centerPoint)
+
+        # --- §2 + §3 + per-gear body creation ---
+        self._buildGearProfiles(
+            designComponent, bevelComponent, targetPlane, centerPoint, anchorLine,
+            module, drivingTeeth, pinionTeeth, shaftAngle_deg,
+            drivingPitchDiameter_cm, pinionPitchDiameter_cm,
+            drivingBore_cm, pinionBore_cm)
+
+        # --- Cleanup ---
+        self._hideConstructionGeometry(bevelComponent)
+
+    # ----- §1 Anchor Sketch -----
+    def _buildAnchorSketch(self, designComponent, targetPlane, centerPoint):
+        sketch = designComponent.sketches.add(targetPlane)
         sketch.name = 'Anchor Sketch'
         sketch.isVisible = True
-
-        # Project the user center point onto the sketch.
-        projected = sketch.project(centerPoint)
-        projectedCenter = projected.item(0)
 
         constraints = sketch.geometricConstraints
         dimensions = sketch.sketchDimensions
         lines = sketch.sketchCurves.sketchLines
 
-        # Anchor line through the projected center, seeded ~10mm long.
+        # Project the user-specified center onto the sketch.
+        projected = sketch.project(centerPoint)
+        projectedCenter = projected.item(0)
+        self._anchorCenterPoint = projectedCenter
+
+        # Create the anchor line through the projected center (~10mm reference line).
         cg = projectedCenter.geometry
-        p0 = adsk.core.Point3D.create(cg.x - to_cm(5), cg.y, 0)
-        p1 = adsk.core.Point3D.create(cg.x + to_cm(5), cg.y, 0)
+        half = to_cm(5)  # ~10mm total length
+        p0 = adsk.core.Point3D.create(cg.x - half, cg.y, 0)
+        p1 = adsk.core.Point3D.create(cg.x + half, cg.y, 0)
         anchorLine = lines.addByTwoPoints(p0, p1)
 
-        # BOTH: intersection (center on line) AND midpoint (center bisects line).
+        # Pin the center onto the line AND make it bisect.
         constraints.addCoincident(projectedCenter, anchorLine)
         constraints.addMidPoint(projectedCenter, anchorLine)
 
         # ~10mm length dimension (arbitrary reference value).
+        midText = adsk.core.Point3D.create(cg.x, cg.y + half, 0)
         lengthDim = dimensions.addDistanceDimension(
             anchorLine.startSketchPoint, anchorLine.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            adsk.core.Point3D.create(cg.x, cg.y + to_cm(2), 0))
+            midText)
         lengthDim.parameter.value = to_cm(10)
 
-        # Pin direction in the sketch's OWN frame (works on any tilted plane).
+        # Pin the direction sketch-locally so the sketch ends fully constrained.
         constraints.addHorizontal(anchorLine)
-
-        # Stash the projected-center SketchPoint so §2 re-projects THIS point.
-        self._anchorCenterPoint = projectedCenter
 
         self._assertFullyConstrained(sketch, 'Anchor Sketch')
         return anchorLine
 
-    # ===================================================================
-    # §2 gear profiles
-    # ===================================================================
-    def _buildGearProfiles(self, designComp, bevelComp, pinionOcc, drivingOcc,
-                           targetPlane, anchorLine,
-                           module, drivingTeeth, pinionTeeth, shaftAngle_deg,
-                           drivingPitchDia_cm, pinionPitchDia_cm,
+    # ----- §2 + §3 + body creation -----
+    def _buildGearProfiles(self, designComponent, bevelComponent, targetPlane,
+                           centerPoint, anchorLine, module, drivingTeeth,
+                           pinionTeeth, shaftAngle_deg,
+                           drivingPitchDiameter_cm, pinionPitchDiameter_cm,
                            drivingBore_cm, pinionBore_cm):
+        DPD = drivingPitchDiameter_cm
+        PPD = pinionPitchDiameter_cm
         Sigma = math.radians(shaftAngle_deg)
+        moduleCm = to_cm(module)
+        dedendum_cm = to_cm(1.25 * module)
+        moduleExt_cm = moduleCm  # module-length construction extensions
 
-        # Build the Gear Profiles plane: includes the Anchor Line, at 90 deg off the
-        # ORIGINAL targetPlane (so it inherits the true target-plane orientation).
-        planeInput = designComp.constructionPlanes.createInput()
-        planeInput.setByAngle(anchorLine, adsk.core.ValueInput.createByString('90 deg'), targetPlane)
-        gearProfilesPlane = designComp.constructionPlanes.add(planeInput)
+        # --- Gear Profiles plane: through anchor line, 90deg off the target plane ---
+        planeInput = designComponent.constructionPlanes.createInput()
+        planeInput.setByAngle(
+            anchorLine, adsk.core.ValueInput.createByString('90 deg'), targetPlane)
+        gearProfilesPlane = designComponent.constructionPlanes.add(planeInput)
         gearProfilesPlane.name = 'Gear Profiles Plane'
 
-        sketch = designComp.sketches.add(gearProfilesPlane)
+        sketch = designComponent.sketches.add(gearProfilesPlane)
         sketch.name = 'Gear Profiles'
         sketch.isVisible = True
 
@@ -332,952 +420,982 @@ class BevelGearGenerator:
         dimensions = sketch.sketchDimensions
         lines = sketch.sketchCurves.sketchLines
 
-        # Project the ANCHOR SKETCH center point (stashed in §1), not the raw center.
-        projectedCenter = sketch.project(self._anchorCenterPoint).item(0)
-        # Project the anchor line to read its 2-D direction.
-        projectedAnchor = sketch.project(anchorLine).item(0)
+        # Project the Anchor Sketch's center point (NOT the raw user point).
+        projected = sketch.project(self._anchorCenterPoint)
+        centerSP = projected.item(0)
+        projectedAnchor = sketch.project(anchorLine)
+        anchorLineProj = projectedAnchor.item(0)
 
-        c = projectedCenter.geometry
-        aStart = projectedAnchor.startSketchPoint.geometry
-        aEnd = projectedAnchor.endSketchPoint.geometry
-        dx = aEnd.x - aStart.x
-        dy = aEnd.y - aStart.y
-        dlen = math.hypot(dx, dy)
-        d = (dx / dlen, dy / dlen)
+        c = centerSP.geometry
+        # Anchor line 2-D unit direction.
+        ag = anchorLineProj.startSketchPoint.geometry
+        bg = anchorLineProj.endSketchPoint.geometry
+        dvec = adsk.core.Vector3D.create(bg.x - ag.x, bg.y - ag.y, 0)
+        dlen = math.hypot(dvec.x, dvec.y)
+        dx = dvec.x / dlen
+        dy = dvec.y / dlen
+        # In-plane perpendicular candidate.
+        perpx, perpy = -dy, dx
 
-        # In-plane perpendicular (two senses). Pick sign by the target normal.
-        perp = (-d[1], d[0])
-
-        # One-bit direction comparison: choose perp pointing toward the target normal.
-        normal = get_normal(targetPlane)
-        normal.normalize()
-        # Map perp (sketch-local) to world via the sketch's two in-plane axes.
-        xAxis = sketch.xDirection
-        yAxis = sketch.yDirection
+        # Pick sign by the target-plane normal (one-bit direction), toward the normal.
+        targetNormal = get_normal(targetPlane)
+        targetNormal.normalize()
+        # Map perp into world to compare its direction against the target normal.
+        # The perp lies in the gear-profiles plane; compare against target normal
+        # by converting two sketch points to world.
+        perpWorldA = sketch.sketchToModelSpace(
+            adsk.core.Point3D.create(c.x, c.y, 0))
+        perpWorldB = sketch.sketchToModelSpace(
+            adsk.core.Point3D.create(c.x + perpx, c.y + perpy, 0))
         perpWorld = adsk.core.Vector3D.create(
-            perp[0] * xAxis.x + perp[1] * yAxis.x,
-            perp[0] * xAxis.y + perp[1] * yAxis.y,
-            perp[0] * xAxis.z + perp[1] * yAxis.z)
-        if perpWorld.dotProduct(normal) < 0:
-            perp = (-perp[0], -perp[1])
+            perpWorldB.x - perpWorldA.x,
+            perpWorldB.y - perpWorldA.y,
+            perpWorldB.z - perpWorldA.z)
+        if perpWorld.dotProduct(targetNormal) < 0:
+            perpx, perpy = -perpx, -perpy
 
-        DPD = drivingPitchDia_cm
-        PPD = pinionPitchDia_cm
-
-        # ---- center -> Apex construction line (perpendicular to anchor) ----
-        apexSeed = adsk.core.Point3D.create(c.x + perp[0] * DPD, c.y + perp[1] * DPD, 0)
-        centerToApex = lines.addByTwoPoints(
-            adsk.core.Point3D.create(c.x, c.y, 0), apexSeed)
+        # --- Apex: free end of a construction line from center, perp to anchor ---
+        apexSeed = adsk.core.Point3D.create(c.x + perpx * DPD, c.y + perpy * DPD, 0)
+        centerToApex = lines.addByTwoPoints(centerSP, apexSeed)
         centerToApex.isConstruction = True
-        constraints.addCoincident(centerToApex.startSketchPoint, projectedCenter)
-        constraints.addPerpendicular(centerToApex, projectedAnchor)
-        # No length constraint -- Apex pinned later by "point I coincident with center".
+        constraints.addPerpendicular(centerToApex, anchorLineProj)
         apexPoint = centerToApex.endSketchPoint
-        apex = apexPoint.geometry
 
-        # ---- closed-form cone geometry seeds for Apex->A / Apex->B ----
-        # tan gamma_p = sin Sigma * PPD / (DPD + PPD cos Sigma)
+        # --- closed-form cone geometry seeds for Apex->A, Apex->B ---
+        # tan(gamma_p) = sin Sigma * PPD / (DPD + PPD cos Sigma)
         gamma_p = math.atan2(math.sin(Sigma) * PPD, DPD + PPD * math.cos(Sigma))
         gamma_g = Sigma - gamma_p
-        R = (PPD / 2) / math.sin(gamma_p)
-        lenA = R * math.cos(gamma_p)   # |Apex->A|
-        lenB = R * math.cos(gamma_g)   # |Apex->B|
+        coneDist_R = (PPD / 2) / math.sin(gamma_p)
+        lenApexA = coneDist_R * math.cos(gamma_p)
+        lenApexB = coneDist_R * math.cos(gamma_g)
 
-        # Driving Gear Shaft Axis: from apex toward the anchor line (-perp), parallel
-        # to centerToApex. End is point B. seed |Apex->B| = lenB along -perp.
+        # --- Driving Gear Shaft Axis: from apex toward anchor line (-perp), -> B ---
+        apexGeom = apexSeed  # seed coordinate for apex
         bSeed = adsk.core.Point3D.create(
-            apex.x - perp[0] * lenB, apex.y - perp[1] * lenB, 0)
-        drivingShaft = lines.addByTwoPoints(
-            adsk.core.Point3D.create(apex.x, apex.y, 0), bSeed)
-        drivingShaft.isConstruction = True
-        constraints.addCoincident(drivingShaft.startSketchPoint, apexPoint)
-        constraints.addParallel(drivingShaft, centerToApex)
-        pointB = drivingShaft.endSketchPoint
+            apexGeom.x - perpx * lenApexB, apexGeom.y - perpy * lenApexB, 0)
+        drivingShaftAxis = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apexGeom.x, apexGeom.y, 0), bSeed)
+        drivingShaftAxis.isConstruction = True
+        constraints.addCoincident(drivingShaftAxis.startSketchPoint, apexPoint)
+        constraints.addParallel(drivingShaftAxis, centerToApex)
+        pointB = drivingShaftAxis.endSketchPoint
 
-        # Pinion Gear Shaft Axis: driving-shaft direction rotated about apex by Sigma.
-        # Form BOTH candidates (+Sigma and -Sigma) and keep the one with greater sketch-X.
-        # Driving shaft direction (apex -> B) is -perp.
-        ddir = (-perp[0], -perp[1])
+        # --- Pinion Gear Shaft Axis: driving direction rotated about apex by Sigma ---
+        # Driving shaft direction (from apex toward B) is -perp.
+        ddx, ddy = -perpx, -perpy
 
-        def rotate_about_apex(direction, theta, length):
-            cs = math.cos(theta)
-            sn = math.sin(theta)
-            rx = direction[0] * cs - direction[1] * sn
-            ry = direction[0] * sn + direction[1] * cs
-            return adsk.core.Point3D.create(apex.x + rx * length, apex.y + ry * length, 0)
+        def rotate2d(vx, vy, theta):
+            cc = math.cos(theta)
+            ss = math.sin(theta)
+            return (vx * cc - vy * ss, vx * ss + vy * cc)
 
-        candPlus = rotate_about_apex(ddir, Sigma, lenA)
-        candMinus = rotate_about_apex(ddir, -Sigma, lenA)
-        # Compare BOTH candidates' X; take the larger (NOT a rotate-then-conditional-flip).
-        if candPlus.x >= candMinus.x:
-            aSeed = candPlus
+        candPlus = rotate2d(ddx, ddy, Sigma)
+        candMinus = rotate2d(ddx, ddy, -Sigma)
+        aPlus = (apexGeom.x + candPlus[0] * lenApexA,
+                 apexGeom.y + candPlus[1] * lenApexA)
+        aMinus = (apexGeom.x + candMinus[0] * lenApexA,
+                  apexGeom.y + candMinus[1] * lenApexA)
+        # Keep the candidate whose endpoint has the GREATER X coordinate.
+        if aPlus[0] >= aMinus[0]:
+            aSeed = aPlus
+            usedPlusSense = True
         else:
-            aSeed = candMinus
+            aSeed = aMinus
+            usedPlusSense = False
 
-        pinionShaft = lines.addByTwoPoints(
-            adsk.core.Point3D.create(apex.x, apex.y, 0), aSeed)
-        pinionShaft.isConstruction = True
-        constraints.addCoincident(pinionShaft.startSketchPoint, apexPoint)
-        pointA = pinionShaft.endSketchPoint
+        pinionShaftAxis = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apexGeom.x, apexGeom.y, 0),
+            adsk.core.Point3D.create(aSeed[0], aSeed[1], 0))
+        pinionShaftAxis.isConstruction = True
+        constraints.addCoincident(pinionShaftAxis.startSketchPoint, apexPoint)
+        pointA = pinionShaftAxis.endSketchPoint
 
-        # Angular dimension Sigma between pinion shaft and driving shaft.
-        # Place text inside the wedge containing Sigma (toward the aSeed/bSeed bisector).
-        angText = adsk.core.Point3D.create(
-            apex.x + (ddir[0] + (aSeed.x - apex.x) / lenA) * 0.25 * lenA,
-            apex.y + (ddir[1] + (aSeed.y - apex.y) / lenA) * 0.25 * lenA, 0)
-        dimensions.addAngularDimension(pinionShaft, drivingShaft, angText).parameter.value = Sigma
+        # Angular dimension Sigma between the two shaft axes, text inside the wedge.
+        wedgeMidx, wedgeMidy = rotate2d(ddx, ddy, Sigma / 2.0
+                                        if usedPlusSense else -Sigma / 2.0)
+        wedgeR = lenApexA * 0.5
+        angleText = adsk.core.Point3D.create(
+            apexGeom.x + wedgeMidx * wedgeR,
+            apexGeom.y + wedgeMidy * wedgeR, 0)
+        angDim = dimensions.addAngularDimension(
+            drivingShaftAxis, pinionShaftAxis, angleText)
+        angDim.parameter.value = Sigma
 
-        # ---- A -> Apex2 perpendicular drop (length PPD/2), perpendicular to pinion shaft ----
-        # seed toward where Apex2 lies (between the two shaft axes / toward anchor line).
-        toMidAB = adsk.core.Vector3D.create(
-            (aSeed.x + bSeed.x) / 2 - aSeed.x, (aSeed.y + bSeed.y) / 2 - aSeed.y, 0)
-        if toMidAB.length > 0:
-            toMidAB.normalize()
-        nApex2A = adsk.core.Point3D.create(
-            aSeed.x + toMidAB.x * (PPD / 2), aSeed.y + toMidAB.y * (PPD / 2), 0)
-        dropA = lines.addByTwoPoints(
-            adsk.core.Point3D.create(aSeed.x, aSeed.y, 0), nApex2A)
-        dropA.isConstruction = True
-        constraints.addCoincident(dropA.startSketchPoint, pointA)
-        constraints.addPerpendicular(dropA, pinionShaft)
-        dimDropA = dimensions.addDistanceDimension(
-            dropA.startSketchPoint, dropA.endSketchPoint,
+        # --- From A, perpendicular drop to Apex2 (length PPD/2) ---
+        # Direction toward Apex2 (between the two shafts, toward anchor line).
+        # Seed: perpendicular to pinion shaft axis, toward center.
+        pinDirx = aSeed[0] - apexGeom.x
+        pinDiry = aSeed[1] - apexGeom.y
+        plen = math.hypot(pinDirx, pinDiry)
+        pinDirx /= plen
+        pinDiry /= plen
+        # Two perpendiculars to pinion shaft; pick the one pointing toward center c.
+        perpAcand1 = (-pinDiry, pinDirx)
+        perpAcand2 = (pinDiry, -pinDirx)
+        toCenterAx = c.x - aSeed[0]
+        toCenterAy = c.y - aSeed[1]
+        if (perpAcand1[0] * toCenterAx + perpAcand1[1] * toCenterAy) >= \
+           (perpAcand2[0] * toCenterAx + perpAcand2[1] * toCenterAy):
+            perpA = perpAcand1
+        else:
+            perpA = perpAcand2
+        apex2SeedA = (aSeed[0] + perpA[0] * (PPD / 2),
+                      aSeed[1] + perpA[1] * (PPD / 2))
+        aToApex2 = lines.addByTwoPoints(
+            adsk.core.Point3D.create(aSeed[0], aSeed[1], 0),
+            adsk.core.Point3D.create(apex2SeedA[0], apex2SeedA[1], 0))
+        aToApex2.isConstruction = True
+        constraints.addCoincident(aToApex2.startSketchPoint, pointA)
+        constraints.addPerpendicular(aToApex2, pinionShaftAxis)
+        aDropDim = dimensions.addDistanceDimension(
+            aToApex2.startSketchPoint, aToApex2.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            adsk.core.Point3D.create(nApex2A.x, nApex2A.y, 0))
-        dimDropA.parameter.value = PPD / 2
+            adsk.core.Point3D.create(
+                (aSeed[0] + apex2SeedA[0]) / 2,
+                (aSeed[1] + apex2SeedA[1]) / 2, 0))
+        aDropDim.parameter.value = PPD / 2
 
-        # ---- B -> Apex2 perpendicular drop (length DPD/2), perpendicular to driving shaft ----
-        toMidBA = adsk.core.Vector3D.create(
-            (aSeed.x + bSeed.x) / 2 - bSeed.x, (aSeed.y + bSeed.y) / 2 - bSeed.y, 0)
-        if toMidBA.length > 0:
-            toMidBA.normalize()
-        nApex2B = adsk.core.Point3D.create(
-            bSeed.x + toMidBA.x * (DPD / 2), bSeed.y + toMidBA.y * (DPD / 2), 0)
-        dropB = lines.addByTwoPoints(
-            adsk.core.Point3D.create(bSeed.x, bSeed.y, 0), nApex2B)
-        dropB.isConstruction = True
-        constraints.addCoincident(dropB.startSketchPoint, pointB)
-        constraints.addPerpendicular(dropB, drivingShaft)
-        dimDropB = dimensions.addDistanceDimension(
-            dropB.startSketchPoint, dropB.endSketchPoint,
+        # --- From B, perpendicular drop to Apex2 (length DPD/2) ---
+        drvDirx = bSeed.x - apexGeom.x
+        drvDiry = bSeed.y - apexGeom.y
+        dlen2 = math.hypot(drvDirx, drvDiry)
+        drvDirx /= dlen2
+        drvDiry /= dlen2
+        perpBcand1 = (-drvDiry, drvDirx)
+        perpBcand2 = (drvDiry, -drvDirx)
+        toCenterBx = c.x - bSeed.x
+        toCenterBy = c.y - bSeed.y
+        if (perpBcand1[0] * toCenterBx + perpBcand1[1] * toCenterBy) >= \
+           (perpBcand2[0] * toCenterBx + perpBcand2[1] * toCenterBy):
+            perpB = perpBcand1
+        else:
+            perpB = perpBcand2
+        apex2SeedB = (bSeed.x + perpB[0] * (DPD / 2),
+                      bSeed.y + perpB[1] * (DPD / 2))
+        bToApex2 = lines.addByTwoPoints(
+            adsk.core.Point3D.create(bSeed.x, bSeed.y, 0),
+            adsk.core.Point3D.create(apex2SeedB[0], apex2SeedB[1], 0))
+        bToApex2.isConstruction = True
+        constraints.addCoincident(bToApex2.startSketchPoint, pointB)
+        constraints.addPerpendicular(bToApex2, drivingShaftAxis)
+        bDropDim = dimensions.addDistanceDimension(
+            bToApex2.startSketchPoint, bToApex2.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            adsk.core.Point3D.create(nApex2B.x, nApex2B.y, 0))
-        dimDropB.parameter.value = DPD / 2
+            adsk.core.Point3D.create(
+                (bSeed.x + apex2SeedB[0]) / 2,
+                (bSeed.y + apex2SeedB[1]) / 2, 0))
+        bDropDim.parameter.value = DPD / 2
 
-        # ---- Apex2: coincide the two drop ends ----
-        constraints.addCoincident(dropA.endSketchPoint, dropB.endSketchPoint)
-        apex2Point = dropA.endSketchPoint
+        # --- Apex2: coincide the two drop endpoints ---
+        constraints.addCoincident(
+            aToApex2.endSketchPoint, bToApex2.endSketchPoint)
+        apex2Point = aToApex2.endSketchPoint
 
-        # ---- Pitch Line: Apex -> Apex2 ----
+        # --- Pitch Line: Apex -> Apex2 ---
         pitchLine = lines.addByTwoPoints(
-            adsk.core.Point3D.create(apex.x, apex.y, 0),
-            adsk.core.Point3D.create(apex2Point.geometry.x, apex2Point.geometry.y, 0))
+            adsk.core.Point3D.create(apexGeom.x, apexGeom.y, 0),
+            adsk.core.Point3D.create(apex2SeedB[0], apex2SeedB[1], 0))
         pitchLine.isConstruction = True
         constraints.addCoincident(pitchLine.startSketchPoint, apexPoint)
         constraints.addCoincident(pitchLine.endSketchPoint, apex2Point)
 
-        ded_cm = to_cm(1.25 * module)
-
-        # ---- Dedendum lines from Apex2, perpendicular to the Pitch Line ----
-        # Pinion Gear Dedendum (away from anchor line) -> point C.
-        # Driving Gear Dedendum (toward anchor line) -> point D.
-        a2 = apex2Point.geometry
-        # pitch-line direction (apex -> apex2)
-        pdx = a2.x - apex.x
-        pdy = a2.y - apex.y
-        plen = math.hypot(pdx, pdy)
-        pu = (pdx / plen, pdy / plen)
-        pperp = (-pu[1], pu[0])  # perpendicular to pitch line
-
-        # Decide which perpendicular sense points "away from anchor line" (toward +perp).
-        if (pperp[0] * perp[0] + pperp[1] * perp[1]) >= 0:
-            awayDir = pperp
+        # --- Dedendum lines from Apex2, perpendicular to Pitch Line, len module*1.25 ---
+        # Pitch line direction (apex -> apex2).
+        plx = apex2SeedB[0] - apexGeom.x
+        ply = apex2SeedB[1] - apexGeom.y
+        pllen = math.hypot(plx, ply)
+        plx /= pllen
+        ply /= pllen
+        pitchPerp1 = (-ply, plx)
+        pitchPerp2 = (ply, -plx)
+        # Driving Gear Dedendum (point D): toward anchor line (toward center).
+        toCenterApex2x = c.x - apex2SeedB[0]
+        toCenterApex2y = c.y - apex2SeedB[1]
+        if (pitchPerp1[0] * toCenterApex2x + pitchPerp1[1] * toCenterApex2y) >= \
+           (pitchPerp2[0] * toCenterApex2x + pitchPerp2[1] * toCenterApex2y):
+            dDir = pitchPerp1
+            cDir = pitchPerp2
         else:
-            awayDir = (-pperp[0], -pperp[1])
-        towardDir = (-awayDir[0], -awayDir[1])
+            dDir = pitchPerp2
+            cDir = pitchPerp1
 
-        cSeed = adsk.core.Point3D.create(
-            a2.x + awayDir[0] * ded_cm, a2.y + awayDir[1] * ded_cm, 0)
-        pinionDedendum = lines.addByTwoPoints(
-            adsk.core.Point3D.create(a2.x, a2.y, 0), cSeed)
-        pinionDedendum.isConstruction = True
-        constraints.addCoincident(pinionDedendum.startSketchPoint, apex2Point)
-        constraints.addPerpendicular(pinionDedendum, pitchLine)
-        dimC = dimensions.addDistanceDimension(
-            pinionDedendum.startSketchPoint, pinionDedendum.endSketchPoint,
-            adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            adsk.core.Point3D.create(cSeed.x, cSeed.y, 0))
-        dimC.parameter.value = ded_cm
-        pointC = pinionDedendum.endSketchPoint
-
-        dSeed = adsk.core.Point3D.create(
-            a2.x + towardDir[0] * ded_cm, a2.y + towardDir[1] * ded_cm, 0)
+        dSeed = (apex2SeedB[0] + dDir[0] * dedendum_cm,
+                 apex2SeedB[1] + dDir[1] * dedendum_cm)
         drivingDedendum = lines.addByTwoPoints(
-            adsk.core.Point3D.create(a2.x, a2.y, 0), dSeed)
+            adsk.core.Point3D.create(apex2SeedB[0], apex2SeedB[1], 0),
+            adsk.core.Point3D.create(dSeed[0], dSeed[1], 0))
         drivingDedendum.isConstruction = True
         constraints.addCoincident(drivingDedendum.startSketchPoint, apex2Point)
         constraints.addPerpendicular(drivingDedendum, pitchLine)
-        dimD = dimensions.addDistanceDimension(
+        ddDim = dimensions.addDistanceDimension(
             drivingDedendum.startSketchPoint, drivingDedendum.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            adsk.core.Point3D.create(dSeed.x, dSeed.y, 0))
-        dimD.parameter.value = ded_cm
+            adsk.core.Point3D.create((apex2SeedB[0] + dSeed[0]) / 2,
+                                     (apex2SeedB[1] + dSeed[1]) / 2, 0))
+        ddDim.parameter.value = dedendum_cm
         pointD = drivingDedendum.endSketchPoint
 
-        # ---- Root Axes: Apex -> C (pinion), Apex -> D (driving) ----
-        pinionRootAxis = lines.addByTwoPoints(
-            adsk.core.Point3D.create(apex.x, apex.y, 0),
-            adsk.core.Point3D.create(pointC.geometry.x, pointC.geometry.y, 0))
-        pinionRootAxis.isConstruction = True
-        constraints.addCoincident(pinionRootAxis.startSketchPoint, apexPoint)
-        constraints.addCoincident(pinionRootAxis.endSketchPoint, pointC)
+        cSeed = (apex2SeedB[0] + cDir[0] * dedendum_cm,
+                 apex2SeedB[1] + cDir[1] * dedendum_cm)
+        pinionDedendum = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apex2SeedB[0], apex2SeedB[1], 0),
+            adsk.core.Point3D.create(cSeed[0], cSeed[1], 0))
+        pinionDedendum.isConstruction = True
+        constraints.addCoincident(pinionDedendum.startSketchPoint, apex2Point)
+        constraints.addPerpendicular(pinionDedendum, pitchLine)
+        cdDim = dimensions.addDistanceDimension(
+            pinionDedendum.startSketchPoint, pinionDedendum.endSketchPoint,
+            adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
+            adsk.core.Point3D.create((apex2SeedB[0] + cSeed[0]) / 2,
+                                     (apex2SeedB[1] + cSeed[1]) / 2, 0))
+        cdDim.parameter.value = dedendum_cm
+        pointC = pinionDedendum.endSketchPoint
 
+        # --- Root Axes: Apex->D (driving), Apex->C (pinion) ---
         drivingRootAxis = lines.addByTwoPoints(
-            adsk.core.Point3D.create(apex.x, apex.y, 0),
-            adsk.core.Point3D.create(pointD.geometry.x, pointD.geometry.y, 0))
+            adsk.core.Point3D.create(apexGeom.x, apexGeom.y, 0),
+            adsk.core.Point3D.create(dSeed[0], dSeed[1], 0))
         drivingRootAxis.isConstruction = True
         constraints.addCoincident(drivingRootAxis.startSketchPoint, apexPoint)
         constraints.addCoincident(drivingRootAxis.endSketchPoint, pointD)
 
-        mod_cm = to_cm(module)
+        pinionRootAxis = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apexGeom.x, apexGeom.y, 0),
+            adsk.core.Point3D.create(cSeed[0], cSeed[1], 0))
+        pinionRootAxis.isConstruction = True
+        constraints.addCoincident(pinionRootAxis.startSketchPoint, apexPoint)
+        constraints.addCoincident(pinionRootAxis.endSketchPoint, pointC)
 
-        # ---- point E: from A, collinear with Apex->A, length module (no dim) ----
-        ag = pointA.geometry
-        adir = (ag.x - apex.x, ag.y - apex.y)
-        adlen = math.hypot(adir[0], adir[1])
-        adir = (adir[0] / adlen, adir[1] / adlen)
-        eSeed = adsk.core.Point3D.create(ag.x + adir[0] * mod_cm, ag.y + adir[1] * mod_cm, 0)
-        lineAE = lines.addByTwoPoints(
-            adsk.core.Point3D.create(ag.x, ag.y, 0), eSeed)
-        lineAE.isConstruction = True
-        constraints.addCoincident(lineAE.startSketchPoint, pointA)
-        constraints.addCollinear(lineAE, pinionShaft)
-        pointE = lineAE.endSketchPoint
+        # --- E: from A collinear with Apex->A, length module (no dimension) ---
+        # Direction along Apex->A.
+        aax = aSeed[0] - apexGeom.x
+        aay = aSeed[1] - apexGeom.y
+        aalen = math.hypot(aax, aay)
+        aax /= aalen
+        aay /= aalen
+        eSeed = (aSeed[0] + aax * moduleExt_cm, aSeed[1] + aay * moduleExt_cm)
+        aToE = lines.addByTwoPoints(
+            adsk.core.Point3D.create(aSeed[0], aSeed[1], 0),
+            adsk.core.Point3D.create(eSeed[0], eSeed[1], 0))
+        aToE.isConstruction = True
+        constraints.addCoincident(aToE.startSketchPoint, pointA)
+        constraints.addCollinear(aToE, pinionShaftAxis)
+        pointE = aToE.endSketchPoint
 
-        # ---- line C->E, perpendicular to A->E ----
-        lineCE = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointC.geometry.x, pointC.geometry.y, 0),
-            adsk.core.Point3D.create(eSeed.x, eSeed.y, 0))
-        lineCE.isConstruction = True
-        constraints.addCoincident(lineCE.startSketchPoint, pointC)
-        constraints.addCoincident(lineCE.endSketchPoint, pointE)
-        constraints.addPerpendicular(lineAE, lineCE)
+        # --- C->E line, perpendicular to A->E ---
+        cToE = lines.addByTwoPoints(
+            adsk.core.Point3D.create(cSeed[0], cSeed[1], 0),
+            adsk.core.Point3D.create(eSeed[0], eSeed[1], 0))
+        cToE.isConstruction = True
+        constraints.addCoincident(cToE.startSketchPoint, pointC)
+        constraints.addCoincident(cToE.endSketchPoint, pointE)
+        constraints.addPerpendicular(aToE, cToE)
 
-        # ---- point F: from B, collinear with Apex->B, length module (no dim) ----
-        bg = pointB.geometry
-        bdir = (bg.x - apex.x, bg.y - apex.y)
-        bdlen = math.hypot(bdir[0], bdir[1])
-        bdir = (bdir[0] / bdlen, bdir[1] / bdlen)
-        fSeed = adsk.core.Point3D.create(bg.x + bdir[0] * mod_cm, bg.y + bdir[1] * mod_cm, 0)
-        lineBF = lines.addByTwoPoints(
-            adsk.core.Point3D.create(bg.x, bg.y, 0), fSeed)
-        lineBF.isConstruction = True
-        constraints.addCoincident(lineBF.startSketchPoint, pointB)
-        constraints.addCollinear(lineBF, drivingShaft)
-        pointF = lineBF.endSketchPoint
+        # --- F: from B collinear with Apex->B, length module ---
+        bbx = bSeed.x - apexGeom.x
+        bby = bSeed.y - apexGeom.y
+        bblen = math.hypot(bbx, bby)
+        bbx /= bblen
+        bby /= bblen
+        fSeed = (bSeed.x + bbx * moduleExt_cm, bSeed.y + bby * moduleExt_cm)
+        bToF = lines.addByTwoPoints(
+            adsk.core.Point3D.create(bSeed.x, bSeed.y, 0),
+            adsk.core.Point3D.create(fSeed[0], fSeed[1], 0))
+        bToF.isConstruction = True
+        constraints.addCoincident(bToF.startSketchPoint, pointB)
+        constraints.addCollinear(bToF, drivingShaftAxis)
+        pointF = bToF.endSketchPoint
 
-        # ---- line D->F, perpendicular to B->F ----
-        lineDF = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointD.geometry.x, pointD.geometry.y, 0),
-            adsk.core.Point3D.create(fSeed.x, fSeed.y, 0))
-        lineDF.isConstruction = True
-        constraints.addCoincident(lineDF.startSketchPoint, pointD)
-        constraints.addCoincident(lineDF.endSketchPoint, pointF)
-        constraints.addPerpendicular(lineBF, lineDF)
+        # --- D->F line, perpendicular to B->F ---
+        dToF = lines.addByTwoPoints(
+            adsk.core.Point3D.create(dSeed[0], dSeed[1], 0),
+            adsk.core.Point3D.create(fSeed[0], fSeed[1], 0))
+        dToF.isConstruction = True
+        constraints.addCoincident(dToF.startSketchPoint, pointD)
+        constraints.addCoincident(dToF.endSketchPoint, pointF)
+        constraints.addPerpendicular(bToF, dToF)
 
-        # ---- point G: from E collinear to A->E, length module (no dim) ----
-        eg = pointE.geometry
-        gSeed = adsk.core.Point3D.create(eg.x + adir[0] * mod_cm, eg.y + adir[1] * mod_cm, 0)
-        lineEG = lines.addByTwoPoints(
-            adsk.core.Point3D.create(eg.x, eg.y, 0), gSeed)
-        lineEG.isConstruction = True
-        constraints.addCoincident(lineEG.startSketchPoint, pointE)
-        constraints.addCollinear(lineEG, lineAE)
-        pointG = lineEG.endSketchPoint
+        # --- G: from E collinear to A->E, length module ---
+        gSeed = (eSeed[0] + aax * moduleExt_cm, eSeed[1] + aay * moduleExt_cm)
+        eToG = lines.addByTwoPoints(
+            adsk.core.Point3D.create(eSeed[0], eSeed[1], 0),
+            adsk.core.Point3D.create(gSeed[0], gSeed[1], 0))
+        eToG.isConstruction = True
+        constraints.addCoincident(eToG.startSketchPoint, pointE)
+        constraints.addCollinear(eToG, aToE)
+        pointG = eToG.endSketchPoint
 
-        # ---- point H: from C, length module, collinear with Apex2->C ----
-        cg = pointC.geometry
-        cdir = (cg.x - a2.x, cg.y - a2.y)
-        cdlen = math.hypot(cdir[0], cdir[1])
-        cdir = (cdir[0] / cdlen, cdir[1] / cdlen)
-        hSeed = adsk.core.Point3D.create(cg.x + cdir[0] * mod_cm, cg.y + cdir[1] * mod_cm, 0)
-        lineCH = lines.addByTwoPoints(
-            adsk.core.Point3D.create(cg.x, cg.y, 0), hSeed)
-        lineCH.isConstruction = True
-        constraints.addCoincident(lineCH.startSketchPoint, pointC)
-        constraints.addCollinear(lineCH, pinionDedendum)
-        pointH = lineCH.endSketchPoint
+        # --- H: from C, length module, collinear with Apex2->C ---
+        # direction along Apex2->C = cDir
+        hSeed = (cSeed[0] + cDir[0] * moduleExt_cm, cSeed[1] + cDir[1] * moduleExt_cm)
+        cToH = lines.addByTwoPoints(
+            adsk.core.Point3D.create(cSeed[0], cSeed[1], 0),
+            adsk.core.Point3D.create(hSeed[0], hSeed[1], 0))
+        cToH.isConstruction = True
+        constraints.addCoincident(cToH.startSketchPoint, pointC)
+        constraints.addCollinear(cToH, pinionDedendum)
+        pointH = cToH.endSketchPoint
 
-        # ---- line G->H, perpendicular to E->G ----
-        lineGH = lines.addByTwoPoints(
-            adsk.core.Point3D.create(gSeed.x, gSeed.y, 0),
-            adsk.core.Point3D.create(hSeed.x, hSeed.y, 0))
-        lineGH.isConstruction = True
-        constraints.addCoincident(lineGH.startSketchPoint, pointG)
-        constraints.addCoincident(lineGH.endSketchPoint, pointH)
-        constraints.addPerpendicular(lineEG, lineGH)
+        # --- G->H line, perpendicular to E->G ---
+        gToH = lines.addByTwoPoints(
+            adsk.core.Point3D.create(gSeed[0], gSeed[1], 0),
+            adsk.core.Point3D.create(hSeed[0], hSeed[1], 0))
+        gToH.isConstruction = True
+        constraints.addCoincident(gToH.startSketchPoint, pointG)
+        constraints.addCoincident(gToH.endSketchPoint, pointH)
+        constraints.addPerpendicular(eToG, gToH)
 
-        # ---- point I: from F collinear to B->F, length module (no dim) ----
-        fg = pointF.geometry
-        iSeed = adsk.core.Point3D.create(fg.x + bdir[0] * mod_cm, fg.y + bdir[1] * mod_cm, 0)
-        lineFI = lines.addByTwoPoints(
-            adsk.core.Point3D.create(fg.x, fg.y, 0), iSeed)
-        lineFI.isConstruction = True
-        constraints.addCoincident(lineFI.startSketchPoint, pointF)
-        constraints.addCollinear(lineFI, lineBF)
-        pointI = lineFI.endSketchPoint
+        # --- I: from F collinear to B->F, length module ---
+        iSeed = (fSeed[0] + bbx * moduleExt_cm, fSeed[1] + bby * moduleExt_cm)
+        fToI = lines.addByTwoPoints(
+            adsk.core.Point3D.create(fSeed[0], fSeed[1], 0),
+            adsk.core.Point3D.create(iSeed[0], iSeed[1], 0))
+        fToI.isConstruction = True
+        constraints.addCoincident(fToI.startSketchPoint, pointF)
+        constraints.addCollinear(fToI, bToF)
+        pointI = fToI.endSketchPoint
 
-        # ---- point J: from D, length module, collinear with Apex2->D ----
-        dg = pointD.geometry
-        ddir2 = (dg.x - a2.x, dg.y - a2.y)
-        ddlen2 = math.hypot(ddir2[0], ddir2[1])
-        ddir2 = (ddir2[0] / ddlen2, ddir2[1] / ddlen2)
-        jSeed = adsk.core.Point3D.create(dg.x + ddir2[0] * mod_cm, dg.y + ddir2[1] * mod_cm, 0)
-        lineDJ = lines.addByTwoPoints(
-            adsk.core.Point3D.create(dg.x, dg.y, 0), jSeed)
-        lineDJ.isConstruction = True
-        constraints.addCoincident(lineDJ.startSketchPoint, pointD)
-        constraints.addCollinear(lineDJ, drivingDedendum)
-        pointJ = lineDJ.endSketchPoint
+        # --- J: from D, length module, collinear with Apex2->D ---
+        jSeed = (dSeed[0] + dDir[0] * moduleExt_cm, dSeed[1] + dDir[1] * moduleExt_cm)
+        dToJ = lines.addByTwoPoints(
+            adsk.core.Point3D.create(dSeed[0], dSeed[1], 0),
+            adsk.core.Point3D.create(jSeed[0], jSeed[1], 0))
+        dToJ.isConstruction = True
+        constraints.addCoincident(dToJ.startSketchPoint, pointD)
+        constraints.addCollinear(dToJ, drivingDedendum)
+        pointJ = dToJ.endSketchPoint
 
-        # ---- line I->J, perpendicular to F->I ----
-        lineIJ = lines.addByTwoPoints(
-            adsk.core.Point3D.create(iSeed.x, iSeed.y, 0),
-            adsk.core.Point3D.create(jSeed.x, jSeed.y, 0))
-        lineIJ.isConstruction = True
-        constraints.addCoincident(lineIJ.startSketchPoint, pointI)
-        constraints.addCoincident(lineIJ.endSketchPoint, pointJ)
-        constraints.addPerpendicular(lineFI, lineIJ)
+        # --- I->J line, perpendicular to F->I ---
+        iToJ = lines.addByTwoPoints(
+            adsk.core.Point3D.create(iSeed[0], iSeed[1], 0),
+            adsk.core.Point3D.create(jSeed[0], jSeed[1], 0))
+        iToJ.isConstruction = True
+        constraints.addCoincident(iToJ.startSketchPoint, pointI)
+        constraints.addCoincident(iToJ.endSketchPoint, pointJ)
+        constraints.addPerpendicular(fToI, iToJ)
 
-        # ---- offset dimension: B->Apex2 drop (dropB) vs J->I (already parallel) ----
+        # --- Offset dimension: B->Apex2 drop vs J->I ; value = driving base height ---
         if self._drivingBaseHeight_cm > 0:
-            drivingBaseHeight_cm = self._drivingBaseHeight_cm
+            drivingBaseHeightVal = self._drivingBaseHeight_cm
         else:
-            drivingBaseHeight_cm = to_cm(module * drivingTeeth / 8)
-        offJI = dimensions.addOffsetDimension(
-            dropB, lineIJ,
-            adsk.core.Point3D.create(jSeed.x, jSeed.y, 0))
-        offJI.parameter.value = drivingBaseHeight_cm
+            drivingBaseHeightVal = to_cm(module * drivingTeeth / 8)
+        jiOffsetDim = dimensions.addOffsetDimension(
+            bToApex2, iToJ,
+            adsk.core.Point3D.create(jSeed[0], jSeed[1], 0))
+        jiOffsetDim.parameter.value = drivingBaseHeightVal
 
-        # ---- offset dimension: A->Apex2 drop (dropA) vs G->H (already parallel) ----
+        # --- Offset dimension: A->Apex2 drop vs G->H ; value = pinion base height ---
         if self._pinionBaseHeight_cm > 0:
-            pinionBaseHeight_cm = self._pinionBaseHeight_cm
+            pinionBaseHeightVal = self._pinionBaseHeight_cm
         else:
-            pinionBaseHeight_cm = drivingBaseHeight_cm * (pinionTeeth / drivingTeeth)
-        offGH = dimensions.addOffsetDimension(
-            dropA, lineGH,
-            adsk.core.Point3D.create(hSeed.x, hSeed.y, 0))
-        offGH.parameter.value = pinionBaseHeight_cm
+            pinionBaseHeightVal = drivingBaseHeightVal * (pinionTeeth / drivingTeeth)
+        ghOffsetDim = dimensions.addOffsetDimension(
+            aToApex2, gToH,
+            adsk.core.Point3D.create(hSeed[0], hSeed[1], 0))
+        ghOffsetDim.parameter.value = pinionBaseHeightVal
 
-        # ---- line A->G ----
-        lineAG = lines.addByTwoPoints(
-            adsk.core.Point3D.create(ag.x, ag.y, 0),
-            adsk.core.Point3D.create(pointG.geometry.x, pointG.geometry.y, 0))
-        lineAG.isConstruction = True
-        constraints.addCoincident(lineAG.startSketchPoint, pointA)
-        constraints.addCoincident(lineAG.endSketchPoint, pointG)
+        # --- Line A->G ---
+        aToG = lines.addByTwoPoints(
+            adsk.core.Point3D.create(aSeed[0], aSeed[1], 0),
+            adsk.core.Point3D.create(gSeed[0], gSeed[1], 0))
+        aToG.isConstruction = True
+        constraints.addCoincident(aToG.startSketchPoint, pointA)
+        constraints.addCoincident(aToG.endSketchPoint, pointG)
 
-        # ---- close the apex: point I coincident with center (pins the figure) ----
-        constraints.addCoincident(pointI, projectedCenter)
+        # --- Constrain Point I with center point ---
+        constraints.addCoincident(pointI, centerSP)
 
-        # ---- point K: from G along Apex->A (away from apex); pin with two coincidents ----
-        kg = pointG.geometry
-        kSeed = adsk.core.Point3D.create(kg.x + adir[0] * mod_cm, kg.y + adir[1] * mod_cm, 0)
-        lineGK = lines.addByTwoPoints(
-            adsk.core.Point3D.create(kg.x, kg.y, 0), kSeed)
-        lineGK.isConstruction = True
-        constraints.addCoincident(lineGK.startSketchPoint, pointG)
-        pointK = lineGK.endSketchPoint
-        # Pin K: on line Apex->A and on pinion dedendum (Apex2->C extended).
-        constraints.addCoincident(pointK, pinionShaft)
+        # --- K: construction line from G away from Apex, along Apex->A, end K ---
+        # direction away from apex along Apex->A = (aax, aay)
+        kSeed = (gSeed[0] + aax * moduleExt_cm, gSeed[1] + aay * moduleExt_cm)
+        gToK = lines.addByTwoPoints(
+            adsk.core.Point3D.create(gSeed[0], gSeed[1], 0),
+            adsk.core.Point3D.create(kSeed[0], kSeed[1], 0))
+        gToK.isConstruction = True
+        constraints.addCoincident(gToK.startSketchPoint, pointG)
+        pointK = gToK.endSketchPoint
+        # Pin K with two point-on-line coincidents (NOT addCollinear).
+        constraints.addCoincident(pointK, pinionShaftAxis)
         constraints.addCoincident(pointK, pinionDedendum)
-        # reference line C -> K
-        lineCK = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointC.geometry.x, pointC.geometry.y, 0),
-            adsk.core.Point3D.create(pointK.geometry.x, pointK.geometry.y, 0))
-        lineCK.isConstruction = True
-        constraints.addCoincident(lineCK.startSketchPoint, pointC)
-        constraints.addCoincident(lineCK.endSketchPoint, pointK)
 
-        # ---- point L: from I along Apex->B; pin the same way ----
-        ig = pointI.geometry
-        lSeed = adsk.core.Point3D.create(ig.x + bdir[0] * mod_cm, ig.y + bdir[1] * mod_cm, 0)
-        lineIL = lines.addByTwoPoints(
-            adsk.core.Point3D.create(ig.x, ig.y, 0), lSeed)
-        lineIL.isConstruction = True
-        constraints.addCoincident(lineIL.startSketchPoint, pointI)
-        pointL = lineIL.endSketchPoint
-        constraints.addCoincident(pointL, drivingShaft)
-        constraints.addCoincident(pointL, drivingDedendum)
-        lineDL = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointD.geometry.x, pointD.geometry.y, 0),
-            adsk.core.Point3D.create(pointL.geometry.x, pointL.geometry.y, 0))
-        lineDL.isConstruction = True
-        constraints.addCoincident(lineDL.startSketchPoint, pointD)
-        constraints.addCoincident(lineDL.endSketchPoint, pointL)
+        # Reference line C->K.
+        cToK = lines.addByTwoPoints(
+            adsk.core.Point3D.create(cSeed[0], cSeed[1], 0),
+            adsk.core.Point3D.create(kSeed[0], kSeed[1], 0))
+        cToK.isConstruction = True
+        constraints.addCoincident(cToK.startSketchPoint, pointC)
+        constraints.addCoincident(cToK.endSketchPoint, pointK)
 
-        # ==========================================================
-        # Maximum Face Width from SOLVED geometry; cap / validate Face Width.
-        # ==========================================================
-        def perpDistance(pt, lineP, lineQ):
-            px, py = pt.x, pt.y
-            qx, qy = lineQ.x - lineP.x, lineQ.y - lineP.y
-            qlen = math.hypot(qx, qy)
-            qx, qy = qx / qlen, qy / qlen
-            wx, wy = px - lineP.x, py - lineP.y
-            # perpendicular component magnitude
-            cross = wx * qy - wy * qx
-            return abs(cross)
+        # --- Tooth-center point K' (Tooth Spacing offset) ---
+        # When spacing == 0: K' == K, reference line C->K. Build nothing extra.
+        if self._toothSpacing_cm > 0:
+            # Shift K outward along the dedendum direction, away from C.
+            # dedendum direction outward = cDir (Apex2 -> C direction), continuing past K.
+            kpSeed = (kSeed[0] + cDir[0] * self._toothSpacing_cm,
+                      kSeed[1] + cDir[1] * self._toothSpacing_cm)
+            kToKp = lines.addByTwoPoints(
+                adsk.core.Point3D.create(kSeed[0], kSeed[1], 0),
+                adsk.core.Point3D.create(kpSeed[0], kpSeed[1], 0))
+            kToKp.isConstruction = True
+            constraints.addCoincident(kToKp.startSketchPoint, pointK)
+            pointKp = kToKp.endSketchPoint
+            constraints.addCoincident(pointKp, pinionDedendum)
+            kpDim = dimensions.addDistanceDimension(
+                kToKp.startSketchPoint, kToKp.endSketchPoint,
+                adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
+                adsk.core.Point3D.create((kSeed[0] + kpSeed[0]) / 2,
+                                         (kSeed[1] + kpSeed[1]) / 2, 0))
+            kpDim.parameter.value = self._toothSpacing_cm
+            # Tooth-center reference line C->K'.
+            cToKp = lines.addByTwoPoints(
+                adsk.core.Point3D.create(cSeed[0], cSeed[1], 0),
+                adsk.core.Point3D.create(kpSeed[0], kpSeed[1], 0))
+            cToKp.isConstruction = True
+            constraints.addCoincident(cToKp.startSketchPoint, pointC)
+            constraints.addCoincident(cToKp.endSketchPoint, pointKp)
+            pinionCenterPoint = pointKp
+            pinionCenterRefLine = cToKp
+        else:
+            pinionCenterPoint = pointK
+            pinionCenterRefLine = cToK
 
-        gA = pointA.geometry
-        gB = pointB.geometry
-        gC = pointC.geometry
-        gD = pointD.geometry
-        gH = pointH.geometry
-        gJ = pointJ.geometry
-        distPinion = perpDistance(gA, gC, gH)   # A to line C-H
-        distDriving = perpDistance(gB, gD, gJ)  # B to line D-J
-        maxFaceWidth_cm = 0.95 * min(distPinion, distDriving)
+        # --- Resolve Maximum Face Width from SOLVED geometry ---
+        aGeo = pointA.geometry
+        bGeo = pointB.geometry
+        cGeo = pointC.geometry
+        dGeo = pointD.geometry
+        hGeo = pointH.geometry
+        jGeo = pointJ.geometry
+        distA = self._perpDistancePointToLine(aGeo, cGeo, hGeo)
+        distB = self._perpDistancePointToLine(bGeo, dGeo, jGeo)
+        maxFaceWidth_cm = 0.95 * min(distA, distB)
 
-        if self._faceWidth_cm > 0:
+        if self._faceWidthSpecified:
             if self._faceWidth_cm > maxFaceWidth_cm:
                 raise Exception(
-                    'Face Width exceeds the maximum permitted '
-                    f'({to_mm(maxFaceWidth_cm):.4f} mm); reduce it or it would '
-                    'self-intersect the revolve axis')
+                    'Face width {:.3f} mm exceeds maximum {:.3f} mm'.format(
+                        to_mm(self._faceWidth_cm), to_mm(maxFaceWidth_cm)))
             faceWidth_cm = self._faceWidth_cm
         else:
-            coneDistance_cm = to_cm(
-                math.sqrt((module * drivingTeeth) ** 2 + (module * pinionTeeth) ** 2))
+            coneDistance_cm = to_cm(math.sqrt(
+                (module * drivingTeeth) ** 2 + (module * pinionTeeth) ** 2))
             faceWidth_cm = min(coneDistance_cm / 6, maxFaceWidth_cm)
 
-        # ==========================================================
-        # Toe line M->N (pinion) and its mirror O->P (driving).
-        # ==========================================================
-        # --- M->N ---
-        # Seed M near midpoint of Apex->C; N slid from M along C->H toward A->Apex2.
-        mSeed = adsk.core.Point3D.create((apex.x + gC.x) / 2, (apex.y + gC.y) / 2, 0)
-        chDir = (gH.x - gC.x, gH.y - gC.y)
-        chLen = math.hypot(chDir[0], chDir[1])
-        chDir = (chDir[0] / chLen, chDir[1] / chLen)
-        mToA = math.hypot(gA.x - mSeed.x, gA.y - mSeed.y)
-        nSeed = adsk.core.Point3D.create(
-            mSeed.x + chDir[0] * mToA, mSeed.y + chDir[1] * mToA, 0)
-        lineMN = lines.addByTwoPoints(mSeed, nSeed)
-        lineMN.isConstruction = True
-        pointM = lineMN.startSketchPoint
-        pointN = lineMN.endSketchPoint
-        constraints.addCoincident(pointM, pinionRootAxis)   # M on Apex->C root axis
-        constraints.addCoincident(pointN, dropA)            # N on A->Apex2 drop line
-        constraints.addParallel(lineMN, lineCH)
-        offMN = dimensions.addOffsetDimension(
-            lineCH, lineMN,
-            adsk.core.Point3D.create(nSeed.x, nSeed.y, 0))
-        offMN.parameter.value = faceWidth_cm
-        # connecting lines M->C and N->A
-        lineMC = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointM.geometry.x, pointM.geometry.y, 0),
-            adsk.core.Point3D.create(gC.x, gC.y, 0))
-        lineMC.isConstruction = True
-        constraints.addCoincident(lineMC.startSketchPoint, pointM)
-        constraints.addCoincident(lineMC.endSketchPoint, pointC)
-        lineNA = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointN.geometry.x, pointN.geometry.y, 0),
-            adsk.core.Point3D.create(gA.x, gA.y, 0))
-        lineNA.isConstruction = True
-        constraints.addCoincident(lineNA.startSketchPoint, pointN)
-        constraints.addCoincident(lineNA.endSketchPoint, pointA)
+        # --- M->N (pinion toe line) ---
+        # C->H direction.
+        chx = hGeo.x - cGeo.x
+        chy = hGeo.y - cGeo.y
+        chlen = math.hypot(chx, chy)
+        chx /= chlen
+        chy /= chlen
+        # Seed M at midpoint of Apex->C.
+        apexSolved = apexPoint.geometry
+        mSeed = ((apexSolved.x + cGeo.x) / 2, (apexSolved.y + cGeo.y) / 2)
+        # Seed N by sliding from M-seed along C->H by ~distance M-seed to A.
+        slideN = math.hypot(mSeed[0] - aGeo.x, mSeed[1] - aGeo.y)
+        nSeed = (mSeed[0] + chx * slideN, mSeed[1] + chy * slideN)
+        mToN = lines.addByTwoPoints(
+            adsk.core.Point3D.create(mSeed[0], mSeed[1], 0),
+            adsk.core.Point3D.create(nSeed[0], nSeed[1], 0))
+        mToN.isConstruction = True
+        pointM = mToN.startSketchPoint
+        pointN = mToN.endSketchPoint
+        constraints.addCoincident(pointM, pinionRootAxis)
+        constraints.addCoincident(pointN, aToApex2)
+        constraints.addParallel(mToN, cToH)
+        mnOffsetDim = dimensions.addOffsetDimension(
+            cToH, mToN,
+            adsk.core.Point3D.create(mSeed[0], mSeed[1], 0))
+        mnOffsetDim.parameter.value = faceWidth_cm
 
-        # --- O->P (driving mirror) ---
-        oSeed = adsk.core.Point3D.create((apex.x + gD.x) / 2, (apex.y + gD.y) / 2, 0)
-        djDir = (gJ.x - gD.x, gJ.y - gD.y)
-        djLen = math.hypot(djDir[0], djDir[1])
-        djDir = (djDir[0] / djLen, djDir[1] / djLen)
-        oToB = math.hypot(gB.x - oSeed.x, gB.y - oSeed.y)
-        pSeed = adsk.core.Point3D.create(
-            oSeed.x + djDir[0] * oToB, oSeed.y + djDir[1] * oToB, 0)
-        lineOP = lines.addByTwoPoints(oSeed, pSeed)
-        lineOP.isConstruction = True
-        pointO = lineOP.startSketchPoint
-        pointP = lineOP.endSketchPoint
-        constraints.addCoincident(pointO, drivingRootAxis)  # O on Apex->D root axis
-        constraints.addCoincident(pointP, dropB)            # P on B->Apex2 drop line
-        constraints.addParallel(lineOP, lineDJ)
-        offOP = dimensions.addOffsetDimension(
-            lineDJ, lineOP,
-            adsk.core.Point3D.create(pSeed.x, pSeed.y, 0))
-        offOP.parameter.value = faceWidth_cm
-        lineOD = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointO.geometry.x, pointO.geometry.y, 0),
-            adsk.core.Point3D.create(gD.x, gD.y, 0))
-        lineOD.isConstruction = True
-        constraints.addCoincident(lineOD.startSketchPoint, pointO)
-        constraints.addCoincident(lineOD.endSketchPoint, pointD)
-        linePB = lines.addByTwoPoints(
-            adsk.core.Point3D.create(pointP.geometry.x, pointP.geometry.y, 0),
-            adsk.core.Point3D.create(gB.x, gB.y, 0))
-        linePB.isConstruction = True
-        constraints.addCoincident(linePB.startSketchPoint, pointP)
-        constraints.addCoincident(linePB.endSketchPoint, pointB)
+        # M->C and N->A connecting lines.
+        mToC = lines.addByTwoPoints(
+            adsk.core.Point3D.create(mSeed[0], mSeed[1], 0),
+            adsk.core.Point3D.create(cSeed[0], cSeed[1], 0))
+        mToC.isConstruction = True
+        constraints.addCoincident(mToC.startSketchPoint, pointM)
+        constraints.addCoincident(mToC.endSketchPoint, pointC)
+        nToA = lines.addByTwoPoints(
+            adsk.core.Point3D.create(nSeed[0], nSeed[1], 0),
+            adsk.core.Point3D.create(aSeed[0], aSeed[1], 0))
+        nToA.isConstruction = True
+        constraints.addCoincident(nToA.startSketchPoint, pointN)
+        constraints.addCoincident(nToA.endSketchPoint, pointA)
 
-        # line from B to I
-        lineBI = lines.addByTwoPoints(
-            adsk.core.Point3D.create(gB.x, gB.y, 0),
-            adsk.core.Point3D.create(pointI.geometry.x, pointI.geometry.y, 0))
-        lineBI.isConstruction = True
-        constraints.addCoincident(lineBI.startSketchPoint, pointB)
-        constraints.addCoincident(lineBI.endSketchPoint, pointI)
+        # --- L: construction line from I away from Apex, along Apex->B, end L ---
+        lSeed = (iSeed[0] + bbx * moduleExt_cm, iSeed[1] + bby * moduleExt_cm)
+        iToL = lines.addByTwoPoints(
+            adsk.core.Point3D.create(iSeed[0], iSeed[1], 0),
+            adsk.core.Point3D.create(lSeed[0], lSeed[1], 0))
+        iToL.isConstruction = True
+        constraints.addCoincident(iToL.startSketchPoint, pointI)
+        pointL = iToL.endSketchPoint
+        constraints.addCoincident(pointL, drivingShaftAxis)
+        constraints.addCoincident(pointL, drivingDedendum)
 
+        dToL = lines.addByTwoPoints(
+            adsk.core.Point3D.create(dSeed[0], dSeed[1], 0),
+            adsk.core.Point3D.create(lSeed[0], lSeed[1], 0))
+        dToL.isConstruction = True
+        constraints.addCoincident(dToL.startSketchPoint, pointD)
+        constraints.addCoincident(dToL.endSketchPoint, pointL)
+
+        # --- Tooth-center point L' (Tooth Spacing offset) ---
+        if self._toothSpacing_cm > 0:
+            lpSeed = (lSeed[0] + dDir[0] * self._toothSpacing_cm,
+                      lSeed[1] + dDir[1] * self._toothSpacing_cm)
+            lToLp = lines.addByTwoPoints(
+                adsk.core.Point3D.create(lSeed[0], lSeed[1], 0),
+                adsk.core.Point3D.create(lpSeed[0], lpSeed[1], 0))
+            lToLp.isConstruction = True
+            constraints.addCoincident(lToLp.startSketchPoint, pointL)
+            pointLp = lToLp.endSketchPoint
+            constraints.addCoincident(pointLp, drivingDedendum)
+            lpDim = dimensions.addDistanceDimension(
+                lToLp.startSketchPoint, lToLp.endSketchPoint,
+                adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
+                adsk.core.Point3D.create((lSeed[0] + lpSeed[0]) / 2,
+                                         (lSeed[1] + lpSeed[1]) / 2, 0))
+            lpDim.parameter.value = self._toothSpacing_cm
+            dToLp = lines.addByTwoPoints(
+                adsk.core.Point3D.create(dSeed[0], dSeed[1], 0),
+                adsk.core.Point3D.create(lpSeed[0], lpSeed[1], 0))
+            dToLp.isConstruction = True
+            constraints.addCoincident(dToLp.startSketchPoint, pointD)
+            constraints.addCoincident(dToLp.endSketchPoint, pointLp)
+            drivingCenterPoint = pointLp
+            drivingCenterRefLine = dToLp
+        else:
+            drivingCenterPoint = pointL
+            drivingCenterRefLine = dToL
+
+        # --- O->P (driving toe line, mirror of M->N) ---
+        djx = jGeo.x - dGeo.x
+        djy = jGeo.y - dGeo.y
+        djlen = math.hypot(djx, djy)
+        djx /= djlen
+        djy /= djlen
+        oSeed = ((apexSolved.x + dGeo.x) / 2, (apexSolved.y + dGeo.y) / 2)
+        slideP = math.hypot(oSeed[0] - bGeo.x, oSeed[1] - bGeo.y)
+        pSeed = (oSeed[0] + djx * slideP, oSeed[1] + djy * slideP)
+        oToP = lines.addByTwoPoints(
+            adsk.core.Point3D.create(oSeed[0], oSeed[1], 0),
+            adsk.core.Point3D.create(pSeed[0], pSeed[1], 0))
+        oToP.isConstruction = True
+        pointO = oToP.startSketchPoint
+        pointP = oToP.endSketchPoint
+        constraints.addCoincident(pointO, drivingRootAxis)
+        constraints.addCoincident(pointP, bToApex2)
+        constraints.addParallel(oToP, dToJ)
+        opOffsetDim = dimensions.addOffsetDimension(
+            dToJ, oToP,
+            adsk.core.Point3D.create(oSeed[0], oSeed[1], 0))
+        opOffsetDim.parameter.value = faceWidth_cm
+
+        oToD = lines.addByTwoPoints(
+            adsk.core.Point3D.create(oSeed[0], oSeed[1], 0),
+            adsk.core.Point3D.create(dSeed[0], dSeed[1], 0))
+        oToD.isConstruction = True
+        constraints.addCoincident(oToD.startSketchPoint, pointO)
+        constraints.addCoincident(oToD.endSketchPoint, pointD)
+        pToB = lines.addByTwoPoints(
+            adsk.core.Point3D.create(pSeed[0], pSeed[1], 0),
+            adsk.core.Point3D.create(bSeed.x, bSeed.y, 0))
+        pToB.isConstruction = True
+        constraints.addCoincident(pToB.startSketchPoint, pointP)
+        constraints.addCoincident(pToB.endSketchPoint, pointB)
+
+        # Line B->I.
+        bToI = lines.addByTwoPoints(
+            adsk.core.Point3D.create(bSeed.x, bSeed.y, 0),
+            adsk.core.Point3D.create(iSeed[0], iSeed[1], 0))
+        bToI.isConstruction = True
+        constraints.addCoincident(bToI.startSketchPoint, pointB)
+        constraints.addCoincident(bToI.endSketchPoint, pointI)
+
+        # Gate: the §2 sketch must be fully constrained.
         self._assertFullyConstrained(sketch, 'Gear Profiles')
 
-        # gather the §2 anchors used downstream
-        prof = {
-            'sketch': sketch,
-            'gearProfilesPlane': gearProfilesPlane,
-            'apexPoint': apexPoint,
-            'A': pointA, 'B': pointB, 'C': pointC, 'D': pointD,
-            'G': pointG, 'H': pointH, 'I': pointI, 'J': pointJ,
-            'K': pointK, 'L': pointL,
-            'M': pointM, 'N': pointN, 'O': pointO, 'P': pointP,
-            'lineCK': lineCK, 'lineDL': lineDL,
-            'gamma_p': gamma_p, 'gamma_g': gamma_g,
-        }
+        # --- §3: virtual spur tooth profiles ---
+        # gamma_p, gamma_g already computed above.
+        pinionVirtualPitchRadius_cm = (PPD / 2) / math.cos(gamma_p)
+        pinionVirtualTeeth = int(math.floor(
+            2 * pinionVirtualPitchRadius_cm / moduleCm))
+        drivingVirtualPitchRadius_cm = (DPD / 2) / math.cos(gamma_g)
+        drivingVirtualTeeth = int(math.floor(
+            2 * drivingVirtualPitchRadius_cm / moduleCm))
 
-        # ==========================================================
-        # §3 + per-gear body creation (pinion first, then driving).
-        # ==========================================================
-        # ---- pinion tooth profile ----
-        (pinionToothSketch, pinionToothAxis) = self._buildVirtualSpurProfile(
-            designComp, prof, targetPlane, module,
-            prof['gamma_p'], pinionPitchDia_cm, prof['C'], prof['K'], prof['lineCK'],
-            'Pinion')
-        # ---- driving tooth profile ----
-        (drivingToothSketch, drivingToothAxis) = self._buildVirtualSpurProfile(
-            designComp, prof, targetPlane, module,
-            prof['gamma_g'], drivingPitchDia_cm, prof['D'], prof['L'], prof['lineDL'],
-            'Driving')
+        # apex sketch point used as the loft degenerate section.
+        apexSketchPoint = centerToApex.endSketchPoint
 
-        # ---- create pinion gear body ----
+        (pinionToothPlane, pinionToothSketch, pinionToothAxis) = \
+            self._buildVirtualSpurProfile(
+                designComponent, sketch, gearProfilesPlane,
+                pinionCenterRefLine, pinionCenterPoint,
+                module, pinionVirtualTeeth, 'Pinion Tooth')
+
+        (drivingToothPlane, drivingToothSketch, drivingToothAxis) = \
+            self._buildVirtualSpurProfile(
+                designComponent, sketch, gearProfilesPlane,
+                drivingCenterRefLine, drivingCenterPoint,
+                module, drivingVirtualTeeth, 'Driving Tooth')
+
+        # --- Pinion Gear body ---
+        pinionGearOccurrence = bevelComponent.occurrences.addNewComponent(
+            adsk.core.Matrix3D.create())
+        pinionGearOccurrence.component.name = 'Pinion Gear'
+
         self._createGearBody(
-            designComp, bevelComp, pinionOcc, prof, gearProfilesPlane,
-            ['A', 'G', 'H', 'C', 'M', 'N'],
-            pinionToothSketch, 'M', 'N', 'C', 'H',
-            pinionTeeth, pinionBore_cm, pinionPitchDia_cm,
-            'Pinion', meshRotateTeeth=None)
+            designComponent, gearProfilesPlane, sketch,
+            [pointA, pointG, pointH, pointC, pointM, pointN],
+            apexSketchPoint, pinionToothSketch,
+            (pointM, pointN), (pointC, pointH),
+            pinionTeeth, pinionBore_cm,
+            'Pinion', pinionGearOccurrence, meshRotation=0.0)
 
-        # ---- create driving gear body (mesh-rotated) ----
+        # --- Driving Gear body ---
+        drivingGearOccurrence = bevelComponent.occurrences.addNewComponent(
+            adsk.core.Matrix3D.create())
+        drivingGearOccurrence.component.name = 'Driving Gear'
+
+        drivingMeshRotation = math.radians(180.0 / drivingTeeth)
         self._createGearBody(
-            designComp, bevelComp, drivingOcc, prof, gearProfilesPlane,
-            ['B', 'I', 'J', 'D', 'O', 'P'],
-            drivingToothSketch, 'O', 'P', 'D', 'J',
-            drivingTeeth, drivingBore_cm, drivingPitchDia_cm,
-            'Driving', meshRotateTeeth=drivingTeeth)
+            designComponent, gearProfilesPlane, sketch,
+            [pointB, pointI, pointJ, pointD, pointO, pointP],
+            apexSketchPoint, drivingToothSketch,
+            (pointO, pointP), (pointD, pointJ),
+            drivingTeeth, drivingBore_cm,
+            'Driving', drivingGearOccurrence, meshRotation=drivingMeshRotation)
 
-    # ===================================================================
-    # §3 virtual spur tooth profile for one gear
-    # ===================================================================
-    def _buildVirtualSpurProfile(self, designComp, prof, targetPlane, module,
-                                 gamma, pitchDia_cm, rootPoint, centerPoint,
-                                 rootToCenterLine, label):
-        gearProfilesPlane = prof['gearProfilesPlane']
-
-        # virtual (Tredgold) tooth number from closed form.
-        virtualPitchRadius_cm = (pitchDia_cm / 2) / math.cos(gamma)
-        # Module is mm; radius is cm -> convert radius to mm for the count.
-        virtualTeeth = int(math.floor(2 * to_mm(virtualPitchRadius_cm) / module))
-        if virtualTeeth < 3:
-            virtualTeeth = 3
-
-        # plane that includes line (root->center), perpendicular to Gear Profiles plane.
-        planeInput = designComp.constructionPlanes.createInput()
+    # ----- §3 helper: virtual spur tooth profile -----
+    def _buildVirtualSpurProfile(self, designComponent, gearProfilesSketch,
+                                 gearProfilesPlane, centerRefLine, centerPoint,
+                                 module, virtualTeeth, label):
+        # Plane that includes centerRefLine, perpendicular to the Gear Profiles plane.
+        planeInput = designComponent.constructionPlanes.createInput()
         planeInput.setByAngle(
-            rootToCenterLine, adsk.core.ValueInput.createByString('90 deg'),
+            centerRefLine, adsk.core.ValueInput.createByString('90 deg'),
             gearProfilesPlane)
-        toothPlane = designComp.constructionPlanes.add(planeInput)
-        toothPlane.name = f'{label} Tooth Plane'
+        toothPlane = designComponent.constructionPlanes.add(planeInput)
+        toothPlane.name = f'{label} Plane'
 
-        toothSketch = designComp.sketches.add(toothPlane)
-        toothSketch.name = f'{label} Tooth'
+        toothSketch = designComponent.sketches.add(toothPlane)
+        toothSketch.name = f'{label} Profile'
         toothSketch.isVisible = True
 
         proxy = _VirtualSpurProxy(module_mm=module, virtualTeeth=virtualTeeth)
         drawer = SpurGearInvoluteToothDesignGenerator(toothSketch, proxy)
         drawer.draw(centerPoint, angle=math.radians(180))
 
-        self._assertFullyConstrained(toothSketch, f'{label} Tooth')
+        self._assertFullyConstrained(toothSketch, f'{label} Profile')
 
-        # construction axis through center, normal to the tooth plane, via setByTwoPlanes:
-        #   Gear Profiles plane  X  helper plane (perp to root->center at its far end).
-        helperInput = designComp.constructionPlanes.createInput()
-        helperInput.setByDistanceOnPath(rootToCenterLine, adsk.core.ValueInput.createByReal(1.0))
-        helperPlane = designComp.constructionPlanes.add(helperInput)
-        helperPlane.name = f'{label} Tooth Axis Helper'
+        # Construction axis through centerPoint normal to the tooth plane, via setByTwoPlanes:
+        # the Gear Profiles plane intersected with a helper plane perpendicular to
+        # centerRefLine at its far end (setByDistanceOnPath at 1.0).
+        helperInput = designComponent.constructionPlanes.createInput()
+        helperInput.setByDistanceOnPath(
+            centerRefLine, adsk.core.ValueInput.createByReal(1.0))
+        helperPlane = designComponent.constructionPlanes.add(helperInput)
+        helperPlane.name = f'{label} Helper Plane'
 
-        axisInput = designComp.constructionAxes.createInput()
+        axisInput = designComponent.constructionAxes.createInput()
         axisInput.setByTwoPlanes(gearProfilesPlane, helperPlane)
-        toothAxis = designComp.constructionAxes.add(axisInput)
-        toothAxis.name = f'{label} Tooth Axis'
-        toothAxis.isLightBulbOn = False
+        toothAxis = designComponent.constructionAxes.add(axisInput)
+        toothAxis.name = f'{label} Axis'
 
-        return (toothSketch, toothAxis)
+        return (toothPlane, toothSketch, toothAxis)
 
-    # ===================================================================
-    # per-gear body creation
-    # ===================================================================
-    def _createGearBody(self, designComp, bevelComp, gearOcc, prof, gearProfilesPlane,
-                        hexVerts, toothSketch, toeStartKey, toeEndKey,
-                        heelStartKey, heelEndKey,
-                        teethNumber, bore_cm, pitchDia_cm,
-                        label, meshRotateTeeth):
-        # ---- fresh profile sketch with the six recreated, FIXED vertices ----
-        profileSketch = designComp.sketches.add(gearProfilesPlane)
-        profileSketch.name = f'{label} Profile'
+    # ----- per-gear body creation -----
+    def _createGearBody(self, designComponent, gearProfilesPlane, gearProfilesSketch,
+                        hexVertices, apexSketchPoint, toothSketch,
+                        toeEdgePoints, heelEdgePoints,
+                        teethNumber, bore_cm, gearLabel, targetOccurrence,
+                        meshRotation):
+        features = designComponent.features
+
+        # --- Profile sketch with recreated fixed vertices ---
+        profileSketch = designComponent.sketches.add(gearProfilesPlane)
+        profileSketch.name = f'{gearLabel} Profile'
         profileSketch.isVisible = True
-
         lines = profileSketch.sketchCurves.sketchLines
 
-        # recreate each §2 vertex as a NEW point (modelToSketchSpace of worldGeometry).
-        srcPoints = [prof[k] for k in hexVerts]
-        verts = [profileSketch.sketchPoints.add(
-            profileSketch.modelToSketchSpace(p.worldGeometry)) for p in srcPoints]
+        # Recreate the six vertices at their world-mapped positions.
+        verts = []
+        for src in hexVertices:
+            local = profileSketch.modelToSketchSpace(src.worldGeometry)
+            verts.append(profileSketch.sketchPoints.add(local))
 
-        # draw the closed hexagon SHARING those points.
+        # Draw the closed hexagon sharing those points (A->G->H->C->M->N->A style).
         hexLines = []
-        n = len(verts)
-        for i in range(n):
-            line = lines.addByTwoPoints(verts[i], verts[(i + 1) % n])
-            line.isConstruction = False
-            hexLines.append(line)
+        for i in range(len(verts)):
+            nxt = (i + 1) % len(verts)
+            hexLines.append(lines.addByTwoPoints(verts[i], verts[nxt]))
 
-        # fix lines AND endpoints AFTER the lines exist.
-        for line in hexLines:
-            line.startSketchPoint.isFixed = True
-            line.endSketchPoint.isFixed = True
+        # Fix endpoints AFTER the lines exist.
+        for ln in hexLines:
+            ln.startSketchPoint.isFixed = True
+            ln.endSketchPoint.isFixed = True
 
-        self._assertFullyConstrained(profileSketch, f'{label} Profile')
+        self._assertFullyConstrained(profileSketch, f'{gearLabel} Profile')
 
-        # The first edge (verts[0]->verts[1]) is the shaft axis for every body op.
-        shaftEdge = hexLines[0]
+        # The shaft axis is this profile sketch's FIRST edge.
+        shaftAxisEdge = hexLines[0]
 
-        # single hexagon loop -> single profile.
+        # Single profile (one hexagon loop).
         profile = profileSketch.profiles.item(0)
 
-        # ---- revolve about the shaft edge ----
-        revolves = designComp.features.revolveFeatures
+        # --- Revolve around the shaft axis edge ---
+        revolves = features.revolveFeatures
         revInput = revolves.createInput(
-            profile, shaftEdge, adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+            profile, shaftAxisEdge,
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
         revInput.setAngleExtent(False, adsk.core.ValueInput.createByString('360 deg'))
         revolve = revolves.add(revInput)
         gearBody = revolve.bodies.item(0)
-        gearBody.name = f'{label} Gear Body'
+        gearBody.name = f'{gearLabel} Gear Body'
 
-        # ---- loft Apex sketch point -> tooth profile ----
-        apexSketchPoint = prof['apexPoint']  # centerToApex.endSketchPoint
+        # --- Loft apex point -> tooth profile ---
         toothProfile = self._findSpurToothProfile(toothSketch)
-        lofts = designComp.features.loftFeatures
-        loftInput = lofts.createInput(adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        lofts = features.loftFeatures
+        loftInput = lofts.createInput(
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
         loftInput.loftSections.add(apexSketchPoint)
         loftInput.loftSections.add(toothProfile)
         loft = lofts.add(loftInput)
         toothBody = loft.bodies.item(0)
-        toothBody.name = f'{label} Gear Tooth Body'
+        toothBody.name = f'{gearLabel} Tooth Body'
 
-        # ---- two interleaved conical cuts ----
-        apexWorld = self._pointWorldGeometry(prof['apexPoint'])
-        toeMidWorld = self._edgeMidWorld(prof, toeStartKey, toeEndKey)
-        heelMidWorld = self._edgeMidWorld(prof, heelStartKey, heelEndKey)
+        # --- Apex world point (for containment tests) ---
+        apexWorld = apexSketchPoint.worldGeometry
 
-        # cut #1: toe cut on the Tooth Body.
+        # --- Conical cuts: toe then heel, with keeper selection between ---
+        toe_m = self._pointWorldGeometry(toeEdgePoints[0])
+        toe_n = self._pointWorldGeometry(toeEdgePoints[1])
+        toeMid = adsk.core.Point3D.create(
+            (toe_m.x + toe_n.x) / 2, (toe_m.y + toe_n.y) / 2,
+            (toe_m.z + toe_n.z) / 2)
+
+        heel_c = self._pointWorldGeometry(heelEdgePoints[0])
+        heel_h = self._pointWorldGeometry(heelEdgePoints[1])
+        heelMid = adsk.core.Point3D.create(
+            (heel_c.x + heel_h.x) / 2, (heel_c.y + heel_h.y) / 2,
+            (heel_c.z + heel_h.z) / 2)
+
+        # Cut 1: toe cut on the Tooth Body using a cone face of the Gear Body (frustum).
         toePieces = self._applyConicalCut(
-            designComp, gearBody, [toothBody], toeMidWorld,
-            f'{label} cut#1 toe')
-        if len(toePieces) < 2:
-            raise Exception(
-                f'{label}: toe cut produced {len(toePieces)} piece(s); expected >=2 '
-                '(apex tip + keeper)')
+            designComponent, gearBody, [toothBody], toeMid,
+            f'{gearLabel} toe cut#1')
 
-        # drop apex tip, keep largest non-apex piece (the keeper).
-        keeper = self._selectKeeper(designComp, toePieces, apexWorld, f'{label} toe')
+        # Drop the apex tip; keep the largest non-apex piece (the keeper).
+        keeper = self._selectKeeper(designComponent, toePieces, apexWorld,
+                                    f'{gearLabel} toe keeper')
 
-        # cut #2: heel cut on the keeper ALONE (may not intersect -> keep whole).
+        # Cut 2: heel cut on the keeper alone. May not intersect (try/except).
         try:
             heelPieces = self._applyConicalCut(
-                designComp, gearBody, [keeper], heelMidWorld,
-                f'{label} cut#2 heel')
+                designComponent, gearBody, [keeper], heelMid,
+                f'{gearLabel} heel cut#2')
+            tooth = self._selectKeeper(
+                designComponent, heelPieces, apexWorld,
+                f'{gearLabel} heel keeper')
         except RuntimeError as e:
             msg = str(e)
             if 'SPLIT_TARGET_TOOL_NOT_INTERSECT' in msg or '交差' in msg:
-                futil.log(f'{label} heel cut: tool did not intersect, kept intact',
-                          force_console=True)
-                heelPieces = [keeper]
+                futil.log(
+                    f'{gearLabel} heel cut: tool did not intersect, kept intact',
+                    force_console=True)
+                tooth = keeper
             else:
                 raise
 
-        # select tooth (drop any apex piece, keep largest non-apex).
-        toothPiece = self._selectKeeper(designComp, heelPieces, apexWorld, f'{label} heel')
-
-        # ---- circular pattern the tooth about the shaft edge ----
+        # --- Circular-pattern the tooth around the shaft axis edge ---
         inputBodies = adsk.core.ObjectCollection.create()
-        inputBodies.add(toothPiece)
-        patterns = designComp.features.circularPatternFeatures
-        patternInput = patterns.createInput(inputBodies, shaftEdge)
+        inputBodies.add(tooth)
+        patterns = features.circularPatternFeatures
+        patternInput = patterns.createInput(inputBodies, shaftAxisEdge)
         patternInput.quantity = adsk.core.ValueInput.createByReal(teethNumber)
         patternInput.totalAngle = adsk.core.ValueInput.createByString('360 deg')
         patternInput.isSymmetric = False
         pattern = patterns.add(patternInput)
 
-        # ---- combine-join all patterned teeth into the gear body ----
+        # --- Combine-join the patterned teeth with the Gear Body ---
         combineTools = adsk.core.ObjectCollection.create()
         for body in pattern.bodies:
             combineTools.add(body)
-        combines = designComp.features.combineFeatures
+        combines = features.combineFeatures
         combineInput = combines.createInput(gearBody, combineTools)
         combineInput.operation = adsk.fusion.FeatureOperations.JoinFeatureOperation
         combines.add(combineInput)
 
-        # ---- bore ----
-        if self._boreEnable:
-            self._cutBore(designComp, gearBody, shaftEdge, bore_cm, pitchDia_cm)
+        # --- Bore ---
+        if self._boreEnable and bore_cm > 0:
+            self._cutBore(designComponent, gearBody, shaftAxisEdge, bore_cm, gearLabel)
 
-        # ---- meshing rotation (driving only), in Design before moveToComponent ----
-        if meshRotateTeeth is not None:
-            startW = shaftEdge.startSketchPoint.worldGeometry
-            endW = shaftEdge.endSketchPoint.worldGeometry
-            axisVec = startW.vectorTo(endW)
+        # --- Meshing rotation (driving gear only) ---
+        if meshRotation != 0.0:
+            startW = shaftAxisEdge.startSketchPoint.worldGeometry
+            endW = shaftAxisEdge.endSketchPoint.worldGeometry
+            axisVec = adsk.core.Vector3D.create(
+                endW.x - startW.x, endW.y - startW.y, endW.z - startW.z)
             axisVec.normalize()
             matrix = adsk.core.Matrix3D.create()
-            matrix.setToRotation(math.radians(180.0 / meshRotateTeeth), axisVec, startW)
+            matrix.setToRotation(meshRotation, axisVec, startW)
             moveBodies = adsk.core.ObjectCollection.create()
             moveBodies.add(gearBody)
-            moves = designComp.features.moveFeatures
+            moves = features.moveFeatures
             moveInput = moves.createInput2(moveBodies)
             moveInput.defineAsFreeMove(matrix)
             moves.add(moveInput)
 
-        # ---- relocate finished body into the gear component ----
-        gearBody.moveToComponent(gearOcc)
+        # --- Relocate finished body into the gear component ---
+        gearBody.moveToComponent(targetOccurrence)
 
-        return gearBody
-
-    # ===================================================================
-    # body-build sub-helpers
-    # ===================================================================
-    def _edgeMidWorld(self, prof, startKey, endKey):
-        s = self._pointWorldGeometry(prof[startKey])
-        e = self._pointWorldGeometry(prof[endKey])
-        return adsk.core.Point3D.create((s.x + e.x) / 2, (s.y + e.y) / 2, (s.z + e.z) / 2)
-
+    # ----- find the spur tooth cross-section profile -----
     def _findSpurToothProfile(self, toothSketch):
-        """Match the tooth cross-section loop by curve-TYPE mix.
-
-        Non-embedded: 2 NURBS flanks + 2 arcs (tip/root) + 2 lines.
-        Embedded:     2 NURBS + 2 arcs + 0 lines."""
-        best = None
-        for profile in toothSketch.profiles:
-            for loop in profile.profileLoops:
-                nNurbs = nArc = nLine = nOther = 0
+        # Match by curve-type mix: 2 NURBS flanks + 2 arcs (tip/root) + 2 lines
+        # (non-embedded), or 2 NURBS + 2 arcs + 0 lines (embedded).
+        line_t = adsk.core.Curve3DTypes.Line3DCurveType
+        arc_t = adsk.core.Curve3DTypes.Arc3DCurveType
+        nurbs_t = adsk.core.Curve3DTypes.NurbsCurve3DCurveType
+        for prof in toothSketch.profiles:
+            for loop in prof.profileLoops:
+                nurbs = arcs = others = lines = 0
                 for curve in loop.profileCurves:
                     ct = curve.geometry.curveType
-                    if ct == adsk.core.Curve3DTypes.NurbsCurve3DCurveType:
-                        nNurbs += 1
-                    elif ct == adsk.core.Curve3DTypes.Arc3DCurveType:
-                        nArc += 1
-                    elif ct == adsk.core.Curve3DTypes.Line3DCurveType:
-                        nLine += 1
+                    if ct == nurbs_t:
+                        nurbs += 1
+                    elif ct == arc_t:
+                        arcs += 1
+                    elif ct == line_t:
+                        lines += 1
                     else:
-                        nOther += 1
-                if nNurbs == 2 and nArc == 2 and nOther == 0 and nLine in (0, 2):
-                    return profile
-                # remember a near-miss for diagnostics
-                best = (nNurbs, nArc, nLine, nOther)
-        raise Exception(
-            f'Could not find spur tooth profile (best loop type mix nNurbs/nArc/nLine/nOther={best})')
+                        others += 1
+                if others != 0:
+                    continue
+                if nurbs == 2 and arcs == 2 and (lines == 2 or lines == 0):
+                    return prof
+        raise Exception('Could not find spur tooth cross-section profile')
 
-    def _findConeFaceForCutLine(self, frustumBody, edgeMidWorld):
-        """Return frustum ConeSurfaceType faces ordered best-first by surface distance
-        to the cut-edge midpoint (unevaluable None treated as +inf, tried last)."""
-        candidates = []
+    # ----- conical cut: split target bodies by best cone face of the frustum -----
+    def _applyConicalCut(self, designComponent, frustumBody, targets,
+                         edgeMidWorld, cutLabel):
+        coneType = adsk.core.SurfaceTypes.ConeSurfaceType
+        coneFaces = []
         for face in frustumBody.faces:
-            if face.geometry.surfaceType != adsk.core.SurfaceTypes.ConeSurfaceType:
-                continue
-            dist = self._surfaceDistance(face.geometry, edgeMidWorld)
-            candidates.append((face, dist))
-        candidates.sort(key=lambda fd: (fd[1] is None, fd[1] if fd[1] is not None else 0.0))
-        return candidates
+            if face.geometry.surfaceType == coneType:
+                coneFaces.append(face)
 
-    def _applyConicalCut(self, designComp, frustumBody, targetBodies, edgeMidWorld, label):
-        """Try each frustum cone face best-first as the split tool; keep the first
-        that actually splits a target into >1 piece. Returns the resulting pieces."""
-        candidates = self._findConeFaceForCutLine(frustumBody, edgeMidWorld)
-        diagnostics = []
-        for (face, dist) in candidates:
-            attemptedAll = True
-            producedPieces = []
-            for targetBody in targetBodies:
-                splits = designComp.features.splitBodyFeatures
-                splitInput = splits.createInput(targetBody, face, True)
+        # Order cone faces by surface distance to the edge midpoint (None -> +inf).
+        def faceKey(face):
+            d = self._surfaceDistance(face.geometry, edgeMidWorld)
+            return d if d is not None else float('inf')
+
+        coneFaces.sort(key=faceKey)
+
+        diag = []
+        for target in targets:
+            for face in coneFaces:
+                d = self._surfaceDistance(face.geometry, edgeMidWorld)
                 try:
-                    splitFeature = splits.add(splitInput)
+                    splits = designComponent.features.splitBodyFeatures
+                    splitInput = splits.createInput(target, face, True)
+                    split = splits.add(splitInput)
+                    pieces = []
+                    for b in split.bodies:
+                        pieces.append(b)
+                    if len(pieces) > 1:
+                        futil.log(
+                            f'{cutLabel}: split with face dist={d} -> '
+                            f'{len(pieces)} pieces', force_console=True)
+                        return pieces
+                    # Did not split (one piece) -- continue trying other faces.
+                    diag.append((d, len(pieces)))
                 except RuntimeError as e:
                     msg = str(e)
                     if 'SPLIT_TARGET_TOOL_NOT_INTERSECT' in msg or '交差' in msg:
-                        attemptedAll = False
-                        break
+                        diag.append((d, 'not-intersect'))
+                        continue
                     raise
-                for b in splitFeature.bodies:
-                    producedPieces.append(b)
-            if attemptedAll and len(producedPieces) > len(targetBodies):
-                futil.log(
-                    f'{label}: selected cone face dist={dist}; '
-                    f'{len(targetBodies)} body(ies) -> {len(producedPieces)} pieces',
-                    force_console=True)
-                return producedPieces
-            diagnostics.append((dist, len(producedPieces) if attemptedAll else 'no-intersect'))
 
-        # No cone face split the target.
         raise Exception(
-            f'{label}: no ConeSurfaceType face of the frustum split the target '
-            f'(cone faces tried: {diagnostics})')
+            f'{cutLabel}: no cone face split the target '
+            f'(cone faces tried={len(coneFaces)}, results={diag})')
 
-    def _selectKeeper(self, designComp, pieces, apexWorld, label):
-        """Drop every Apex-containing piece, keep the single largest by volume,
-        remove the rest."""
+    # ----- keeper/tooth selection: drop apex pieces, keep largest by volume -----
+    def _selectKeeper(self, designComponent, pieces, apexWorld, label):
         nonApex = []
-        apexPieces = []
         for body in pieces:
             containment = body.pointContainment(apexWorld)
             if (containment == adsk.fusion.PointContainment.PointInsidePointContainment
-                    or containment == adsk.fusion.PointContainment.PointOnPointContainment):
-                apexPieces.append(body)
+                    or containment ==
+                    adsk.fusion.PointContainment.PointOnPointContainment):
+                # apex-containing piece: remove it.
+                designComponent.features.removeFeatures.add(body)
             else:
                 nonApex.append(body)
 
         if len(nonApex) == 0:
-            raise Exception(
-                f'{label}: no non-apex piece after cut '
-                f'(total pieces={len(pieces)}, apex pieces={len(apexPieces)})')
+            raise Exception(f'{label}: no non-apex piece found')
 
+        # Keep the single largest by volume; remove the rest.
         nonApex.sort(key=lambda b: b.physicalProperties.volume, reverse=True)
         keeper = nonApex[0]
-
-        removes = designComp.features.removeFeatures
-        for body in apexPieces + nonApex[1:]:
-            removes.add(body)
-
+        for body in nonApex[1:]:
+            designComponent.features.removeFeatures.add(body)
         return keeper
 
-    def _cutBore(self, designComp, gearBody, shaftEdge, bore_cm, pitchDia_cm):
-        boreDiameter_cm = bore_cm if bore_cm > 0 else pitchDia_cm / 4
-        if boreDiameter_cm <= 0:
-            return
+    # ----- bore cut -----
+    def _cutBore(self, designComponent, gearBody, shaftAxisEdge, bore_cm, gearLabel):
+        # Bore plane normal to the shaft at its start (distance 0 on the A->G edge).
+        planeInput = designComponent.constructionPlanes.createInput()
+        planeInput.setByDistanceOnPath(
+            shaftAxisEdge, adsk.core.ValueInput.createByReal(0.0))
+        borePlane = designComponent.constructionPlanes.add(planeInput)
+        borePlane.name = f'{gearLabel} Bore Plane'
 
-        # bore plane normal to the shaft at its start.
-        planeInput = designComp.constructionPlanes.createInput()
-        planeInput.setByDistanceOnPath(shaftEdge, adsk.core.ValueInput.createByReal(0.0))
-        borePlane = designComp.constructionPlanes.add(planeInput)
-        borePlane.name = 'Bore Plane'
-
-        boreSketch = designComp.sketches.add(borePlane)
-        boreSketch.name = 'Bore Profile'
+        boreSketch = designComponent.sketches.add(borePlane)
+        boreSketch.name = f'{gearLabel} Bore'
         boreSketch.isVisible = True
-
         circles = boreSketch.sketchCurves.sketchCircles
         dimensions = boreSketch.sketchDimensions
+
+        radius = bore_cm / 2
         circle = circles.addByCenterRadius(
-            adsk.core.Point3D.create(0, 0, 0), boreDiameter_cm / 2)
-        # fix center (do NOT coincident to origin) + diameter dimension.
+            adsk.core.Point3D.create(0, 0, 0), radius)
         circle.centerSketchPoint.isFixed = True
         dimensions.addDiameterDimension(
-            circle, adsk.core.Point3D.create(boreDiameter_cm / 2, boreDiameter_cm / 2, 0))
+            circle, adsk.core.Point3D.create(radius, radius, 0)).parameter.value = bore_cm
 
-        self._assertFullyConstrained(boreSketch, 'Bore Profile')
+        self._assertFullyConstrained(boreSketch, f'{gearLabel} Bore')
 
         profile = boreSketch.profiles.item(0)
-        extrudes = designComp.features.extrudeFeatures
+        extrudes = designComponent.features.extrudeFeatures
         extInput = extrudes.createInput(
             profile, adsk.fusion.FeatureOperations.CutFeatureOperation)
-        extInput.setSymmetricExtent(adsk.core.ValueInput.createByReal(to_cm(1000)), False)
+        extInput.setSymmetricExtent(
+            adsk.core.ValueInput.createByReal(to_cm(1000)), False)
         extInput.participantBodies = [gearBody]
         extrudes.add(extInput)
 
-        boreSketch.isVisible = False
-
-    # ===================================================================
-    # cleanup
-    # ===================================================================
-    def _hideConstructionGeometry(self, bevelComp):
+    # ----- cleanup: hide construction geometry -----
+    def _hideConstructionGeometry(self, bevelComponent):
         seen = set()
 
         def walk(component):
+            token = component.entityToken
+            if token in seen:
+                return
+            seen.add(token)
+
             for sketch in component.sketches:
-                token = sketch.entityToken
-                if token in seen:
-                    continue
-                seen.add(token)
+                sketch.isLightBulbOn = False
                 sketch.isVisible = False
             for plane in component.constructionPlanes:
-                token = plane.entityToken
-                if token in seen:
-                    continue
-                seen.add(token)
                 plane.isLightBulbOn = False
             for axis in component.constructionAxes:
-                token = axis.entityToken
-                if token in seen:
-                    continue
-                seen.add(token)
                 axis.isLightBulbOn = False
+
             for occ in component.occurrences:
                 walk(occ.component)
 
-        walk(bevelComp)
-
-    # ===================================================================
-    # orchestration
-    # ===================================================================
-    def generate(self, inputs: adsk.core.CommandInputs):
-        (parentComponent, targetPlane, centerPoint,
-         module, drivingTeeth, pinionTeeth, shaftAngle_deg) = self._readInputs(inputs)
-
-        # pitch diameters & bores (Python, cm).
-        drivingPitchDia_cm = to_cm(module * drivingTeeth)
-        pinionPitchDia_cm = to_cm(module * pinionTeeth)
-        drivingBore_cm = self._drivingBore_cm
-        pinionBore_cm = self._pinionBore_cm
-
-        # ---- build component tree: Bevel Gear -> Design / Pinion / Driving ----
-        self.bevelOccurrence = parentComponent.occurrences.addNewComponent(
-            adsk.core.Matrix3D.create())
-        bevelComp = self.bevelOccurrence.component
-        bevelComp.name = (
-            f'Bevel Gear (M={module}, Driving={drivingTeeth}, Pinion={pinionTeeth}, '
-            f'Shaft={shaftAngle_deg:.1f} deg)')
-
-        designOcc = bevelComp.occurrences.addNewComponent(adsk.core.Matrix3D.create())
-        designComp = designOcc.component
-        designComp.name = 'Design'
-
-        pinionOcc = bevelComp.occurrences.addNewComponent(adsk.core.Matrix3D.create())
-        pinionOcc.component.name = 'Pinion Gear'
-
-        drivingOcc = bevelComp.occurrences.addNewComponent(adsk.core.Matrix3D.create())
-        drivingOcc.component.name = 'Driving Gear'
-
-        # ---- §1 anchor sketch ----
-        anchorLine = self._buildAnchorSketch(designComp, targetPlane, centerPoint)
-
-        # ---- §2 + §3 + per-gear body creation ----
-        self._buildGearProfiles(
-            designComp, bevelComp, pinionOcc, drivingOcc,
-            targetPlane, anchorLine,
-            module, drivingTeeth, pinionTeeth, shaftAngle_deg,
-            drivingPitchDia_cm, pinionPitchDia_cm,
-            drivingBore_cm, pinionBore_cm)
-
-        # ---- cleanup ----
-        self._hideConstructionGeometry(bevelComp)
-
-    def deleteComponent(self):
-        if self.bevelOccurrence:
-            self.bevelOccurrence.deleteMe()
-            self.bevelOccurrence = None
+        walk(bevelComponent)


### PR DESCRIPTION
- add `Tooth Spacing` input (mm, default 0, both gears): shifts the virtual spur tooth center outward along the dedendum line, tooth size unchanged
- spacing 0 reproduces prior geometry byte-for-byte
- regenerate `bevelgear.py` from the updated spec