### PR TITLE
dedup command entries into shared GearCommand

### DIFF
--- a/.claude/skills/generate-gear/PLAYBOOK.md
+++ b/.claude/skills/generate-gear/PLAYBOOK.md
@@ -21,7 +21,7 @@ Each gear lives in `lib/geargen/<gear>.py` and imports exactly:
 ```python
 import math
 from ...lib import fusion360utils as futil
-from .misc import *        # to_cm, to_mm, get_design, get_ui
+from .misc import *        # to_cm, to_mm, get_design
 from .base import *        # Generator, GenerationContext, get_value/get_boolean/get_selection, ParamNamePrefix, ComponentCleaner
 from .utilities import *   # get_normal
 ```
@@ -81,7 +81,8 @@ and the spec describes that). When inherited, `lib/geargen/base.py` provides:
 - `getParameter(name)`, `getParameterAsValueInput(name)`, `getParameterAsBoolean(name)`.
 - `parameterName(name)` → `f'{prefix}_{name}'` (creates the occurrence if needed).
 - `prefixBase()` → default `'Gear'`; override per gear (`'SpurGear'`, `'HelicalGear'`, …).
-- `deleteComponent()` — deletes the occurrence; used by the entry point on failure.
+- `deleteComponent()` — deletes the registered user parameters (via `ComponentCleaner`) and the
+  occurrence; used by the entry point on failure.
 - `createSketchObject(name, plane=None)` — adds a sketch (defaults to XY plane), names it, sets
   `isVisible=False`, returns it. (Note: a sketch created this way starts hidden; make it visible
   while you draw/consume profiles, per the spec's sketch-discipline rules.)
@@ -198,14 +199,38 @@ expected front-face edge count, etc.; the spec says what each returns for the de
 
 ## Command-entry wiring (`commands/<gear>/entry.py`)
 
-Standard Fusion add-in command module (mostly boilerplate; mirror the existing command modules):
-`GEAR_TYPE`/`CMD_ID`/`CMD_NAME`; `start()` registers the button + dropdown and the
-`commandCreated` handler; `command_created` calls
-`geargen.<Gear>CommandInputsConfigurator.configure(args.command)` and wires the
-execute/inputChanged/executePreview/validateInputs/destroy handlers via `futil.add_handler`;
-`command_execute` does `g = geargen.<Gear>Generator(design); g.generate(inputs)` inside
-`try/except` and calls `g.deleteComponent()` on failure (errors surfaced with
-`futil.handle_error("Generation error", show_message_box=True)`).
+The Fusion command boilerplate lives once in `commands/_gear_command.py` (`GearCommand`): it
+registers the button in the shared Gears dropdown, wires the
+execute/inputChanged/validateInputs/destroy handlers via `futil.add_handler`, runs
+`generator_class(get_design()).generate(inputs)` inside `try/except Exception` (failure →
+`futil.handle_error('Generation error', show_message_box=True)` + `g.deleteComponent()`), and on
+`stop()` removes only its own control — the shared dropdown is deleted once by
+`commands/__init__.py` after all commands stop. An entry module only declares its command and
+re-exports the lifecycle hooks:
+
+```python
+import os
+from ...lib import geargen
+from .._gear_command import GearCommand
+
+command = GearCommand(
+    gear_type='SpurGear',     # CMD_ID becomes f'{COMPANY_NAME}_{ADDIN_NAME}_{gear_type}_cmdDialog'
+    name='Spur Gear Generator',
+    description='Generates a Spur Gear',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.SpurGearCommandInputsConfigurator,
+    generator_class=geargen.SpurGearGenerator,
+    # optional: input_changed=<callback(args)> for dialogs with reactive inputs
+    # (e.g. bevel passes its configurator's handle_input_changed to drive
+    # conditional visibility of the spiral-only inputs)
+)
+
+start = command.start
+stop = command.stop
+```
+
+New gears: add the entry directory (with `resources/`), then import and list it in
+`commands/__init__.py`.
 
 **[PB-AUTOFOCUS-FIRST] Dialog auto-focus ordering gotcha.** Fusion auto-focuses the FIRST `SelectionCommandInput` and
 ignores a later `hasFocus=True`; add the selection input that should own initial focus first (so the

--- a/Gear Generator.py
+++ b/Gear Generator.py
@@ -8,7 +8,7 @@ def run(context):
         # This will run the start function in each of your commands as defined in commands/__init__.py
         commands.start()
 
-    except:
+    except Exception:
         futil.handle_error('run')
 
 
@@ -20,5 +20,5 @@ def stop(context):
         # This will run the start function in each of your commands as defined in commands/__init__.py
         commands.stop()
 
-    except:
+    except Exception:
         futil.handle_error('stop')

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,14 +1,12 @@
 # Here you define the commands that will be added to your add-in.
-
-# TODO Import the modules corresponding to the commands you created.
-# If you want to add an additional command, duplicate one of the existing directories and import it here.
-# You need to use aliases (import "entry" as "my_module") assuming you have the default module named "entry".
+# To add a command: create a directory with an entry.py declaring a GearCommand
+# (see commands/_gear_command.py), import it here, and add it to the list.
+from . import _gear_command
 from .spurgear import entry as spurgear
 from .helicalgear import entry as helicalgear
 from .herringbonegear import entry as herringbonegear
 from .bevelgear import entry as bevelgear
 
-# TODO add your imported modules to this list.
 # Fusion will automatically call the start() and stop() functions.
 commands = [
     spurgear,
@@ -18,15 +16,14 @@ commands = [
 ]
 
 
-# Assumes you defined a "start" function in each of your modules.
-# The start function will be run when the add-in is started.
 def start():
     for command in commands:
         command.start()
 
 
-# Assumes you defined a "stop" function in each of your modules.
-# The stop function will be run when the add-in is stopped.
 def stop():
     for command in commands:
         command.stop()
+    # Each command removed its own control above; the shared Gears dropdown is
+    # owned by this package and deleted once here.
+    _gear_command.delete_dropdown()

--- a/commands/_gear_command.py
+++ b/commands/_gear_command.py
@@ -1,0 +1,111 @@
+# Shared implementation of a gear-generator command. Each commands/<gear>/entry.py
+# declares one GearCommand and re-exports its start/stop (see those modules).
+
+import adsk.core
+from ..lib import fusion360utils as futil
+from ..lib import geargen
+from .. import config
+
+ui = adsk.core.Application.get().userInterface
+
+
+def _panel():
+    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
+    return workspace.toolbarPanels.itemById(config.PANEL_ID)
+
+
+def get_or_create_dropdown():
+    panel = _panel()
+    dropdown = panel.controls.itemById(config.DROPDOWN_ID)
+    if not dropdown:
+        dropdown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
+    return dropdown
+
+
+def delete_dropdown():
+    # The dropdown is shared by all gear commands and owned by the commands
+    # package: deleted once, after every command has removed its own control
+    # (see commands/__init__.py stop()).
+    dropdown = _panel().controls.itemById(config.DROPDOWN_ID)
+    if dropdown:
+        dropdown.deleteMe()
+
+
+class GearCommand:
+    def __init__(self, *, gear_type, name, description, icon_folder,
+                 configurator, generator_class, input_changed=None):
+        self.cmd_id = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{gear_type}_cmdDialog'
+        self.name = name
+        self.description = description
+        self.icon_folder = icon_folder
+        self.configurator = configurator
+        self.generator_class = generator_class
+        self.input_changed = input_changed
+        # Keeps references to the per-dialog handlers so they are not garbage
+        # collected while the dialog is open.
+        self.local_handlers = []
+
+    # Executed when the add-in is run.
+    def start(self):
+        cmd_def = ui.commandDefinitions.itemById(self.cmd_id)
+        if not cmd_def:
+            cmd_def = ui.commandDefinitions.addButtonDefinition(
+                self.cmd_id, self.name, self.description, self.icon_folder)
+
+        futil.add_handler(cmd_def.commandCreated, self.command_created)
+
+        dropdown = get_or_create_dropdown()
+        if not dropdown.controls.itemById(self.cmd_id):
+            dropdown.controls.addCommand(cmd_def, '', False)
+
+    # Executed when the add-in is stopped. Removes only this command's control
+    # and definition; the shared dropdown is deleted by the commands package.
+    def stop(self):
+        dropdown = _panel().controls.itemById(config.DROPDOWN_ID)
+        if dropdown:
+            control = dropdown.controls.itemById(self.cmd_id)
+            if control:
+                control.deleteMe()
+
+        cmd_def = ui.commandDefinitions.itemById(self.cmd_id)
+        if cmd_def:
+            cmd_def.deleteMe()
+
+    # Called when the user clicks the command's button: builds the dialog
+    # inputs and connects the command events.
+    def command_created(self, args: adsk.core.CommandCreatedEventArgs):
+        futil.log(f'{self.name} Command Created Event')
+
+        self.configurator.configure(args.command)
+
+        futil.add_handler(args.command.execute, self.command_execute,
+                          local_handlers=self.local_handlers)
+        futil.add_handler(args.command.inputChanged, self.command_input_changed,
+                          local_handlers=self.local_handlers)
+        futil.add_handler(args.command.validateInputs, self.command_validate_input,
+                          local_handlers=self.local_handlers)
+        futil.add_handler(args.command.destroy, self.command_destroy,
+                          local_handlers=self.local_handlers)
+
+    def command_execute(self, args: adsk.core.CommandEventArgs):
+        futil.log(f'{self.name} Command Execute Event')
+        g = None
+        try:
+            g = self.generator_class(geargen.get_design())
+            g.generate(args.command.commandInputs)
+        except Exception:
+            futil.handle_error('Generation error', show_message_box=True)
+            if g:
+                g.deleteComponent()
+
+    def command_input_changed(self, args: adsk.core.InputChangedEventArgs):
+        futil.log(f'{self.name} Input Changed Event fired from a change to {args.input.id}')
+        if self.input_changed:
+            self.input_changed(args)
+
+    def command_validate_input(self, args: adsk.core.ValidateInputsEventArgs):
+        args.areInputsValid = True
+
+    def command_destroy(self, args: adsk.core.CommandEventArgs):
+        futil.log(f'{self.name} Command Destroy Event')
+        self.local_handlers = []

--- a/commands/bevelgear/entry.py
+++ b/commands/bevelgear/entry.py
@@ -1,94 +1,17 @@
-import adsk.core
 import os
-from ...lib import fusion360utils as futil
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
-GEAR_TYPE = 'BevelGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Bevel Gear Generator'
-CMD_Description = 'Bevel Gear Generator'
+command = GearCommand(
+    gear_type='BevelGear',
+    name='Bevel Gear Generator',
+    description='Bevel Gear Generator',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.BevelGearCommandInputsConfigurator,
+    generator_class=geargen.BevelGearGenerator,
+    # Drives conditional visibility of the spiral-only inputs (shown only when ψ > 0).
+    input_changed=geargen.BevelGearCommandInputsConfigurator.handle_input_changed,
+)
 
-IS_PROMOTED = True
-
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-local_handlers = []
-
-
-def start():
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-
-def stop():
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    if command_definition:
-        command_definition.deleteMe()
-
-
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.BevelGearCommandInputsConfigurator.configure(args.command)
-
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-def command_execute(args: adsk.core.CommandEventArgs):
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.BevelGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-
-def command_preview(args: adsk.core.CommandEventArgs):
-    pass
-
-
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    # Drive conditional visibility of the spiral-only inputs (shown only when ψ > 0).
-    geargen.BevelGearCommandInputsConfigurator.handle_input_changed(args)
-
-
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    args.areInputsValid = True
-
-
-def command_destroy(args: adsk.core.CommandEventArgs):
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/commands/helicalgear/entry.py
+++ b/commands/helicalgear/entry.py
@@ -1,130 +1,15 @@
-import adsk.core
-import os, math
-from ...lib import fusion360utils as futil
+import os
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
-GEAR_TYPE='HelicalGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Helical Gear Generator'
-CMD_Description = 'Helical Gear Generator'
+command = GearCommand(
+    gear_type='HelicalGear',
+    name='Helical Gear Generator',
+    description='Helical Gear Generator',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.HelicalGearCommandConfigurator,
+    generator_class=geargen.HelicalGearGenerator,
+)
 
-# Specify that the command will be promoted to the panel.
-IS_PROMOTED = True
-
-# Resource location for command icons, here we assume a sub folder in this directory named "resources".
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-# Local list of event handlers used to maintain a reference so
-# they are not released and garbage collected.
-local_handlers = []
-
-
-# Executed when add-in is run.
-def start():
-    # Create a command Definition.
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    # Define an event handler for the command created event. It will be called when the button is clicked.
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    # Get the target workspace the button will be created in.
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-
-    # Get the panel the button will be created in.
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-        # Create the button command control in the UI after the specified existing command.
-    
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-# Executed when add-in is stopped.
-def stop():
-    # Get the various UI elements for this command
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    # Delete the command definition
-    if command_definition:
-        command_definition.deleteMe()
-
-
-
-# Function that is called when a user clicks the corresponding button in the UI.
-# This defines the contents of the command dialog and connects to the command related events.
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.HelicalGearCommandConfigurator.configure(args.command)
-
-    # TODO Connect to the events that are needed by this command.
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-# This event handler is called when the user clicks the OK button in the command dialog or 
-# is immediately called after the created event not command inputs were created for the dialog.
-def command_execute(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.HelicalGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-# This event handler is called when the command needs to compute a new preview in the graphics window.
-def command_preview(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Preview Event')
-    inputs = args.command.commandInputs
-
-
-# This event handler is called when the user changes anything in the command dialog
-# allowing you to modify values of other inputs based on that change.
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    changed_input = args.input
-    inputs = args.inputs
-
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Input Changed Event fired from a change to {changed_input.id}')
-
-
-# This event handler is called when the user interacts with any of the inputs in the dialog
-# which allows you to verify that all of the inputs are valid and enables the OK button.
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Validate Input Event')
-
-    args.areInputsValid = True
-
-# This event handler is called when the command terminates.
-def command_destroy(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Destroy Event')
-
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/commands/herringbonegear/entry.py
+++ b/commands/herringbonegear/entry.py
@@ -1,133 +1,15 @@
-import adsk.core
-import os, math
-from ...lib import fusion360utils as futil
+import os
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
+command = GearCommand(
+    gear_type='HerringboneGear',
+    name='Herringbone Gear Generator',
+    description='Herringbone Gear Generator',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.HerringboneGearCommandConfigurator,
+    generator_class=geargen.HerringboneGearGenerator,
+)
 
-# TODO *** Specify the command identity information. ***
-GEAR_TYPE='HerringboneGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Herringbone Gear Generator'
-CMD_Description = 'Herringbone Gear Generator'
-
-# Specify that the command will be promoted to the panel.
-IS_PROMOTED = True
-
-# Resource location for command icons, here we assume a sub folder in this directory named "resources".
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-# Local list of event handlers used to maintain a reference so
-# they are not released and garbage collected.
-local_handlers = []
-
-
-# Executed when add-in is run.
-def start():
-    # Create a command Definition.
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    # Define an event handler for the command created event. It will be called when the button is clicked.
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    # Get the target workspace the button will be created in.
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-
-    # Get the panel the button will be created in.
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-        # Create the button command control in the UI after the specified existing command.
-    
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-# Executed when add-in is stopped.
-def stop():
-    # Get the various UI elements for this command
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    # Delete the command definition
-    if command_definition:
-        command_definition.deleteMe()
-
-
-
-# Function that is called when a user clicks the corresponding button in the UI.
-# This defines the contents of the command dialog and connects to the command related events.
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.HerringboneGearCommandConfigurator.configure(args.command)
-
-    # TODO Connect to the events that are needed by this command.
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-# This event handler is called when the user clicks the OK button in the command dialog or 
-# is immediately called after the created event not command inputs were created for the dialog.
-def command_execute(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.HerringboneGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-
-# This event handler is called when the command needs to compute a new preview in the graphics window.
-def command_preview(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Preview Event')
-    inputs = args.command.commandInputs
-
-
-# This event handler is called when the user changes anything in the command dialog
-# allowing you to modify values of other inputs based on that change.
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    changed_input = args.input
-    inputs = args.inputs
-
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Input Changed Event fired from a change to {changed_input.id}')
-
-
-# This event handler is called when the user interacts with any of the inputs in the dialog
-# which allows you to verify that all of the inputs are valid and enables the OK button.
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Validate Input Event')
-
-    args.areInputsValid = True
-
-# This event handler is called when the command terminates.
-def command_destroy(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Destroy Event')
-
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/commands/spurgear/entry.py
+++ b/commands/spurgear/entry.py
@@ -1,129 +1,15 @@
-import adsk.core
-import os, math
-from ...lib import fusion360utils as futil
+import os
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
-# TODO *** Specify the command identity information. ***
-GEAR_TYPE='SpurGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Spur Gear Generator'
-CMD_Description = 'Generates a Spur Gear'
+command = GearCommand(
+    gear_type='SpurGear',
+    name='Spur Gear Generator',
+    description='Generates a Spur Gear',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.SpurGearCommandInputsConfigurator,
+    generator_class=geargen.SpurGearGenerator,
+)
 
-# Specify that the command will be promoted to the panel.
-IS_PROMOTED = True
-
-# Resource location for command icons, here we assume a sub folder in this directory named "resources".
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-# Local list of event handlers used to maintain a reference so
-# they are not released and garbage collected.
-local_handlers = []
-
-
-# Executed when add-in is run.
-def start():
-    # Create a command Definition.
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    # Define an event handler for the command created event. It will be called when the button is clicked.
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    # Get the target workspace the button will be created in.
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-
-    # Get the panel the button will be created in.
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-        # Create the button command control in the UI after the specified existing command.
-    
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-# Executed when add-in is stopped.
-def stop():
-    # Get the various UI elements for this command
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    # Delete the command definition
-    if command_definition:
-        command_definition.deleteMe()
-
-
-# Function that is called when a user clicks the corresponding button in the UI.
-# This defines the contents of the command dialog and connects to the command related events.
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.SpurGearCommandInputsConfigurator.configure(args.command)
-
-    # TODO Connect to the events that are needed by this command.
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-# This event handler is called when the user clicks the OK button in the command dialog or 
-# is immediately called after the created event not command inputs were created for the dialog.
-def command_execute(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.SpurGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-
-# This event handler is called when the command needs to compute a new preview in the graphics window.
-def command_preview(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Preview Event')
-
-
-# This event handler is called when the user changes anything in the command dialog
-# allowing you to modify values of other inputs based on that change.
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    futil.log(f'{CMD_NAME} Command Input Changed')
-    changed_input = args.input
-
-
-# This event handler is called when the user interacts with any of the inputs in the dialog
-# which allows you to verify that all of the inputs are valid and enables the OK button.
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Validate Input Event')
-
-    args.areInputsValid = True
-    
-
-
-# This event handler is called when the command terminates.
-def command_destroy(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Destroy Event')
-
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/config.py
+++ b/config.py
@@ -31,10 +31,4 @@ COMPANY_NAME = 'endeworks'
 
 WORKSPACE_ID = 'FusionSolidEnvironment'
 PANEL_ID = 'SolidScriptsAddinsPanel' if LOCATE_MENU_IN_ADDIN else 'SolidCreatePanel'
-COMMAND_BESIDE_ID = 'ScriptsManagerCommand'
 DROPDOWN_ID = 'GearGeneratorDropDown'
-
-
-
-# Palettes
-sample_palette_id = f'{COMPANY_NAME}_{ADDIN_NAME}_palette_id'

--- a/lib/geargen/base.py
+++ b/lib/geargen/base.py
@@ -87,7 +87,6 @@ class Generator(ABC):
     def __init__(self, design: adsk.fusion.Design):
         self.design = design
         self.parentComponent = None # TODO: nothing is protecting this from being used when value is None
-        self.component = adsk.fusion.Component.cast(None)
         self.occurrence = adsk.fusion.Occurrence.cast(None)
         self.prefix = None
         self.cleaner = None
@@ -135,9 +134,14 @@ class Generator(ABC):
         return self.prefix.name(name)
 
     def deleteComponent(self):
-        if self.occurrence:
+        if self.cleaner:
+            # Deletes the registered user parameters AND the occurrence.
+            self.cleaner.deleteAll()
+        elif self.occurrence:
             self.occurrence.deleteMe()
-            self.component = None
+        self.occurrence = None
+        self.cleaner = None
+        self.prefix = None
 
     @abstractmethod
     def generate(self, inputs: adsk.core.CommandInputs):

--- a/lib/geargen/helicalgear.py
+++ b/lib/geargen/helicalgear.py
@@ -1,3 +1,5 @@
+import math
+import adsk.core, adsk.fusion
 from .spurgear import *
 from .misc import *
 
@@ -31,7 +33,7 @@ class HelicalGearGenerator(SpurGearGenerator):
     def generateName(self):
         module = self.getParameter(PARAM_MODULE)
         toothNumber = self.getParameter(PARAM_TOOTH_NUMBER)
-        thickness = self.getParameter('Thickness')
+        thickness = self.getParameter(PARAM_THICKNESS)
         helixAngle = self.getParameter(PARAM_HELIX_ANGLE)
         return 'Helical Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(
             module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
@@ -49,7 +51,7 @@ class HelicalGearGenerator(SpurGearGenerator):
     # relative to the base plane. Herringbone halves this so the mirror plane
     # sits in the middle of the gear body.
     def helicalPlaneOffset(self) -> adsk.core.ValueInput:
-        return self.getParameterAsValueInput('Thickness')
+        return self.getParameterAsValueInput(PARAM_THICKNESS)
 
     def chamferWantEdges(self):
         return 4

--- a/lib/geargen/herringbonegear.py
+++ b/lib/geargen/herringbonegear.py
@@ -1,10 +1,9 @@
+import adsk.core, adsk.fusion
 from .helicalgear import *
 
 class HerringboneGearCommandConfigurator(HelicalGearCommandConfigurator): pass
 
-class HerringboneGearGenerationContext(HelicalGearGenerationContext):
-    def __init__(self):
-        super().__init__()
+class HerringboneGearGenerationContext(HelicalGearGenerationContext): pass
 
 class HerringboneGearGenerator(HelicalGearGenerator):
     def newContext(self):
@@ -16,7 +15,7 @@ class HerringboneGearGenerator(HelicalGearGenerator):
     def generateName(self):
         module = self.getParameter(PARAM_MODULE)
         toothNumber = self.getParameter(PARAM_TOOTH_NUMBER)
-        thickness = self.getParameter('Thickness')
+        thickness = self.getParameter(PARAM_THICKNESS)
         helixAngle = self.getParameter(PARAM_HELIX_ANGLE)
         return 'Herringbone Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(
             module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
@@ -24,7 +23,7 @@ class HerringboneGearGenerator(HelicalGearGenerator):
     # The mirror plane sits in the middle of the body, so the loft only covers
     # half the thickness.
     def helicalPlaneOffset(self) -> adsk.core.ValueInput:
-        thickness = self.getParameter('Thickness').value
+        thickness = self.getParameter(PARAM_THICKNESS).value
         return adsk.core.ValueInput.createByReal(thickness / 2)
 
     def buildTooth(self, ctx: GenerationContext):

--- a/lib/geargen/misc.py
+++ b/lib/geargen/misc.py
@@ -1,4 +1,3 @@
-import math
 import adsk.core
 
 def to_cm(mm):
@@ -6,12 +5,6 @@ def to_cm(mm):
 
 def to_mm(cm):
     return cm*10
-
-def get_ui(app=adsk.core.Application.get()):
-    ui = app.userInterface
-    if not ui:
-        raise Exception('No UI object available. Please run this script from within Fusion 360')
-    return ui
 
 def get_design(app=adsk.core.Application.get()):
     des = adsk.fusion.Design.cast(app.activeProduct)


### PR DESCRIPTION
- collapse the four near-identical `commands/*/entry.py` into a shared `GearCommand` (`commands/_gear_command.py`); each entry is now a 5-line declaration
- fix dropdown ownership: each command's `stop()` removes only its own control; the shared Gears dropdown is deleted once by `commands/__init__.py`
- `Generator.deleteComponent()` now runs `ComponentCleaner.deleteAll()`, so a failed generation no longer leaks prefixed user parameters
- replace `'Thickness'` literals with `PARAM_THICKNESS` and add explicit `math`/`adsk` imports in helical/herringbone (previously transitive via star-imports)
- drop dead code (`get_ui`, `COMMAND_BESIDE_ID`, `sample_palette_id`, `IS_PROMOTED`, unused `Generator.component`) and narrow bare `except:` to `except Exception`
- update PLAYBOOK command-entry wiring + `deleteComponent` contract to match
