### PR TITLE
dedup gear commands, extract framework helpers

### DIFF
--- a/.claude/skills/generate-gear/PLAYBOOK.md
+++ b/.claude/skills/generate-gear/PLAYBOOK.md
@@ -21,7 +21,7 @@ Each gear lives in `lib/geargen/<gear>.py` and imports exactly:
 ```python
 import math
 from ...lib import fusion360utils as futil
-from .misc import *        # to_cm, to_mm, get_design, get_ui
+from .misc import *        # to_cm, to_mm, get_design
 from .base import *        # Generator, GenerationContext, get_value/get_boolean/get_selection, ParamNamePrefix, ComponentCleaner
 from .utilities import *   # get_normal
 ```
@@ -81,7 +81,8 @@ and the spec describes that). When inherited, `lib/geargen/base.py` provides:
 - `getParameter(name)`, `getParameterAsValueInput(name)`, `getParameterAsBoolean(name)`.
 - `parameterName(name)` → `f'{prefix}_{name}'` (creates the occurrence if needed).
 - `prefixBase()` → default `'Gear'`; override per gear (`'SpurGear'`, `'HelicalGear'`, …).
-- `deleteComponent()` — deletes the occurrence; used by the entry point on failure.
+- `deleteComponent()` — deletes the registered user parameters (via `ComponentCleaner`) and the
+  occurrence; used by the entry point on failure.
 - `createSketchObject(name, plane=None)` — adds a sketch (defaults to XY plane), names it, sets
   `isVisible=False`, returns it. (Note: a sketch created this way starts hidden; make it visible
   while you draw/consume profiles, per the spec's sketch-discipline rules.)
@@ -198,14 +199,38 @@ expected front-face edge count, etc.; the spec says what each returns for the de
 
 ## Command-entry wiring (`commands/<gear>/entry.py`)
 
-Standard Fusion add-in command module (mostly boilerplate; mirror the existing command modules):
-`GEAR_TYPE`/`CMD_ID`/`CMD_NAME`; `start()` registers the button + dropdown and the
-`commandCreated` handler; `command_created` calls
-`geargen.<Gear>CommandInputsConfigurator.configure(args.command)` and wires the
-execute/inputChanged/executePreview/validateInputs/destroy handlers via `futil.add_handler`;
-`command_execute` does `g = geargen.<Gear>Generator(design); g.generate(inputs)` inside
-`try/except` and calls `g.deleteComponent()` on failure (errors surfaced with
-`futil.handle_error("Generation error", show_message_box=True)`).
+The Fusion command boilerplate lives once in `commands/_gear_command.py` (`GearCommand`): it
+registers the button in the shared Gears dropdown, wires the
+execute/inputChanged/validateInputs/destroy handlers via `futil.add_handler`, runs
+`generator_class(get_design()).generate(inputs)` inside `try/except Exception` (failure →
+`futil.handle_error('Generation error', show_message_box=True)` + `g.deleteComponent()`), and on
+`stop()` removes only its own control — the shared dropdown is deleted once by
+`commands/__init__.py` after all commands stop. An entry module only declares its command and
+re-exports the lifecycle hooks:
+
+```python
+import os
+from ...lib import geargen
+from .._gear_command import GearCommand
+
+command = GearCommand(
+    gear_type='SpurGear',     # CMD_ID becomes f'{COMPANY_NAME}_{ADDIN_NAME}_{gear_type}_cmdDialog'
+    name='Spur Gear Generator',
+    description='Generates a Spur Gear',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.SpurGearCommandInputsConfigurator,
+    generator_class=geargen.SpurGearGenerator,
+    # optional: input_changed=<callback(args)> for dialogs with reactive inputs
+    # (e.g. bevel passes its configurator's handle_input_changed to drive
+    # conditional visibility of the spiral-only inputs)
+)
+
+start = command.start
+stop = command.stop
+```
+
+New gears: add the entry directory (with `resources/`), then import and list it in
+`commands/__init__.py`.
 
 **[PB-AUTOFOCUS-FIRST] Dialog auto-focus ordering gotcha.** Fusion auto-focuses the FIRST `SelectionCommandInput` and
 ignores a later `hasFocus=True`; add the selection input that should own initial focus first (so the

--- a/.claude/skills/generate-gear/PLAYBOOK.md
+++ b/.claude/skills/generate-gear/PLAYBOOK.md
@@ -16,18 +16,24 @@ that point of use. IDs are permanent — never renamed or reused once a spec cit
 
 ## Module layout & imports
 
-Each gear lives in `lib/geargen/<gear>.py` and imports exactly:
+Each gear lives in `lib/geargen/<gear>.py` and imports **explicitly — no `import *` in gear
+modules** (star-imports hide real dependencies and have broken modules that relied on a name
+arriving transitively). Import exactly the names the module uses, from their home modules:
 
 ```python
 import math
+import adsk.core, adsk.fusion
 from ...lib import fusion360utils as futil
-from .misc import *        # to_cm, to_mm, get_design
-from .base import *        # Generator, GenerationContext, get_value/get_boolean/get_selection, ParamNamePrefix, ComponentCleaner
-from .utilities import *   # get_normal
+from .misc import to_cm, to_mm, get_design
+from .base import Generator, GenerationContext, get_value, get_boolean, get_selection
+from .utilities import get_normal, find_profile_by_curve_counts, find_circle_by_radius
+from . import solids                     # body-op helpers — only gears that need them
+from .spurproxy import VirtualSpurProxy  # only gears that borrow the spur tooth drawer
 ```
 
-Some gears import `adsk.core, adsk.fusion` explicitly; others rely on the star-imports pulling
-`adsk` in transitively. Use the same import list as the existing gear modules.
+(Trim the list to what the gear actually uses; the last two lines apply only to gears whose spec
+calls for them. `lib/geargen/__init__.py` star-imports each gear module to build the package
+facade — that one facade star-import is fine; gear modules themselves never use `import *`.)
 
 Module-level constants name the recurring parameters and dialog input ids, e.g.
 `PARAM_MODULE = 'Module'`, `INPUT_ID_PARENT = 'parentComponent'`, `INPUT_ID_PLANE = 'plane'`,
@@ -88,42 +94,70 @@ and the spec describes that). When inherited, `lib/geargen/base.py` provides:
   while you draw/consume profiles, per the spec's sketch-discipline rules.)
 - `@abstractmethod generate(self, inputs)` — every gear implements this.
 
-Helpers (free functions in `base.py`): `get_selection(inputs, id)` → `(list_of_entities, ok)`;
-`get_boolean(inputs, id)` → `(value, ok)`; `get_value(inputs, id, units)` → `(value, ok)`.
+Helpers (free functions in `base.py`): `get_selection(inputs, id)` → list of selected entities;
+`get_boolean(inputs, id)` → bool; `get_value(inputs, id, units)` → `ValueInput` (raises on an
+invalid expression).
 
-**[PB-GET-VALUE-CONTRACT] `get_value` return contract — important, easy to get wrong.** It does NOT always return a
-`ValueInput`:
-- Numeric `ValueCommandInput`, valid expression → `(ValueInput.createByReal(evaluated), True)`.
-- Numeric input, invalid expression → `(None, False)`.
-- `StringValueCommandInput` whose text **is** an existing user-parameter name →
-  `(ValueInput.createByString(text), True)`.
-- `StringValueCommandInput` holding a literal expression (e.g. a default like `'0 mm'`) →
-  `(evaluated_number, False)` — a **raw float, not a `ValueInput`, and `ok` is False**.
+**[PB-GET-VALUE-CONTRACT]** `get_value` ALWAYS returns a `ValueInput` ready to pass straight to
+`addParameter` / `userParameters.add` — string-value (expression) inputs included: a text that
+names an existing user parameter becomes a live `createByString` reference; a literal expression
+(e.g. `'5 mm'`) is evaluated to internal units and wrapped `createByReal`; numeric inputs are
+evaluated and wrapped `createByReal`. It **raises** on an invalid expression rather than returning
+`None`. No caller-side `ok`-flag handling or `ValueInput` wrapping is needed — `addParameter` the
+result directly.
 
-`addParameter(name, value, units, comment)` calls `userParameters.add(...)`, whose value
-argument **must be a `ValueInput`** — passing the raw float raises
-`TypeError: ... argument 3 of type 'adsk::core::Ptr< adsk::core::ValueInput >'`. So whenever
-`get_value` can return `ok=False` (i.e. any `addStringValueInput` field), the caller must wrap
-the returned value in a `ValueInput` before `addParameter`. **Wrap the evaluated number
-`get_value` handed back — do not discard it to 0.** That returned float is already in Fusion's
-internal units (cm), which is exactly what `ValueInput.createByReal` expects, so wrapping it
-preserves the user's value; a literal like `'5 mm'` then actually takes effect. (Discarding it to
-`createByReal(0)` silently throws the user's value away — e.g. a typed bore diameter that then
-never cuts a hole.)
+## Shared geargen helper library (use, do not re-implement)
 
-```python
-# For any addStringValueInput field <FIELD>:
-(value, ok) = get_value(inputs, INPUT_ID_<FIELD>, 'mm')
-if not ok:
-    # get_value returned the evaluated value as a raw number (internal cm).
-    # Wrap THAT — wrapping 0 would silently ignore a typed value.
-    value = adsk.core.ValueInput.createByReal(
-        value if isinstance(value, (int, float)) else 0)
-self.addParameter(PARAM_<FIELD>, value, 'mm', '…')
-```
+The framework carries a small library of **proven** helpers; each encodes a known Fusion failure
+mode that took real debugging to pin down. A generated gear **MUST call these instead of
+re-implementing the pattern** — re-defining one of these names (or writing a private equivalent of
+one) in a generated module is a contract violation the validation step checks for. The gear's spec
+says *which* helpers it uses and *on what geometry*; the behavior below is the helper's contract.
 
-(Numeric inputs return `ok=True` with a `ValueInput`, so they don't need this wrap; only the
-string-value inputs do.)
+**`lib/geargen/utilities.py`:**
+- `find_profile_by_curve_counts(sketch, nurbs=0, arcs=0, lines=0)` → the profile whose loop has
+  exactly those curve-type counts and no other curve types ([PB-PROFILE-MATCH]); raises (never
+  falls back to a wrong profile) with a self-diagnosing message.
+- `find_circle_by_radius(sketch, radius, tolerance=0.0001)` → the sketch circle matching the
+  radius (cm); raises on no match.
+- `get_normal(entity)` → world normal of a `BRepFace` / `ConstructionPlane` / `Plane` / `Sketch`.
+
+**`lib/geargen/solids.py`** (body operations; all take the owning component first):
+- `cut_conical_ends(component, toothBody, gearBody, toeMid, heelMid, apexWorld, label)` → the
+  toe-then-heel two-cone flush trim. Toe cut is strict (failure raises); a heel cone that does not
+  intersect the keeper is caught (typed `NonIntersectError`) and the keeper is returned intact.
+  Exactly two split features per gear, every gear ratio.
+- `apply_conical_cut(component, targetBody, frustumBody, edgeMidWorld, apexWorld, label)` → one
+  conical cut: candidate `ConeSurfaceType` faces of `frustumBody` ordered best-first by the cut
+  edge's world-MIDPOINT distance ([PB-FACE-BY-MIDPOINT]), each tried as the split tool
+  (`isSplittingToolExtended=True`), first that splits wins; keeper per `select_keeper`. When no
+  face splits: raises `NonIntersectError` if the per-face failures carried Fusion's
+  `SPLIT_TARGET_TOOL_NOT_INTERSECT` (or localized `交差`) signal, else `RuntimeError` — both with
+  the full per-face distance/error history ([PB-SELF-DIAGNOSING]).
+- `select_keeper(component, pieces, apexWorld, label)` → drops apex-containing pieces, keeps the
+  largest remaining, removes the rest ([PB-REMOVE-PIECES]); raises when nothing remains.
+- `find_cone_faces_by_midpoint(frustumBody, edgeMidWorld)` / `surface_distance(surface, point)` —
+  the face-candidate ordering primitives (unevaluable distance → `inf`, "try last").
+- `slice_body_by_offset_planes(component, body, basePlane, offsets)` → splits piece-by-piece with
+  planes offset by each value (cm); a plane that misses a piece leaves it whole. The caller picks
+  the offsets/signs and asserts the resulting piece count ([PB-EMPTY-RESULT]).
+- `rotate_body_about_edge(component, body, edge, angleRad)` — rotation about a sketch edge's world
+  endpoints via free-move matrix ([PB-MOVE-ROTATE]).
+- `plane_by_angle(component, line, refPlane, angleDeg)` — `setByAngle` construction plane through
+  a sketch line (passed directly, never via `Path.create` — [PB-CONSTRUCTION-PLANES]).
+- `combine_point(base, a, e1, b=0.0, e2=None)` → world `Point3D` = base + a·e1 (+ b·e2), cm.
+- `circle_intersect_nearest(R, Cx, Cy, r_c, refX, refY)` → the 2-D circle∩circle intersection
+  nearest the reference point (non-overlap clamps to tangency).
+- `hide_construction_geometry(component)` — recursive light-bulb-off walk over every sketch /
+  construction plane / axis in the tree, deduped by `entityToken` ([PB-TREE-CLEANUP]).
+
+**`lib/geargen/spurproxy.py`:**
+- `VirtualSpurProxy(module_mm, virtualTeeth, pressureAngleRad=radians(20), involuteSteps=15)` — a
+  fake spur `parent` for `SpurGearInvoluteToothDesignGenerator` ([PB-PRECOMPUTED-MODE]): serves,
+  in internal cm, exactly the parameter keys the spur drawer reads (`Module`, `ToothNumber`,
+  `PressureAngle`, the Pitch/Base/Root/Tip circle diameters+radii, `InvoluteSteps`), each wrapped
+  in a `.value` carrier (`Val`). Carries the `_lastToothEmbedded` output slot the drawer writes
+  during `draw()` — the borrowing gear reads it back afterward.
 
 ## `processInputs` pattern
 
@@ -427,7 +461,10 @@ ignores a later `hasFocus=True`; add the selection input that should own initial
 
 The involute gears only extrude + pattern + combine + chamfer + fillet. Gears whose spec calls for
 revolved bodies, lofted teeth, or split-by-face shaping (bevel) use these additional features. The
-spec says *which* to use and *on what geometry*; this pins the *API shape*.
+spec says *which* to use and *on what geometry*; this pins the *API shape*. Several of these
+patterns are implemented once in `lib/geargen/solids.py` (see "Shared geargen helper library") —
+when a helper exists, call it instead of re-implementing the pattern; the anchors below remain the
+authoritative description of the behavior the helpers encode.
 
 - **[PB-REVOLVE] Revolve** (`component.features.revolveFeatures`): `createInput(profile, axis, operation)` →
   `setAngleExtent(False, ValueInput.createByString('360 deg'))` → `add(input)`. The `axis` is a

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -97,6 +97,12 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
      surface those dependents bind to (by name) exists unchanged.
    - **Dependency resolution:** every name the generated file imports from another gear or
      framework module actually exists in that module.
+   - **Helper-shadowing check:** the generated file must not re-define (via `def` or `class`) any
+     name the framework helper library provides (PLAYBOOK "Shared geargen helper library":
+     `find_profile_by_curve_counts`, `find_circle_by_radius`, the `solids.*` functions,
+     `VirtualSpurProxy`/`Val`), nor carry a private re-implementation of one. A shadow or
+     re-implementation means the spec/playbook failed to direct the generator to the helper — fix
+     there and regenerate.
 
 5. **Iterate.** A parse error, a missing contract item, or an unresolved dependency means the
    **spec or playbook** is incomplete or wrong — fix it there (never hand-edit the generated file,
@@ -200,7 +206,8 @@ the spec.
 > - `.claude/skills/generate-gear/PLAYBOOK.md` — shared framework conventions and Fusion-API rules.
 > - Every document the spec references by name (e.g. a geometry-derivation `.md`).
 > - The framework files the output builds on: `lib/geargen/base.py`, `lib/geargen/misc.py`,
->   `lib/geargen/utilities.py`, and `lib/fusion360utils/`.
+>   `lib/geargen/utilities.py`, `lib/geargen/solids.py`, `lib/geargen/spurproxy.py`, and
+>   `lib/fusion360utils/`.
 > - Every gear/module the spec's **Dependencies** section declares (read the exact surface bevel/…
 >   borrows: class names, constructor/`draw` signatures, and any attribute it reads or writes).
 >

--- a/Gear Generator.py
+++ b/Gear Generator.py
@@ -8,7 +8,7 @@ def run(context):
         # This will run the start function in each of your commands as defined in commands/__init__.py
         commands.start()
 
-    except:
+    except Exception:
         futil.handle_error('run')
 
 
@@ -20,5 +20,5 @@ def stop(context):
         # This will run the start function in each of your commands as defined in commands/__init__.py
         commands.stop()
 
-    except:
+    except Exception:
         futil.handle_error('stop')

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,14 +1,12 @@
 # Here you define the commands that will be added to your add-in.
-
-# TODO Import the modules corresponding to the commands you created.
-# If you want to add an additional command, duplicate one of the existing directories and import it here.
-# You need to use aliases (import "entry" as "my_module") assuming you have the default module named "entry".
+# To add a command: create a directory with an entry.py declaring a GearCommand
+# (see commands/_gear_command.py), import it here, and add it to the list.
+from . import _gear_command
 from .spurgear import entry as spurgear
 from .helicalgear import entry as helicalgear
 from .herringbonegear import entry as herringbonegear
 from .bevelgear import entry as bevelgear
 
-# TODO add your imported modules to this list.
 # Fusion will automatically call the start() and stop() functions.
 commands = [
     spurgear,
@@ -18,15 +16,14 @@ commands = [
 ]
 
 
-# Assumes you defined a "start" function in each of your modules.
-# The start function will be run when the add-in is started.
 def start():
     for command in commands:
         command.start()
 
 
-# Assumes you defined a "stop" function in each of your modules.
-# The stop function will be run when the add-in is stopped.
 def stop():
     for command in commands:
         command.stop()
+    # Each command removed its own control above; the shared Gears dropdown is
+    # owned by this package and deleted once here.
+    _gear_command.delete_dropdown()

--- a/commands/_gear_command.py
+++ b/commands/_gear_command.py
@@ -1,0 +1,111 @@
+# Shared implementation of a gear-generator command. Each commands/<gear>/entry.py
+# declares one GearCommand and re-exports its start/stop (see those modules).
+
+import adsk.core
+from ..lib import fusion360utils as futil
+from ..lib import geargen
+from .. import config
+
+ui = adsk.core.Application.get().userInterface
+
+
+def _panel():
+    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
+    return workspace.toolbarPanels.itemById(config.PANEL_ID)
+
+
+def get_or_create_dropdown():
+    panel = _panel()
+    dropdown = panel.controls.itemById(config.DROPDOWN_ID)
+    if not dropdown:
+        dropdown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
+    return dropdown
+
+
+def delete_dropdown():
+    # The dropdown is shared by all gear commands and owned by the commands
+    # package: deleted once, after every command has removed its own control
+    # (see commands/__init__.py stop()).
+    dropdown = _panel().controls.itemById(config.DROPDOWN_ID)
+    if dropdown:
+        dropdown.deleteMe()
+
+
+class GearCommand:
+    def __init__(self, *, gear_type, name, description, icon_folder,
+                 configurator, generator_class, input_changed=None):
+        self.cmd_id = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{gear_type}_cmdDialog'
+        self.name = name
+        self.description = description
+        self.icon_folder = icon_folder
+        self.configurator = configurator
+        self.generator_class = generator_class
+        self.input_changed = input_changed
+        # Keeps references to the per-dialog handlers so they are not garbage
+        # collected while the dialog is open.
+        self.local_handlers = []
+
+    # Executed when the add-in is run.
+    def start(self):
+        cmd_def = ui.commandDefinitions.itemById(self.cmd_id)
+        if not cmd_def:
+            cmd_def = ui.commandDefinitions.addButtonDefinition(
+                self.cmd_id, self.name, self.description, self.icon_folder)
+
+        futil.add_handler(cmd_def.commandCreated, self.command_created)
+
+        dropdown = get_or_create_dropdown()
+        if not dropdown.controls.itemById(self.cmd_id):
+            dropdown.controls.addCommand(cmd_def, '', False)
+
+    # Executed when the add-in is stopped. Removes only this command's control
+    # and definition; the shared dropdown is deleted by the commands package.
+    def stop(self):
+        dropdown = _panel().controls.itemById(config.DROPDOWN_ID)
+        if dropdown:
+            control = dropdown.controls.itemById(self.cmd_id)
+            if control:
+                control.deleteMe()
+
+        cmd_def = ui.commandDefinitions.itemById(self.cmd_id)
+        if cmd_def:
+            cmd_def.deleteMe()
+
+    # Called when the user clicks the command's button: builds the dialog
+    # inputs and connects the command events.
+    def command_created(self, args: adsk.core.CommandCreatedEventArgs):
+        futil.log(f'{self.name} Command Created Event')
+
+        self.configurator.configure(args.command)
+
+        futil.add_handler(args.command.execute, self.command_execute,
+                          local_handlers=self.local_handlers)
+        futil.add_handler(args.command.inputChanged, self.command_input_changed,
+                          local_handlers=self.local_handlers)
+        futil.add_handler(args.command.validateInputs, self.command_validate_input,
+                          local_handlers=self.local_handlers)
+        futil.add_handler(args.command.destroy, self.command_destroy,
+                          local_handlers=self.local_handlers)
+
+    def command_execute(self, args: adsk.core.CommandEventArgs):
+        futil.log(f'{self.name} Command Execute Event')
+        g = None
+        try:
+            g = self.generator_class(geargen.get_design())
+            g.generate(args.command.commandInputs)
+        except Exception:
+            futil.handle_error('Generation error', show_message_box=True)
+            if g:
+                g.deleteComponent()
+
+    def command_input_changed(self, args: adsk.core.InputChangedEventArgs):
+        futil.log(f'{self.name} Input Changed Event fired from a change to {args.input.id}')
+        if self.input_changed:
+            self.input_changed(args)
+
+    def command_validate_input(self, args: adsk.core.ValidateInputsEventArgs):
+        args.areInputsValid = True
+
+    def command_destroy(self, args: adsk.core.CommandEventArgs):
+        futil.log(f'{self.name} Command Destroy Event')
+        self.local_handlers = []

--- a/commands/bevelgear/entry.py
+++ b/commands/bevelgear/entry.py
@@ -1,94 +1,17 @@
-import adsk.core
 import os
-from ...lib import fusion360utils as futil
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
-GEAR_TYPE = 'BevelGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Bevel Gear Generator'
-CMD_Description = 'Bevel Gear Generator'
+command = GearCommand(
+    gear_type='BevelGear',
+    name='Bevel Gear Generator',
+    description='Bevel Gear Generator',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.BevelGearCommandInputsConfigurator,
+    generator_class=geargen.BevelGearGenerator,
+    # Drives conditional visibility of the spiral-only inputs (shown only when ψ > 0).
+    input_changed=geargen.BevelGearCommandInputsConfigurator.handle_input_changed,
+)
 
-IS_PROMOTED = True
-
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-local_handlers = []
-
-
-def start():
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-
-def stop():
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    if command_definition:
-        command_definition.deleteMe()
-
-
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.BevelGearCommandInputsConfigurator.configure(args.command)
-
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-def command_execute(args: adsk.core.CommandEventArgs):
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.BevelGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-
-def command_preview(args: adsk.core.CommandEventArgs):
-    pass
-
-
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    # Drive conditional visibility of the spiral-only inputs (shown only when ψ > 0).
-    geargen.BevelGearCommandInputsConfigurator.handle_input_changed(args)
-
-
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    args.areInputsValid = True
-
-
-def command_destroy(args: adsk.core.CommandEventArgs):
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/commands/helicalgear/entry.py
+++ b/commands/helicalgear/entry.py
@@ -1,130 +1,15 @@
-import adsk.core
-import os, math
-from ...lib import fusion360utils as futil
+import os
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
-GEAR_TYPE='HelicalGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Helical Gear Generator'
-CMD_Description = 'Helical Gear Generator'
+command = GearCommand(
+    gear_type='HelicalGear',
+    name='Helical Gear Generator',
+    description='Helical Gear Generator',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.HelicalGearCommandConfigurator,
+    generator_class=geargen.HelicalGearGenerator,
+)
 
-# Specify that the command will be promoted to the panel.
-IS_PROMOTED = True
-
-# Resource location for command icons, here we assume a sub folder in this directory named "resources".
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-# Local list of event handlers used to maintain a reference so
-# they are not released and garbage collected.
-local_handlers = []
-
-
-# Executed when add-in is run.
-def start():
-    # Create a command Definition.
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    # Define an event handler for the command created event. It will be called when the button is clicked.
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    # Get the target workspace the button will be created in.
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-
-    # Get the panel the button will be created in.
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-        # Create the button command control in the UI after the specified existing command.
-    
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-# Executed when add-in is stopped.
-def stop():
-    # Get the various UI elements for this command
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    # Delete the command definition
-    if command_definition:
-        command_definition.deleteMe()
-
-
-
-# Function that is called when a user clicks the corresponding button in the UI.
-# This defines the contents of the command dialog and connects to the command related events.
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.HelicalGearCommandConfigurator.configure(args.command)
-
-    # TODO Connect to the events that are needed by this command.
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-# This event handler is called when the user clicks the OK button in the command dialog or 
-# is immediately called after the created event not command inputs were created for the dialog.
-def command_execute(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.HelicalGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-# This event handler is called when the command needs to compute a new preview in the graphics window.
-def command_preview(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Preview Event')
-    inputs = args.command.commandInputs
-
-
-# This event handler is called when the user changes anything in the command dialog
-# allowing you to modify values of other inputs based on that change.
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    changed_input = args.input
-    inputs = args.inputs
-
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Input Changed Event fired from a change to {changed_input.id}')
-
-
-# This event handler is called when the user interacts with any of the inputs in the dialog
-# which allows you to verify that all of the inputs are valid and enables the OK button.
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Validate Input Event')
-
-    args.areInputsValid = True
-
-# This event handler is called when the command terminates.
-def command_destroy(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Destroy Event')
-
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/commands/herringbonegear/entry.py
+++ b/commands/herringbonegear/entry.py
@@ -1,133 +1,15 @@
-import adsk.core
-import os, math
-from ...lib import fusion360utils as futil
+import os
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
+command = GearCommand(
+    gear_type='HerringboneGear',
+    name='Herringbone Gear Generator',
+    description='Herringbone Gear Generator',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.HerringboneGearCommandConfigurator,
+    generator_class=geargen.HerringboneGearGenerator,
+)
 
-# TODO *** Specify the command identity information. ***
-GEAR_TYPE='HerringboneGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Herringbone Gear Generator'
-CMD_Description = 'Herringbone Gear Generator'
-
-# Specify that the command will be promoted to the panel.
-IS_PROMOTED = True
-
-# Resource location for command icons, here we assume a sub folder in this directory named "resources".
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-# Local list of event handlers used to maintain a reference so
-# they are not released and garbage collected.
-local_handlers = []
-
-
-# Executed when add-in is run.
-def start():
-    # Create a command Definition.
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    # Define an event handler for the command created event. It will be called when the button is clicked.
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    # Get the target workspace the button will be created in.
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-
-    # Get the panel the button will be created in.
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-        # Create the button command control in the UI after the specified existing command.
-    
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-# Executed when add-in is stopped.
-def stop():
-    # Get the various UI elements for this command
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    # Delete the command definition
-    if command_definition:
-        command_definition.deleteMe()
-
-
-
-# Function that is called when a user clicks the corresponding button in the UI.
-# This defines the contents of the command dialog and connects to the command related events.
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.HerringboneGearCommandConfigurator.configure(args.command)
-
-    # TODO Connect to the events that are needed by this command.
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-# This event handler is called when the user clicks the OK button in the command dialog or 
-# is immediately called after the created event not command inputs were created for the dialog.
-def command_execute(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.HerringboneGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-
-# This event handler is called when the command needs to compute a new preview in the graphics window.
-def command_preview(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Preview Event')
-    inputs = args.command.commandInputs
-
-
-# This event handler is called when the user changes anything in the command dialog
-# allowing you to modify values of other inputs based on that change.
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    changed_input = args.input
-    inputs = args.inputs
-
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Input Changed Event fired from a change to {changed_input.id}')
-
-
-# This event handler is called when the user interacts with any of the inputs in the dialog
-# which allows you to verify that all of the inputs are valid and enables the OK button.
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Validate Input Event')
-
-    args.areInputsValid = True
-
-# This event handler is called when the command terminates.
-def command_destroy(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Destroy Event')
-
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/commands/spurgear/entry.py
+++ b/commands/spurgear/entry.py
@@ -1,129 +1,15 @@
-import adsk.core
-import os, math
-from ...lib import fusion360utils as futil
+import os
 from ...lib import geargen
-from ... import config
-app = adsk.core.Application.get()
-ui = app.userInterface
+from .._gear_command import GearCommand
 
-# TODO *** Specify the command identity information. ***
-GEAR_TYPE='SpurGear'
-CMD_ID = f'{config.COMPANY_NAME}_{config.ADDIN_NAME}_{GEAR_TYPE}_cmdDialog'
-CMD_NAME = 'Spur Gear Generator'
-CMD_Description = 'Generates a Spur Gear'
+command = GearCommand(
+    gear_type='SpurGear',
+    name='Spur Gear Generator',
+    description='Generates a Spur Gear',
+    icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
+    configurator=geargen.SpurGearCommandInputsConfigurator,
+    generator_class=geargen.SpurGearGenerator,
+)
 
-# Specify that the command will be promoted to the panel.
-IS_PROMOTED = True
-
-# Resource location for command icons, here we assume a sub folder in this directory named "resources".
-ICON_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', '')
-
-# Local list of event handlers used to maintain a reference so
-# they are not released and garbage collected.
-local_handlers = []
-
-
-# Executed when add-in is run.
-def start():
-    # Create a command Definition.
-    cmd_def = ui.commandDefinitions.itemById(CMD_ID)
-    if not cmd_def:
-        cmd_def = ui.commandDefinitions.addButtonDefinition(CMD_ID, CMD_NAME, CMD_Description, ICON_FOLDER)
-
-    # Define an event handler for the command created event. It will be called when the button is clicked.
-    futil.add_handler(cmd_def.commandCreated, command_created)
-
-    # Get the target workspace the button will be created in.
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-
-    # Get the panel the button will be created in.
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    if not dropDown:
-        dropDown = panel.controls.addDropDown('Gears', '', config.DROPDOWN_ID)
-        # Create the button command control in the UI after the specified existing command.
-    
-    control = dropDown.controls.itemById(CMD_ID)
-    if not control:
-        control = dropDown.controls.addCommand(cmd_def, '', False)
-
-# Executed when add-in is stopped.
-def stop():
-    # Get the various UI elements for this command
-    workspace = ui.workspaces.itemById(config.WORKSPACE_ID)
-    panel = workspace.toolbarPanels.itemById(config.PANEL_ID)
-    dropDown = panel.controls.itemById(config.DROPDOWN_ID)
-    command_definition = ui.commandDefinitions.itemById(CMD_ID)
-
-    if dropDown:
-        dropDown.deleteMe()
-
-    # Delete the command definition
-    if command_definition:
-        command_definition.deleteMe()
-
-
-# Function that is called when a user clicks the corresponding button in the UI.
-# This defines the contents of the command dialog and connects to the command related events.
-def command_created(args: adsk.core.CommandCreatedEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Created Event')
-
-    geargen.SpurGearCommandInputsConfigurator.configure(args.command)
-
-    # TODO Connect to the events that are needed by this command.
-    futil.add_handler(args.command.execute, command_execute, local_handlers=local_handlers)
-    futil.add_handler(args.command.inputChanged, command_input_changed, local_handlers=local_handlers)
-    futil.add_handler(args.command.executePreview, command_preview, local_handlers=local_handlers)
-    futil.add_handler(args.command.validateInputs, command_validate_input, local_handlers=local_handlers)
-    futil.add_handler(args.command.destroy, command_destroy, local_handlers=local_handlers)
-
-
-# This event handler is called when the user clicks the OK button in the command dialog or 
-# is immediately called after the created event not command inputs were created for the dialog.
-def command_execute(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Execute Event')
-    g = None
-    try:
-        inputs = args.command.commandInputs
-        design = geargen.get_design()
-        g = geargen.SpurGearGenerator(design)
-        g.generate(inputs)
-    except:
-        futil.handle_error("Generation error", show_message_box=True)
-        if g:
-            g.deleteComponent()
-
-
-# This event handler is called when the command needs to compute a new preview in the graphics window.
-def command_preview(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Preview Event')
-
-
-# This event handler is called when the user changes anything in the command dialog
-# allowing you to modify values of other inputs based on that change.
-def command_input_changed(args: adsk.core.InputChangedEventArgs):
-    futil.log(f'{CMD_NAME} Command Input Changed')
-    changed_input = args.input
-
-
-# This event handler is called when the user interacts with any of the inputs in the dialog
-# which allows you to verify that all of the inputs are valid and enables the OK button.
-def command_validate_input(args: adsk.core.ValidateInputsEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Validate Input Event')
-
-    args.areInputsValid = True
-    
-
-
-# This event handler is called when the command terminates.
-def command_destroy(args: adsk.core.CommandEventArgs):
-    # General logging for debug.
-    futil.log(f'{CMD_NAME} Command Destroy Event')
-
-    global local_handlers
-    local_handlers = []
+start = command.start
+stop = command.stop

--- a/config.py
+++ b/config.py
@@ -31,10 +31,4 @@ COMPANY_NAME = 'endeworks'
 
 WORKSPACE_ID = 'FusionSolidEnvironment'
 PANEL_ID = 'SolidScriptsAddinsPanel' if LOCATE_MENU_IN_ADDIN else 'SolidCreatePanel'
-COMMAND_BESIDE_ID = 'ScriptsManagerCommand'
 DROPDOWN_ID = 'GearGeneratorDropDown'
-
-
-
-# Palettes
-sample_palette_id = f'{COMPANY_NAME}_{ADDIN_NAME}_palette_id'

--- a/lib/geargen/base.py
+++ b/lib/geargen/base.py
@@ -1,44 +1,50 @@
 from abc import ABC, abstractmethod
-from .misc import *
+from .misc import get_design
 from ...lib import fusion360utils as futil
 import adsk.core, adsk.fusion
 
-def get_boolean(inputs: adsk.core.CommandInputs, name):
-    input = inputs.itemById(name)
-    return (input.value, True)
+def get_boolean(inputs: adsk.core.CommandInputs, name: str) -> bool:
+    return inputs.itemById(name).value
 
 def get_selection(inputs: adsk.core.CommandInputs, name: str):
     input = inputs.itemById(name)
     futil.log(f'get_selection: item {name} has {input.selectionCount} selections')
-    list = []
+    entities = []
     for i in range(0, input.selectionCount):
-        selection = input.selection(i)
-        list.append(selection.entity)
-    return (list, True)
+        entities.append(input.selection(i).entity)
+    return entities
 
-def get_value(inputs: adsk.core.CommandInputs, name: str, units: str):
+def get_value(inputs: adsk.core.CommandInputs, name: str, units: str) -> adsk.core.ValueInput:
+    """Read a dialog input and return a ValueInput ready for
+    userParameters.add(). Raises on an invalid expression — never returns
+    None or a raw number ([PB-GET-VALUE-CONTRACT]).
+
+    - StringValueCommandInput whose text names an existing user parameter ->
+      ValueInput.createByString(text) (a live reference to that parameter).
+    - StringValueCommandInput holding a literal expression (e.g. '5 mm') ->
+      ValueInput.createByReal(evaluated value, internal units).
+    - Numeric ValueCommandInput -> ValueInput.createByReal(evaluated value).
+    """
     input = inputs.itemById(name)
     design = get_design()
     unitsManager = design.unitsManager
-    userParameters = design.userParameters
 
-    # If it's a string, we attempt to convert 
     if input.classType == adsk.core.StringValueCommandInput.classType:
-        value = input.value
-        if userParameters.itemByName(value) == None:
-            evaluated = unitsManager.evaluateExpression(value, units)
-            if evaluated == None:
-                raise Exception(f'Failed to evaluate expression "{value}"')
-            return (evaluated, False)
-        return (adsk.core.ValueInput.createByString(value), True)
+        text = input.value
+        if design.userParameters.itemByName(text) is not None:
+            return adsk.core.ValueInput.createByString(text)
+        if not unitsManager.isValidExpression(text, units):
+            raise Exception(f'Invalid expression "{text}" for input "{name}"')
+        return adsk.core.ValueInput.createByReal(
+            unitsManager.evaluateExpression(text, units))
 
-    if units == None:
+    if units is None:
         units = input.unitType
     if not unitsManager.isValidExpression(input.expression, units):
-        return (None, False)
-
-    evaluated = unitsManager.evaluateExpression(input.expression, units)
-    return (adsk.core.ValueInput.createByReal(evaluated), True)
+        raise Exception(
+            f'Invalid expression "{input.expression}" for input "{name}"')
+    return adsk.core.ValueInput.createByReal(
+        unitsManager.evaluateExpression(input.expression, units))
 
 
 # Base object for generation contexts

--- a/lib/geargen/base.py
+++ b/lib/geargen/base.py
@@ -87,7 +87,6 @@ class Generator(ABC):
     def __init__(self, design: adsk.fusion.Design):
         self.design = design
         self.parentComponent = None # TODO: nothing is protecting this from being used when value is None
-        self.component = adsk.fusion.Component.cast(None)
         self.occurrence = adsk.fusion.Occurrence.cast(None)
         self.prefix = None
         self.cleaner = None
@@ -135,9 +134,14 @@ class Generator(ABC):
         return self.prefix.name(name)
 
     def deleteComponent(self):
-        if self.occurrence:
+        if self.cleaner:
+            # Deletes the registered user parameters AND the occurrence.
+            self.cleaner.deleteAll()
+        elif self.occurrence:
             self.occurrence.deleteMe()
-            self.component = None
+        self.occurrence = None
+        self.cleaner = None
+        self.prefix = None
 
     @abstractmethod
     def generate(self, inputs: adsk.core.CommandInputs):

--- a/lib/geargen/bevelgear.py
+++ b/lib/geargen/bevelgear.py
@@ -1,17 +1,36 @@
+# Bevel gear generator — generated from spec/bevelgear/instructions.md
+# (+ fusion.md, spiral-tooth-trace.md) and the shared PLAYBOOK.md.
+#
+# Standalone generator: does NOT subclass base.Generator and carries no
+# GenerationContext. One generator builds both straight (Mean Spiral Angle
+# psi == 0) and spiral (psi > 0) bevels. Bevel registers no Fusion user
+# parameters; every value is precomputed in Python (internal cm) and written
+# into geometry numerically ([PB-PRECOMPUTED-MODE]).
+
 import math
-from ...lib import fusion360utils as futil
-from .misc import *        # to_cm, to_mm, get_design, get_ui
-from .base import *        # Generator, GenerationContext, get_value/get_boolean/get_selection, ParamNamePrefix, ComponentCleaner
-from .utilities import *   # get_normal
-from .spurgear import SpurGearInvoluteToothDesignGenerator
 import adsk.core, adsk.fusion
 
+from ...lib import fusion360utils as futil
+from .misc import to_cm, get_design
+from .base import get_boolean, get_selection
+from .utilities import find_profile_by_curve_counts
+from .spurproxy import VirtualSpurProxy
+from .spurgear import SpurGearInvoluteToothDesignGenerator
+from . import solids
+from .solids import (
+    cut_conical_ends,
+    slice_body_by_offset_planes,
+    rotate_body_about_edge,
+    plane_by_angle,
+    combine_point,
+    circle_intersect_nearest,
+    hide_construction_geometry,
+)
 
-# ---------------------------------------------------------------------------
-# Dialog input ids (the 17 reproduced-surface strings)
-# ---------------------------------------------------------------------------
+
+# -- dialog input ids (reproduced surface; row order per the spec table) -------
 INPUT_ID_PLANE = 'targetPlane'
-INPUT_ID_CENTER = 'centerPoint'
+INPUT_ID_CENTER_POINT = 'centerPoint'
 INPUT_ID_PARENT = 'parentComponent'
 INPUT_ID_MODULE = 'module'
 INPUT_ID_SHAFT_ANGLE = 'shaftAngle'
@@ -28,1210 +47,1177 @@ INPUT_ID_SPIRAL_ANGLE = 'spiralAngle'
 INPUT_ID_HAND = 'spiralHand'
 INPUT_ID_CUTTER_RADIUS = 'cutterRadius'
 
-# Hand-of-spiral list-item strings (reproduced surface)
+# Hand-of-spiral list-item strings (reproduced surface).
 _HAND_RIGHT = 'Right'
 _HAND_LEFT = 'Left'
 
-# Spur generator parameter keys the proxy must serve
-PARAM_MODULE = 'Module'
-PARAM_TOOTH_NUMBER = 'ToothNumber'
-PARAM_PRESSURE_ANGLE = 'PressureAngle'
-PARAM_PITCH_CIRCLE_DIAMETER = 'PitchCircleDiameter'
-PARAM_PITCH_CIRCLE_RADIUS = 'PitchCircleRadius'
-PARAM_BASE_CIRCLE_DIAMETER = 'BaseCircleDiameter'
-PARAM_BASE_CIRCLE_RADIUS = 'BaseCircleRadius'
-PARAM_ROOT_CIRCLE_DIAMETER = 'RootCircleDiameter'
-PARAM_ROOT_CIRCLE_RADIUS = 'RootCircleRadius'
-PARAM_TIP_CIRCLE_DIAMETER = 'TipCircleDiameter'
-PARAM_TIP_CIRCLE_RADIUS = 'TipCircleRadius'
-PARAM_INVOLUTE_STEPS = 'InvoluteSteps'
 
-# bevel hardcodes a 20deg pressure angle (not a dialog input)
-_PRESSURE_ANGLE_DEG = 20.0
-_INVOLUTE_STEPS = 15
-
-# slice count for the spiral tooth body (not user-configurable)
-_SPIRAL_SLICE_COUNT = 8
+def _vec(a, b):
+    """World vector b - a as a Vector3D (both Point3D)."""
+    return adsk.core.Vector3D.create(b.x - a.x, b.y - a.y, b.z - a.z)
 
 
-# ---------------------------------------------------------------------------
-# Dialog inputs configurator
-# ---------------------------------------------------------------------------
+def _sub2(a, b):
+    return (a[0] - b[0], a[1] - b[1])
+
+
+def _add2(a, b):
+    return (a[0] + b[0], a[1] + b[1])
+
+
+def _scale2(a, s):
+    return (a[0] * s, a[1] * s)
+
+
+def _norm2(a):
+    n = math.hypot(a[0], a[1])
+    if n == 0:
+        return (0.0, 0.0)
+    return (a[0] / n, a[1] / n)
+
+
+def _world_point(p):
+    """A SketchPoint's world geometry as a Point3D."""
+    return p.worldGeometry
+
+
+def _midpoint(a, b):
+    return adsk.core.Point3D.create(
+        (a.x + b.x) / 2.0, (a.y + b.y) / 2.0, (a.z + b.z) / 2.0)
+
+
 class BevelGearCommandInputsConfigurator:
+    """Adds the 17 dialog inputs (display order per the spec table) and drives
+    the conditional visibility of the spiral-only inputs. Bound by name from
+    commands/bevelgear/entry.py (configure / handle_input_changed)."""
+
     @classmethod
     def configure(cls, cmd):
         inputs = cmd.commandInputs
+        ValueInput = adsk.core.ValueInput
+        Sel = adsk.core.SelectionCommandInput
 
-        # 1. Target Plane (selection) -- first so Fusion auto-focus lands here
-        planeInput = inputs.addSelectionInput(
+        # 1: Target Plane (added first so it wins Fusion auto-focus —
+        # [PB-AUTOFOCUS-FIRST]).
+        plane = inputs.addSelectionInput(
             INPUT_ID_PLANE, 'Target Plane',
-            'Select the plane the driving gear sits flush against')
-        planeInput.addSelectionFilter(adsk.core.SelectionCommandInput.ConstructionPlanes)
-        planeInput.addSelectionFilter(adsk.core.SelectionCommandInput.PlanarFaces)
-        planeInput.setSelectionLimits(1, 1)
+            'Plane the bottom of the driving gear sits flush against')
+        plane.addSelectionFilter(Sel.ConstructionPlanes)
+        plane.addSelectionFilter(Sel.PlanarFaces)
+        plane.setSelectionLimits(1)
 
-        # 2. Center Point (selection)
-        centerInput = inputs.addSelectionInput(
-            INPUT_ID_CENTER, 'Center Point',
-            'Select the point the driving gear is centered on')
-        centerInput.addSelectionFilter(adsk.core.SelectionCommandInput.ConstructionPoints)
-        centerInput.addSelectionFilter(adsk.core.SelectionCommandInput.SketchPoints)
-        centerInput.setSelectionLimits(1, 1)
+        # 2: Center Point
+        center = inputs.addSelectionInput(
+            INPUT_ID_CENTER_POINT, 'Center Point',
+            'Point the driving bevel gear is centered on')
+        center.addSelectionFilter(Sel.ConstructionPoints)
+        center.addSelectionFilter(Sel.SketchPoints)
+        center.setSelectionLimits(1)
 
-        # 3. Parent Component (selection) -- pre-selected to root
-        parentInput = inputs.addSelectionInput(
+        # 3: Parent Component (root pre-selected)
+        parent = inputs.addSelectionInput(
             INPUT_ID_PARENT, 'Parent Component',
-            'Select the parent component for the new gear pair')
-        parentInput.addSelectionFilter(adsk.core.SelectionCommandInput.Occurrences)
-        parentInput.addSelectionFilter(adsk.core.SelectionCommandInput.RootComponents)
-        parentInput.setSelectionLimits(1, 1)
-        parentInput.addSelection(get_design().rootComponent)
+            'Component the gear pair is created under')
+        parent.addSelectionFilter(Sel.Occurrences)
+        parent.addSelectionFilter(Sel.RootComponents)
+        parent.setSelectionLimits(1)
+        parent.addSelection(get_design().rootComponent)
 
-        # 4. Module
+        # 4: Module
         inputs.addValueInput(
-            INPUT_ID_MODULE, 'Module', '', adsk.core.ValueInput.createByReal(1))
+            INPUT_ID_MODULE, 'Module', '', ValueInput.createByReal(1))
 
-        # 5. Shaft Angle
+        # 5: Shaft Angle
         inputs.addValueInput(
             INPUT_ID_SHAFT_ANGLE, 'Shaft Angle', 'deg',
-            adsk.core.ValueInput.createByString('90 deg'))
+            ValueInput.createByString('90 deg'))
 
-        # 6. Driving Gear Teeth
+        # 6: Driving Gear Teeth
         inputs.addValueInput(
             INPUT_ID_DRIVING_TEETH, 'Driving Gear Teeth', '',
-            adsk.core.ValueInput.createByReal(31))
+            ValueInput.createByReal(31))
 
-        # 7. Pinion Gear Teeth
+        # 7: Pinion Gear Teeth
         inputs.addValueInput(
             INPUT_ID_PINION_TEETH, 'Pinion Gear Teeth', '',
-            adsk.core.ValueInput.createByReal(31))
+            ValueInput.createByReal(31))
 
-        # 8. Driving Gear Base Height
+        # 8: Driving Gear Base Height
         inputs.addValueInput(
             INPUT_ID_DRIVING_BASE_HEIGHT, 'Driving Gear Base Height', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # 9. Pinion Gear Base Height
+        # 9: Pinion Gear Base Height
         inputs.addValueInput(
             INPUT_ID_PINION_BASE_HEIGHT, 'Pinion Gear Base Height', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # 10. Enable Bore
-        inputs.addBoolValueInput(INPUT_ID_BORE_ENABLE, 'Enable Bore', True, '', True)
+        # 10: Enable Bore
+        inputs.addBoolValueInput(
+            INPUT_ID_BORE_ENABLE, 'Enable Bore', True, '', True)
 
-        # 11. Driving Gear Bore Diameter
+        # 11: Driving Gear Bore Diameter
         inputs.addValueInput(
             INPUT_ID_DRIVING_BORE, 'Driving Gear Bore Diameter', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # 12. Pinion Gear Bore Diameter
+        # 12: Pinion Gear Bore Diameter
         inputs.addValueInput(
             INPUT_ID_PINION_BORE, 'Pinion Gear Bore Diameter', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # 13. Face Width
+        # 13: Face Width
         inputs.addValueInput(
             INPUT_ID_FACE_WIDTH, 'Face Width', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # 14. Tooth Spacing
+        # 14: Tooth Spacing
         inputs.addValueInput(
             INPUT_ID_TOOTH_SPACING, 'Tooth Spacing', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # 15. Mean Spiral Angle (always visible -- the controller)
+        # 15: Mean Spiral Angle (controller; always visible)
         inputs.addValueInput(
             INPUT_ID_SPIRAL_ANGLE, 'Mean Spiral Angle', 'deg',
-            adsk.core.ValueInput.createByString('35 deg'))
+            ValueInput.createByString('35 deg'))
 
-        # 16. Hand of Spiral (text-list dropdown)
-        handInput = inputs.addDropDownCommandInput(
+        # 16: Hand of Spiral (text-list dropdown)
+        hand = inputs.addDropDownCommandInput(
             INPUT_ID_HAND, 'Hand of Spiral',
             adsk.core.DropDownStyles.TextListDropDownStyle)
-        handInput.listItems.add(_HAND_RIGHT, True)
-        handInput.listItems.add(_HAND_LEFT, False)
+        hand.listItems.add(_HAND_RIGHT, True)
+        hand.listItems.add(_HAND_LEFT, False)
 
-        # 17. Cutter Radius
+        # 17: Cutter Radius
         inputs.addValueInput(
             INPUT_ID_CUTTER_RADIUS, 'Cutter Radius', 'mm',
-            adsk.core.ValueInput.createByReal(to_cm(0)))
+            ValueInput.createByReal(to_cm(0)))
 
-        # initial conditional visibility (default psi = 35deg -> both shown)
+        # Last step: set the initial spiral-input visibility (default psi=35 ->
+        # both shown).
         cls._updateSpiralInputVisibility(inputs)
 
     @classmethod
     def _updateSpiralInputVisibility(cls, inputs):
-        spiralInput = inputs.itemById(INPUT_ID_SPIRAL_ANGLE)
-        handInput = inputs.itemById(INPUT_ID_HAND)
-        cutterInput = inputs.itemById(INPUT_ID_CUTTER_RADIUS)
-        if spiralInput is None or handInput is None or cutterInput is None:
+        spiral = inputs.itemById(INPUT_ID_SPIRAL_ANGLE)
+        hand = inputs.itemById(INPUT_ID_HAND)
+        cutter = inputs.itemById(INPUT_ID_CUTTER_RADIUS)
+        if spiral is None or hand is None or cutter is None:
             return
         try:
             value = get_design().unitsManager.evaluateExpression(
-                spiralInput.expression, 'deg')
+                spiral.expression, 'rad')
             show = value > 0
-        except:
-            # half-typed expression mid-edit -> leave both shown
+        except Exception:
+            # A half-typed expression can raise mid-edit; leave both shown.
             show = True
-        handInput.isVisible = show
-        cutterInput.isVisible = show
+        hand.isVisible = show
+        cutter.isVisible = show
 
     @classmethod
     def handle_input_changed(cls, args):
         cls._updateSpiralInputVisibility(args.inputs)
 
 
-# ---------------------------------------------------------------------------
-# Virtual spur proxy -- a fake spur `parent` so the borrowed tooth generator
-# can run without registering Fusion user parameters.
-# ---------------------------------------------------------------------------
-class _Val:
-    def __init__(self, value):
-        self.value = value
-
-
-class _VirtualSpurProxy:
-    def __init__(self, module_mm, virtualTeeth):
-        # OUTPUT slot the spur generator writes during draw()
-        self._lastToothEmbedded = False
-
-        pressureAngle = math.radians(_PRESSURE_ANGLE_DEG)
-        # Standard spur formulas (Module here is raw mm):
-        pitch = virtualTeeth * module_mm        # pitch diameter (mm)
-        base = pitch * math.cos(pressureAngle)  # base diameter (mm)
-        root = pitch - 2.5 * module_mm          # root diameter (mm)
-        tip = pitch + 2.0 * module_mm           # tip diameter (mm)
-
-        # Serve every key the spur drawer reads, in internal cm.
-        self._params = {
-            PARAM_MODULE: to_cm(module_mm),
-            PARAM_TOOTH_NUMBER: virtualTeeth,
-            PARAM_PRESSURE_ANGLE: pressureAngle,
-            PARAM_PITCH_CIRCLE_DIAMETER: to_cm(pitch),
-            PARAM_PITCH_CIRCLE_RADIUS: to_cm(pitch / 2.0),
-            PARAM_BASE_CIRCLE_DIAMETER: to_cm(base),
-            PARAM_BASE_CIRCLE_RADIUS: to_cm(base / 2.0),
-            PARAM_ROOT_CIRCLE_DIAMETER: to_cm(root),
-            PARAM_ROOT_CIRCLE_RADIUS: to_cm(root / 2.0),
-            PARAM_TIP_CIRCLE_DIAMETER: to_cm(tip),
-            PARAM_TIP_CIRCLE_RADIUS: to_cm(tip / 2.0),
-            PARAM_INVOLUTE_STEPS: _INVOLUTE_STEPS,
-        }
-
-    def getParameter(self, name):
-        return _Val(self._params[name])
-
-
-# ---------------------------------------------------------------------------
-# Bevel gear generator (standalone -- does NOT subclass base.Generator)
-# ---------------------------------------------------------------------------
 class BevelGearGenerator:
-    # Tunable crown relief constant (0 disables crown); default 0.5
+    """Standalone generator building a straight (psi==0) or spiral (psi>0)
+    bevel pair. Bound by name from commands/bevelgear/entry.py."""
+
+    # Lengthwise-crown relief factor (0 disables the crown).
     _CROWN_PER_RAD = 0.5
-    # Extra pinion mesh-phase, in tooth-fractions (0 by default)
-    _PINION_MESH_PHASE_TEETH = 0.0
+    # Pinion's extra mesh phase, in tooth fractions (0 -> no extra nudge).
+    _PINION_MESH_PHASE_TEETH = 0
 
     def __init__(self, design):
         self.design = design
         self.bevelOccurrence = None
 
-    # =======================================================================
-    # generate -- top-level orchestration
-    # =======================================================================
+    # -- input reading ------------------------------------------------------
+    def _readInputs(self, inputs):
+        """Read + validate every input. Returns the 7-tuple
+        (parentComponent, targetPlane, centerPoint, module, drivingTeeth,
+        pinionTeeth, shaftAngle_deg) and stashes the rest on self."""
+        unitsManager = self.design.unitsManager
+
+        def evalv(name, units):
+            inp = inputs.itemById(name)
+            return unitsManager.evaluateExpression(inp.expression, units)
+
+        # Selections.
+        parents = get_selection(inputs, INPUT_ID_PARENT)
+        if len(parents) != 1:
+            raise Exception('Select exactly one Parent Component')
+        parentSel = parents[0]
+        if isinstance(parentSel, adsk.fusion.Occurrence) or \
+                parentSel.objectType == adsk.fusion.Occurrence.classType():
+            parentComponent = parentSel.component
+        else:
+            parentComponent = parentSel
+
+        planes = get_selection(inputs, INPUT_ID_PLANE)
+        if len(planes) != 1:
+            raise Exception('Select exactly one Target Plane')
+        targetPlane = planes[0]
+
+        centers = get_selection(inputs, INPUT_ID_CENTER_POINT)
+        if len(centers) != 1:
+            raise Exception('Select exactly one Center Point')
+        centerPoint = centers[0]
+
+        # Module is read unit '' -> raw number that means MILLIMETRES.
+        module = evalv(INPUT_ID_MODULE, '')
+        if module <= 0:
+            raise Exception('Module must be > 0')
+
+        drivingTeeth = int(round(evalv(INPUT_ID_DRIVING_TEETH, '')))
+        pinionTeeth = int(round(evalv(INPUT_ID_PINION_TEETH, '')))
+        if drivingTeeth < 3 or pinionTeeth < 3:
+            raise Exception('Teeth number must be >= 3')
+
+        # Shaft Angle reads back in radians; range-check in degrees.
+        shaftAngle_rad = evalv(INPUT_ID_SHAFT_ANGLE, 'deg')
+        shaftAngle_deg = math.degrees(shaftAngle_rad)
+        if shaftAngle_deg < 30 or shaftAngle_deg > 150:
+            raise Exception('Shaft Angle must be between 30 and 150 degrees')
+
+        # 'mm' inputs come back already in internal cm — do NOT to_cm again.
+        self._drivingBaseHeight_cm = evalv(INPUT_ID_DRIVING_BASE_HEIGHT, 'mm')
+        self._pinionBaseHeight_cm = evalv(INPUT_ID_PINION_BASE_HEIGHT, 'mm')
+        if self._drivingBaseHeight_cm < 0 or self._pinionBaseHeight_cm < 0:
+            raise Exception('Base heights must be non-negative')
+
+        self._boreEnable = get_boolean(inputs, INPUT_ID_BORE_ENABLE)
+        self._drivingBore_cm = evalv(INPUT_ID_DRIVING_BORE, 'mm')
+        self._pinionBore_cm = evalv(INPUT_ID_PINION_BORE, 'mm')
+        if self._drivingBore_cm < 0 or self._pinionBore_cm < 0:
+            raise Exception('Bore diameters must be non-negative')
+
+        self._faceWidth_cm = evalv(INPUT_ID_FACE_WIDTH, 'mm')
+        if self._faceWidth_cm < 0:
+            raise Exception('Face Width must be non-negative')
+
+        self._toothSpacing_cm = evalv(INPUT_ID_TOOTH_SPACING, 'mm')
+        if self._toothSpacing_cm < 0:
+            raise Exception('Tooth Spacing must be non-negative')
+
+        # Mean Spiral Angle reads back in radians; range-check [0, 60) deg.
+        self._spiralAngle_rad = evalv(INPUT_ID_SPIRAL_ANGLE, 'deg')
+        spiralAngle_deg = math.degrees(self._spiralAngle_rad)
+        if spiralAngle_deg < 0 or spiralAngle_deg >= 60:
+            raise Exception('Mean Spiral Angle must be in [0, 60) degrees')
+
+        handInput = inputs.itemById(INPUT_ID_HAND)
+        selectedItem = handInput.selectedItem
+        self._hand = selectedItem.name if selectedItem is not None else _HAND_RIGHT
+
+        # Cutter Radius reads back in internal cm via 'mm'. 0 -> auto.
+        self._cutterRadius_cm = evalv(INPUT_ID_CUTTER_RADIUS, 'mm')
+        if self._cutterRadius_cm < 0:
+            raise Exception('Cutter Radius must be non-negative')
+
+        return (parentComponent, targetPlane, centerPoint, module,
+                drivingTeeth, pinionTeeth, shaftAngle_deg)
+
+    # -- orchestration ------------------------------------------------------
     def generate(self, inputs):
-        (parentComponent, targetPlane, centerPoint,
-         module, drivingTeeth, pinionTeeth, shaftAngle_deg) = self._readInputs(inputs)
+        (parentComponent, targetPlane, centerPoint, module,
+         drivingTeeth, pinionTeeth, shaftAngle_deg) = self._readInputs(inputs)
 
         shaftAngle_rad = math.radians(shaftAngle_deg)
 
-        # Resolve pitch diameters (internal cm) -- Module is raw mm.
-        drivingPitchDiameter_cm = to_cm(module * drivingTeeth)
-        pinionPitchDiameter_cm = to_cm(module * pinionTeeth)
+        # Resolve pitch diameters & bores in Python (internal cm).
+        drivingPitchDia_cm = to_cm(module * drivingTeeth)
+        pinionPitchDia_cm = to_cm(module * pinionTeeth)
 
-        # Cone distance (cm)
-        coneDistance_cm = to_cm(
-            math.sqrt((module * drivingTeeth) ** 2 + (module * pinionTeeth) ** 2))
-
-        # Pitch-cone half angles (closed form). PPD/DPD ratios reduce to teeth.
-        # tan gamma_p = sin(S)*PPD / (DPD + PPD*cos(S))
-        ppd = module * pinionTeeth
-        dpd = module * drivingTeeth
-        self._gamma_p = math.atan2(
-            math.sin(shaftAngle_rad) * ppd,
-            dpd + ppd * math.cos(shaftAngle_rad))
-        self._gamma_g = shaftAngle_rad - self._gamma_p
-
-        # Resolve bores (cm). 0 means auto = pitch diameter / 4.
         if self._drivingBore_cm > 0:
-            drivingBore_cm = self._drivingBore_cm
+            drivingBoreDia_cm = self._drivingBore_cm
         else:
-            drivingBore_cm = drivingPitchDiameter_cm / 4.0
+            drivingBoreDia_cm = drivingPitchDia_cm / 4.0
         if self._pinionBore_cm > 0:
-            pinionBore_cm = self._pinionBore_cm
+            pinionBoreDia_cm = self._pinionBore_cm
         else:
-            pinionBore_cm = pinionPitchDiameter_cm / 4.0
+            pinionBoreDia_cm = pinionPitchDia_cm / 4.0
 
-        # ---- build component tree ----
-        # Bevel Gear component as a child of the parent component.
+        # Cone distance (internal cm).
+        coneDistance_cm = to_cm(
+            math.sqrt((module * drivingTeeth) ** 2
+                      + (module * pinionTeeth) ** 2))
+        self._coneDistance_cm = coneDistance_cm
+
+        # Pitch-cone half-angles (used both for A/B seeds and §3 virtual radii).
+        # tan gamma_p = sin Sigma * PPD / (DPD + PPD * cos Sigma)
+        ppd = pinionPitchDia_cm
+        dpd = drivingPitchDia_cm
+        gamma_p = math.atan2(math.sin(shaftAngle_rad) * ppd,
+                             dpd + ppd * math.cos(shaftAngle_rad))
+        gamma_g = shaftAngle_rad - gamma_p
+        self._gamma_p = gamma_p
+        self._gamma_g = gamma_g
+
+        # Build the component tree: Bevel Gear under Parent, Design under it.
+        Matrix3D = adsk.core.Matrix3D
         self.bevelOccurrence = parentComponent.occurrences.addNewComponent(
-            adsk.core.Matrix3D.create())
+            Matrix3D.create())
         bevelComponent = self.bevelOccurrence.component
         bevelComponent.name = 'Bevel Gear'
 
-        # Design component as a child of the Bevel Gear component.
-        designOccurrence = self.bevelOccurrence.component.occurrences.addNewComponent(
-            adsk.core.Matrix3D.create())
-        designComponent = designOccurrence.component
+        self.designOccurrence = bevelComponent.occurrences.addNewComponent(
+            Matrix3D.create())
+        designComponent = self.designOccurrence.component
         designComponent.name = 'Design'
+        self.designComponent = designComponent
+        self.bevelComponent = bevelComponent
 
-        # ---- geometry ----
-        # Stash precomputed cm/numeric values commonly needed downstream.
-        self._module_mm = module
-        self._drivingTeeth = drivingTeeth
-        self._pinionTeeth = pinionTeeth
-        self._drivingPitchDiameter_cm = drivingPitchDiameter_cm
-        self._pinionPitchDiameter_cm = pinionPitchDiameter_cm
-        self._coneDistance_cm = coneDistance_cm
+        # §1 Anchor sketch.
+        anchorLine = self._buildAnchorSketch(
+            designComponent, targetPlane, centerPoint)
 
-        # §1 Anchor Sketch
-        anchorLine = self._buildAnchorSketch(designComponent, targetPlane, centerPoint)
-
-        # §2 + §3 + per-gear bodies
+        # §2 + §3 + per-gear bodies.
         self._buildGearProfiles(
-            designComponent, designOccurrence, bevelComponent,
-            targetPlane, anchorLine,
-            module, drivingTeeth, pinionTeeth, shaftAngle_rad,
-            drivingPitchDiameter_cm, pinionPitchDiameter_cm,
-            drivingBore_cm, pinionBore_cm)
+            designComponent, targetPlane, anchorLine, module,
+            drivingTeeth, pinionTeeth, shaftAngle_rad,
+            drivingPitchDia_cm, pinionPitchDia_cm,
+            drivingBoreDia_cm, pinionBoreDia_cm)
 
-        # Cleanup
+        # Cleanup.
         self._hideConstructionGeometry(bevelComponent)
 
     def deleteComponent(self):
         if self.bevelOccurrence:
             self.bevelOccurrence.deleteMe()
-            self.bevelOccurrence = None
+        self.bevelOccurrence = None
 
-    # =======================================================================
-    # Input reading / validation
-    # =======================================================================
-    def _readInputs(self, inputs):
-        unitsManager = self.design.unitsManager
-
-        def evalExpr(input_id, units):
-            inp = inputs.itemById(input_id)
-            return unitsManager.evaluateExpression(inp.expression, units)
-
-        # Selections
-        (parentList, _) = get_selection(inputs, INPUT_ID_PARENT)
-        if len(parentList) != 1:
-            raise Exception('Exactly one Parent Component must be selected')
-        parentEntity = parentList[0]
-        if isinstance(parentEntity, adsk.fusion.Occurrence) or \
-                parentEntity.objectType == adsk.fusion.Occurrence.classType():
-            parentComponent = parentEntity.component
-        else:
-            parentComponent = parentEntity
-
-        (planeList, _) = get_selection(inputs, INPUT_ID_PLANE)
-        if len(planeList) != 1:
-            raise Exception('Exactly one Target Plane must be selected')
-        targetPlane = planeList[0]
-
-        (centerList, _) = get_selection(inputs, INPUT_ID_CENTER)
-        if len(centerList) != 1:
-            raise Exception('Exactly one Center Point must be selected')
-        centerPoint = centerList[0]
-
-        # Module -- raw mm number (unit '')
-        module = evalExpr(INPUT_ID_MODULE, '')
-
-        # Shaft Angle -- comes back in radians; convert to degrees for range check
-        shaftAngle_rad = evalExpr(INPUT_ID_SHAFT_ANGLE, 'deg')
-        shaftAngle_deg = math.degrees(shaftAngle_rad)
-        if shaftAngle_deg < 30 or shaftAngle_deg > 150:
-            raise Exception(
-                f'Shaft Angle must be between 30 and 150 degrees (got {shaftAngle_deg:.2f})')
-
-        # Teeth
-        drivingTeeth = int(round(evalExpr(INPUT_ID_DRIVING_TEETH, '')))
-        pinionTeeth = int(round(evalExpr(INPUT_ID_PINION_TEETH, '')))
-        if drivingTeeth < 3:
-            raise Exception('Driving Gear Teeth must be at least 3')
-        if pinionTeeth < 3:
-            raise Exception('Pinion Gear Teeth must be at least 3')
-
-        # 'mm' inputs come back already in internal cm.
-        self._drivingBaseHeight_cm = evalExpr(INPUT_ID_DRIVING_BASE_HEIGHT, 'mm')
-        self._pinionBaseHeight_cm = evalExpr(INPUT_ID_PINION_BASE_HEIGHT, 'mm')
-        self._drivingBore_cm = evalExpr(INPUT_ID_DRIVING_BORE, 'mm')
-        self._pinionBore_cm = evalExpr(INPUT_ID_PINION_BORE, 'mm')
-        self._faceWidth_cm = evalExpr(INPUT_ID_FACE_WIDTH, 'mm')
-        self._toothSpacing_cm = evalExpr(INPUT_ID_TOOTH_SPACING, 'mm')
-
-        (self._boreEnable, _) = get_boolean(inputs, INPUT_ID_BORE_ENABLE)
-
-        if self._drivingBaseHeight_cm < 0 or self._pinionBaseHeight_cm < 0:
-            raise Exception('Base heights must be non-negative')
-        if self._drivingBore_cm < 0 or self._pinionBore_cm < 0:
-            raise Exception('Bore diameters must be non-negative')
-        if self._faceWidth_cm < 0:
-            raise Exception('Face Width must be non-negative')
-        if self._toothSpacing_cm < 0:
-            raise Exception('Tooth Spacing must be non-negative')
-
-        # Spiral inputs
-        spiralAngle_rad = evalExpr(INPUT_ID_SPIRAL_ANGLE, 'deg')
-        spiralAngle_deg = math.degrees(spiralAngle_rad)
-        if spiralAngle_deg < 0 or spiralAngle_deg >= 60:
-            raise Exception(
-                f'Mean Spiral Angle must be in [0, 60) degrees (got {spiralAngle_deg:.2f})')
-        self._spiralAngle_rad = spiralAngle_rad
-
-        handInput = inputs.itemById(INPUT_ID_HAND)
-        selectedItem = handInput.selectedItem
-        self._spiralHand = selectedItem.name if selectedItem is not None else _HAND_RIGHT
-
-        cutterRadius_cm = evalExpr(INPUT_ID_CUTTER_RADIUS, 'mm')
-        if cutterRadius_cm < 0:
-            raise Exception('Cutter Radius must be non-negative')
-        self._cutterRadius_cm = cutterRadius_cm
-
-        return (parentComponent, targetPlane, centerPoint,
-                module, drivingTeeth, pinionTeeth, shaftAngle_deg)
-
-    # =======================================================================
-    # §1 Anchor Sketch
-    # =======================================================================
+    # -- §1: Anchor Sketch --------------------------------------------------
     def _buildAnchorSketch(self, designComponent, targetPlane, centerPoint):
+        # Start the sketch DIRECTLY on the selected target plane/face
+        # ([PB-USE-SELECTED-PLANE]).
         sketch = designComponent.sketches.add(targetPlane)
         sketch.name = 'Anchor'
-        sketch.isVisible = True
 
-        constraints = sketch.geometricConstraints
-        dimensions = sketch.sketchDimensions
-        lines = sketch.sketchCurves.sketchLines
-
-        # Mark the center point by projecting the user center point.
+        # Project the user-specified center point onto the sketch.
         projected = sketch.project(centerPoint)
         projectedCenter = projected.item(0)
-
-        # Anchor line through the projected center: ~10mm length.
-        cg = projectedCenter.geometry
-        half = to_cm(5.0)
-        line = lines.addByTwoPoints(
-            adsk.core.Point3D.create(cg.x - half, cg.y, 0),
-            adsk.core.Point3D.create(cg.x + half, cg.y, 0))
-
-        # BOTH: pin center onto the line, and center bisects the line.
-        constraints.addCoincident(projectedCenter, line)
-        constraints.addMidPoint(projectedCenter, line)
-        dimensions.addDistanceDimension(
-            line.startSketchPoint, line.endSketchPoint,
-            adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            adsk.core.Point3D.create(cg.x, cg.y + half, 0))
-        # Pin direction (sketch-local) so the sketch has zero DOF.
-        constraints.addHorizontal(line)
-
-        # Stash the projected-center SketchPoint for §2 to re-project.
         self._anchorCenterPoint = projectedCenter
+
+        # Draw a reference line through the projected center.
+        lines = sketch.sketchCurves.sketchLines
+        cg = projectedCenter.geometry
+        seedA = adsk.core.Point3D.create(cg.x - 0.5, cg.y, cg.z)
+        seedB = adsk.core.Point3D.create(cg.x + 0.5, cg.y, cg.z)
+        anchorLine = lines.addByTwoPoints(seedA, seedB)
+
+        gc = sketch.geometricConstraints
+        dims = sketch.sketchDimensions
+        # BOTH coincident (pins center onto line) and midpoint (center bisects).
+        gc.addCoincident(projectedCenter, anchorLine)
+        gc.addMidPoint(projectedCenter, anchorLine)
+        # ~10mm reference length.
+        dims.addDistanceDimension(
+            anchorLine.startSketchPoint, anchorLine.endSketchPoint,
+            adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
+            adsk.core.Point3D.create(cg.x, cg.y + 0.2, cg.z))
+        # Pin direction sketch-locally so the sketch is fully constrained.
+        gc.addHorizontal(anchorLine)
 
         if not sketch.isFullyConstrained:
             raise Exception('Anchor sketch is not fully constrained')
 
         self._anchorSketch = sketch
-        return line
+        return anchorLine
 
-    # =======================================================================
-    # §2 + §3 + per-gear bodies
-    # =======================================================================
-    def _buildGearProfiles(self, designComponent, designOccurrence, bevelComponent,
-                           targetPlane, anchorLine,
+    # -- §2 + §3 + per-gear bodies -----------------------------------------
+    def _buildGearProfiles(self, designComponent, targetPlane, anchorLine,
                            module, drivingTeeth, pinionTeeth, shaftAngle_rad,
-                           drivingPitchDiameter_cm, pinionPitchDiameter_cm,
-                           drivingBore_cm, pinionBore_cm):
-        # ---- §2: Gear Profiles sketch on a plane perpendicular to target ----
+                           dpd_cm, ppd_cm, drivingBoreDia_cm, pinionBoreDia_cm):
         planes = designComponent.constructionPlanes
+        ValueInput = adsk.core.ValueInput
+
+        # Gear Profiles plane: includes the anchor line, set 90deg off the
+        # ORIGINAL target plane (perpendicular) — [PB-USE-SELECTED-PLANE].
         gpInput = planes.createInput()
         gpInput.setByAngle(anchorLine,
-                           adsk.core.ValueInput.createByString('90 deg'),
-                           targetPlane)
-        gearProfilesPlane = planes.add(gpInput)
-        gearProfilesPlane.name = 'Gear Profiles Plane'
+                           ValueInput.createByString('90 deg'), targetPlane)
+        gpPlane = planes.add(gpInput)
+        gpPlane.name = 'Gear Profiles Plane'
+        self._gearProfilesPlane = gpPlane
 
-        sketch = designComponent.sketches.add(gearProfilesPlane)
+        sketch = designComponent.sketches.add(gpPlane)
         sketch.name = 'Gear Profiles'
-        sketch.isVisible = True
-        self._gearProfilesPlane = gearProfilesPlane
-        self._gearProfilesSketch = sketch
-
-        constraints = sketch.geometricConstraints
-        dimensions = sketch.sketchDimensions
         lines = sketch.sketchCurves.sketchLines
+        gc = sketch.geometricConstraints
+        dims = sketch.sketchDimensions
 
-        DPD = drivingPitchDiameter_cm
-        PPD = pinionPitchDiameter_cm
+        # Project the ANCHOR sketch's stashed center point (not the raw input).
+        projected = sketch.project(self._anchorCenterPoint)
+        c_pt = projected.item(0)
+        c = c_pt.geometry  # 2-D (local) coords; (x, y)
 
-        # Project the Anchor Sketch's center point (NOT the raw user center).
-        projectedCenter = sketch.project(self._anchorCenterPoint).item(0)
-        projectedAnchor = sketch.project(anchorLine).item(0)
+        # Also need the projected anchor-line direction. Project the anchor line
+        # to read its local direction.
+        projLine = sketch.project(anchorLine)
+        anchorProj = projLine.item(0)
+        ap0 = anchorProj.startSketchPoint.geometry
+        ap1 = anchorProj.endSketchPoint.geometry
+        d = _norm2((ap1.x - ap0.x, ap1.y - ap0.y))
+        perp = (-d[1], d[0])
 
-        c = projectedCenter.geometry
-        # 2-D unit direction of the projected anchor line.
-        ag0 = projectedAnchor.startSketchPoint.geometry
-        ag1 = projectedAnchor.endSketchPoint.geometry
-        dvec = adsk.core.Vector3D.create(ag1.x - ag0.x, ag1.y - ag0.y, 0)
-        dlen = dvec.length
-        dx, dy = dvec.x / dlen, dvec.y / dlen
-        # in-plane perpendicular
-        perpx, perpy = -dy, dx
+        # Grow side: pick perp sign toward the target-plane NORMAL
+        # ([BEVEL-F-GROW-SIDE]). Express the target normal in the sketch's local
+        # frame by mapping two world points.
+        normalWorld = self._targetNormal(targetPlane)
+        # A world point a unit along the normal from the projected center.
+        cWorld = c_pt.worldGeometry
+        normEnd = adsk.core.Point3D.create(
+            cWorld.x + normalWorld.x, cWorld.y + normalWorld.y,
+            cWorld.z + normalWorld.z)
+        normEndLocal = sketch.modelToSketchSpace(normEnd)
+        normLocal = _norm2((normEndLocal.x - c.x, normEndLocal.y - c.y))
+        if (perp[0] * normLocal[0] + perp[1] * normLocal[1]) < 0:
+            perp = (-perp[0], -perp[1])
 
-        # Grow side: choose the perp sign so it points toward the target normal.
-        targetNormal = get_normal(targetPlane)
-        # map the sketch-local perp to world via the sketch transform
-        perpWorld = sketch.sketchToModelSpace(
-            adsk.core.Point3D.create(c.x + perpx, c.y + perpy, 0))
-        cWorld = sketch.sketchToModelSpace(adsk.core.Point3D.create(c.x, c.y, 0))
-        perpWorldVec = adsk.core.Vector3D.create(
-            perpWorld.x - cWorld.x, perpWorld.y - cWorld.y, perpWorld.z - cWorld.z)
-        if perpWorldVec.dotProduct(targetNormal) < 0:
-            perpx, perpy = -perpx, -perpy
+        DPD = dpd_cm
+        PPD = ppd_cm
 
-        def P(x, y):
-            return adsk.core.Point3D.create(x, y, 0)
+        # Apex position is sketch-local: c + perp * DPD ([BEVEL-F-APEX-LOCAL]).
+        apex2d = (c.x + perp[0] * DPD, c.y + perp[1] * DPD)
 
-        # ---- center -> Apex construction line ----
-        apexSeedX = c.x + perpx * DPD
-        apexSeedY = c.y + perpy * DPD
-        centerToApex = lines.addByTwoPoints(P(c.x, c.y), P(apexSeedX, apexSeedY))
+        # center -> apex construction line (perpendicular to the anchor line).
+        centerToApex = lines.addByTwoPoints(
+            adsk.core.Point3D.create(c.x, c.y, 0),
+            adsk.core.Point3D.create(apex2d[0], apex2d[1], 0))
         centerToApex.isConstruction = True
-        constraints.addCoincident(centerToApex.startSketchPoint, projectedCenter)
-        constraints.addPerpendicular(centerToApex, projectedAnchor)
-        apex = centerToApex.endSketchPoint
+        gc.addCoincident(centerToApex.startSketchPoint, c_pt)
+        gc.addPerpendicular(centerToApex, anchorProj)
+        apexPoint = centerToApex.endSketchPoint
 
-        # ---- closed-form along-shaft seed geometry ----
-        Sigma = shaftAngle_rad
-        gamma_p = self._gamma_p
-        R = (PPD / 2.0) / math.sin(gamma_p)
-        lenA = R * math.cos(gamma_p)          # |Apex -> A|
-        lenB = R * math.cos(self._gamma_g)    # |Apex -> B|
+        # Closed-form along-shaft seed lengths.
+        R = (PPD / 2.0) / math.sin(self._gamma_p)
+        lenA = R * math.cos(self._gamma_p)
+        lenB = R * math.cos(self._gamma_g)
 
-        # ---- Driving Gear Shaft Axis (Apex -> B), parallel to center->apex ----
-        # seed point B at apex + (-perp) * lenB
-        bSeedX = apexSeedX - perpx * lenB
-        bSeedY = apexSeedY - perpy * lenB
-        drivingShaftAxis = lines.addByTwoPoints(P(apexSeedX, apexSeedY), P(bSeedX, bSeedY))
-        drivingShaftAxis.isConstruction = True
-        constraints.addCoincident(drivingShaftAxis.startSketchPoint, apex)
-        constraints.addParallel(drivingShaftAxis, centerToApex)
-        pointB = drivingShaftAxis.endSketchPoint
+        # Driving Gear Shaft Axis: from apex toward the anchor line (-perp), end
+        # point B. Parallel to centerToApex.
+        Bseed = (apex2d[0] - perp[0] * lenB, apex2d[1] - perp[1] * lenB)
+        drivingShaft = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apex2d[0], apex2d[1], 0),
+            adsk.core.Point3D.create(Bseed[0], Bseed[1], 0))
+        drivingShaft.isConstruction = True
+        gc.addCoincident(drivingShaft.startSketchPoint, apexPoint)
+        gc.addParallel(drivingShaft, centerToApex)
+        pointB = drivingShaft.endSketchPoint
 
-        # ---- Pinion Gear Shaft Axis (Apex -> A) ----
-        # candidate A positions: rotate driving-shaft dir about apex by +/- Sigma
-        # driving-shaft direction (apex -> B) is -perp
-        ddirx, ddiry = -perpx, -perpy
-        cosS, sinS = math.cos(Sigma), math.sin(Sigma)
-        # +Sigma rotation
-        plusx = ddirx * cosS - ddiry * sinS
-        plusy = ddirx * sinS + ddiry * cosS
-        # -Sigma rotation
-        minusx = ddirx * cosS + ddiry * sinS
-        minusy = -ddirx * sinS + ddiry * cosS
-        aPlus = (apexSeedX + plusx * lenA, apexSeedY + plusy * lenA)
-        aMinus = (apexSeedX + minusx * lenA, apexSeedY + minusy * lenA)
-        # keep the candidate with the GREATER X
-        if aPlus[0] >= aMinus[0]:
-            aSeed = aPlus
+        # Pinion Gear Shaft Axis: driving direction rotated about apex by
+        # +-Sigma; choose the sense whose endpoint has the greater X.
+        drivingDir = _norm2((Bseed[0] - apex2d[0], Bseed[1] - apex2d[1]))
+
+        def rot(vec, ang):
+            ca, sa = math.cos(ang), math.sin(ang)
+            return (vec[0] * ca - vec[1] * sa, vec[0] * sa + vec[1] * ca)
+
+        candPlus = rot(drivingDir, shaftAngle_rad)
+        candMinus = rot(drivingDir, -shaftAngle_rad)
+        Aplus = (apex2d[0] + candPlus[0] * lenA, apex2d[1] + candPlus[1] * lenA)
+        Aminus = (apex2d[0] + candMinus[0] * lenA,
+                  apex2d[1] + candMinus[1] * lenA)
+        if Aplus[0] >= Aminus[0]:
+            pinionDir = candPlus
+            Aseed = Aplus
         else:
-            aSeed = aMinus
-        pinionShaftAxis = lines.addByTwoPoints(P(apexSeedX, apexSeedY), P(aSeed[0], aSeed[1]))
-        pinionShaftAxis.isConstruction = True
-        constraints.addCoincident(pinionShaftAxis.startSketchPoint, apex)
-        # angular dimension between the two shaft axes = Shaft Angle, measured at Sigma
-        midWedge = P((aSeed[0] + bSeedX) / 2.0, (aSeed[1] + bSeedY) / 2.0)
-        angDim = dimensions.addAngularDimension(drivingShaftAxis, pinionShaftAxis, midWedge)
-        angDim.parameter.value = Sigma
-        pointA = pinionShaftAxis.endSketchPoint
+            pinionDir = candMinus
+            Aseed = Aminus
 
-        # ---- A->Apex2 perpendicular drop (PPD/2) ----
-        ag = pointA.geometry
-        # perpendicular to the pinion shaft axis (Apex->A direction) toward Apex2
-        paxd = adsk.core.Vector3D.create(
-            ag.x - apexSeedX, ag.y - apexSeedY, 0)
-        pl = paxd.length
-        paxd_x, paxd_y = paxd.x / pl, paxd.y / pl
-        # perpendicular candidates; choose toward the anchor (toward apex/center side)
-        n1 = (-paxd_y, paxd_x)
-        # pick the one pointing toward c
-        toC = adsk.core.Vector3D.create(c.x - ag.x, c.y - ag.y, 0)
-        if (n1[0] * toC.x + n1[1] * toC.y) < 0:
-            n1 = (-n1[0], -n1[1])
-        a2SeedFromA = (ag.x + n1[0] * (PPD / 2.0), ag.y + n1[1] * (PPD / 2.0))
-        dropA = lines.addByTwoPoints(P(ag.x, ag.y), P(a2SeedFromA[0], a2SeedFromA[1]))
-        dropA.isConstruction = True
-        constraints.addCoincident(dropA.startSketchPoint, pointA)
-        constraints.addPerpendicular(dropA, pinionShaftAxis)
-        dimensions.addDistanceDimension(
-            dropA.startSketchPoint, dropA.endSketchPoint,
+        pinionShaft = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apex2d[0], apex2d[1], 0),
+            adsk.core.Point3D.create(Aseed[0], Aseed[1], 0))
+        pinionShaft.isConstruction = True
+        gc.addCoincident(pinionShaft.startSketchPoint, apexPoint)
+        pointA = pinionShaft.endSketchPoint
+
+        # Angular dimension Sigma between the two shaft axes; text point inside
+        # the Sigma wedge ([PB-ANGULAR-DIM]).
+        bis = _norm2(_add2(pinionDir, drivingDir))
+        textPt = (apex2d[0] + bis[0] * (PPD / 4.0),
+                  apex2d[1] + bis[1] * (PPD / 4.0))
+        dims.addAngularDimension(
+            pinionShaft, drivingShaft,
+            adsk.core.Point3D.create(textPt[0], textPt[1], 0))
+
+        # A -> Apex2 : perpendicular drop from A toward the driving shaft / B,
+        # length PPD/2.
+        abDir = _norm2((Bseed[0] - Aseed[0], Bseed[1] - Aseed[1]))
+        # perpendicular to pinion shaft, chosen toward A->B.
+        pinionPerp = (-pinionDir[1], pinionDir[0])
+        if (pinionPerp[0] * abDir[0] + pinionPerp[1] * abDir[1]) < 0:
+            pinionPerp = (-pinionPerp[0], -pinionPerp[1])
+        apex2seedA = (Aseed[0] + pinionPerp[0] * (PPD / 2.0),
+                      Aseed[1] + pinionPerp[1] * (PPD / 2.0))
+        aToApex2 = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Aseed[0], Aseed[1], 0),
+            adsk.core.Point3D.create(apex2seedA[0], apex2seedA[1], 0))
+        aToApex2.isConstruction = True
+        gc.addCoincident(aToApex2.startSketchPoint, pointA)
+        gc.addPerpendicular(aToApex2, pinionShaft)
+        dims.addDistanceDimension(
+            aToApex2.startSketchPoint, aToApex2.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            P(a2SeedFromA[0], a2SeedFromA[1])).parameter.value = PPD / 2.0
+            adsk.core.Point3D.create(
+                (Aseed[0] + apex2seedA[0]) / 2.0 + 0.1,
+                (Aseed[1] + apex2seedA[1]) / 2.0, 0)
+        ).parameter.value = PPD / 2.0
 
-        # ---- B->Apex2 perpendicular drop (DPD/2) ----
-        bg = pointB.geometry
-        dbxd = adsk.core.Vector3D.create(bg.x - apexSeedX, bg.y - apexSeedY, 0)
-        bl = dbxd.length
-        dbxd_x, dbxd_y = dbxd.x / bl, dbxd.y / bl
-        n2 = (-dbxd_y, dbxd_x)
-        toC2 = adsk.core.Vector3D.create(c.x - bg.x, c.y - bg.y, 0)
-        if (n2[0] * toC2.x + n2[1] * toC2.y) < 0:
-            n2 = (-n2[0], -n2[1])
-        a2SeedFromB = (bg.x + n2[0] * (DPD / 2.0), bg.y + n2[1] * (DPD / 2.0))
-        dropB = lines.addByTwoPoints(P(bg.x, bg.y), P(a2SeedFromB[0], a2SeedFromB[1]))
-        dropB.isConstruction = True
-        constraints.addCoincident(dropB.startSketchPoint, pointB)
-        constraints.addPerpendicular(dropB, drivingShaftAxis)
-        dimensions.addDistanceDimension(
-            dropB.startSketchPoint, dropB.endSketchPoint,
+        # B -> Apex2 : perpendicular drop from B toward the pinion shaft / A,
+        # length DPD/2.
+        baDir = _norm2((Aseed[0] - Bseed[0], Aseed[1] - Bseed[1]))
+        drivingPerp = (-drivingDir[1], drivingDir[0])
+        if (drivingPerp[0] * baDir[0] + drivingPerp[1] * baDir[1]) < 0:
+            drivingPerp = (-drivingPerp[0], -drivingPerp[1])
+        apex2seedB = (Bseed[0] + drivingPerp[0] * (DPD / 2.0),
+                      Bseed[1] + drivingPerp[1] * (DPD / 2.0))
+        bToApex2 = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Bseed[0], Bseed[1], 0),
+            adsk.core.Point3D.create(apex2seedB[0], apex2seedB[1], 0))
+        bToApex2.isConstruction = True
+        gc.addCoincident(bToApex2.startSketchPoint, pointB)
+        gc.addPerpendicular(bToApex2, drivingShaft)
+        dims.addDistanceDimension(
+            bToApex2.startSketchPoint, bToApex2.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            P(a2SeedFromB[0], a2SeedFromB[1])).parameter.value = DPD / 2.0
+            adsk.core.Point3D.create(
+                (Bseed[0] + apex2seedB[0]) / 2.0 + 0.1,
+                (Bseed[1] + apex2seedB[1]) / 2.0, 0)
+        ).parameter.value = DPD / 2.0
 
-        # ---- Apex2: coincident the two drop endpoints ----
-        constraints.addCoincident(dropA.endSketchPoint, dropB.endSketchPoint)
-        apex2 = dropA.endSketchPoint
+        # Close the two drops at Apex 2.
+        gc.addCoincident(aToApex2.endSketchPoint, bToApex2.endSketchPoint)
+        apex2Point = aToApex2.endSketchPoint
 
-        # ---- Pitch Line: Apex -> Apex2 ----
-        a2g = apex2.geometry
-        pitchLine = lines.addByTwoPoints(P(apexSeedX, apexSeedY), P(a2g.x, a2g.y))
+        # Pitch Line Apex -> Apex2.
+        pitchLine = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apex2d[0], apex2d[1], 0),
+            adsk.core.Point3D.create(apex2seedA[0], apex2seedA[1], 0))
         pitchLine.isConstruction = True
-        constraints.addCoincident(pitchLine.startSketchPoint, apex)
-        constraints.addCoincident(pitchLine.endSketchPoint, apex2)
+        gc.addCoincident(pitchLine.startSketchPoint, apexPoint)
+        gc.addCoincident(pitchLine.endSketchPoint, apex2Point)
 
-        # ---- Dedendum lines from Apex2 (Module * 1.25), perpendicular to Pitch Line ----
+        # Dedendum drops from Apex 2, perpendicular to the Pitch Line, length
+        # Module*1.25, one to each side. The one toward the anchor line = D
+        # (Driving Dedendum); away = C (Pinion Dedendum).
         ded_cm = to_cm(1.25 * module)
-        # pitch line direction
-        pld = adsk.core.Vector3D.create(a2g.x - apexSeedX, a2g.y - apexSeedY, 0)
-        pld.normalize()
-        # perpendicular dirs
-        pp = (-pld.y, pld.x)
-        # toward anchor line = toward c
-        towardC = adsk.core.Vector3D.create(c.x - a2g.x, c.y - a2g.y, 0)
-        if (pp[0] * towardC.x + pp[1] * towardC.y) >= 0:
-            dirToD = pp
-            dirToC = (-pp[0], -pp[1])
+        ap2 = apex2seedA
+        # pitch direction apex->apex2
+        pitchDir = _norm2((ap2[0] - apex2d[0], ap2[1] - apex2d[1]))
+        pitchPerp = (-pitchDir[1], pitchDir[0])
+        # "toward the anchor line" = -perp (grow direction points away from it).
+        towardAnchor = (-perp[0], -perp[1])
+        if (pitchPerp[0] * towardAnchor[0] + pitchPerp[1] * towardAnchor[1]) >= 0:
+            dDir = pitchPerp
+            cDir = (-pitchPerp[0], -pitchPerp[1])
         else:
-            dirToD = (-pp[0], -pp[1])
-            dirToC = pp
-        # Driving Gear Dedendum -> point D (toward anchor line)
-        dSeed = (a2g.x + dirToD[0] * ded_cm, a2g.y + dirToD[1] * ded_cm)
-        drivingDedendum = lines.addByTwoPoints(P(a2g.x, a2g.y), P(dSeed[0], dSeed[1]))
+            dDir = (-pitchPerp[0], -pitchPerp[1])
+            cDir = pitchPerp
+
+        Dseed = (ap2[0] + dDir[0] * ded_cm, ap2[1] + dDir[1] * ded_cm)
+        drivingDedendum = lines.addByTwoPoints(
+            adsk.core.Point3D.create(ap2[0], ap2[1], 0),
+            adsk.core.Point3D.create(Dseed[0], Dseed[1], 0))
         drivingDedendum.isConstruction = True
-        constraints.addCoincident(drivingDedendum.startSketchPoint, apex2)
-        constraints.addPerpendicular(drivingDedendum, pitchLine)
-        dimensions.addDistanceDimension(
+        gc.addCoincident(drivingDedendum.startSketchPoint, apex2Point)
+        gc.addPerpendicular(drivingDedendum, pitchLine)
+        dims.addDistanceDimension(
             drivingDedendum.startSketchPoint, drivingDedendum.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            P(dSeed[0], dSeed[1])).parameter.value = ded_cm
+            adsk.core.Point3D.create(
+                (ap2[0] + Dseed[0]) / 2.0, (ap2[1] + Dseed[1]) / 2.0 + 0.1, 0)
+        ).parameter.value = ded_cm
         pointD = drivingDedendum.endSketchPoint
-        # Pinion Gear Dedendum -> point C (away from anchor line)
-        cSeed = (a2g.x + dirToC[0] * ded_cm, a2g.y + dirToC[1] * ded_cm)
-        pinionDedendum = lines.addByTwoPoints(P(a2g.x, a2g.y), P(cSeed[0], cSeed[1]))
+
+        Cseed = (ap2[0] + cDir[0] * ded_cm, ap2[1] + cDir[1] * ded_cm)
+        pinionDedendum = lines.addByTwoPoints(
+            adsk.core.Point3D.create(ap2[0], ap2[1], 0),
+            adsk.core.Point3D.create(Cseed[0], Cseed[1], 0))
         pinionDedendum.isConstruction = True
-        constraints.addCoincident(pinionDedendum.startSketchPoint, apex2)
-        constraints.addPerpendicular(pinionDedendum, pitchLine)
-        dimensions.addDistanceDimension(
+        gc.addCoincident(pinionDedendum.startSketchPoint, apex2Point)
+        gc.addPerpendicular(pinionDedendum, pitchLine)
+        dims.addDistanceDimension(
             pinionDedendum.startSketchPoint, pinionDedendum.endSketchPoint,
             adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-            P(cSeed[0], cSeed[1])).parameter.value = ded_cm
+            adsk.core.Point3D.create(
+                (ap2[0] + Cseed[0]) / 2.0, (ap2[1] + Cseed[1]) / 2.0 + 0.1, 0)
+        ).parameter.value = ded_cm
         pointC = pinionDedendum.endSketchPoint
 
-        # ---- Root Axes: Apex -> D (driving), Apex -> C (pinion) ----
-        dg = pointD.geometry
-        cg2 = pointC.geometry
-        drivingRootAxis = lines.addByTwoPoints(P(apexSeedX, apexSeedY), P(dg.x, dg.y))
+        # Root Axes: Apex -> D (driving), Apex -> C (pinion).
+        drivingRootAxis = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apex2d[0], apex2d[1], 0),
+            adsk.core.Point3D.create(Dseed[0], Dseed[1], 0))
         drivingRootAxis.isConstruction = True
-        constraints.addCoincident(drivingRootAxis.startSketchPoint, apex)
-        constraints.addCoincident(drivingRootAxis.endSketchPoint, pointD)
-        pinionRootAxis = lines.addByTwoPoints(P(apexSeedX, apexSeedY), P(cg2.x, cg2.y))
-        pinionRootAxis.isConstruction = True
-        constraints.addCoincident(pinionRootAxis.startSketchPoint, apex)
-        constraints.addCoincident(pinionRootAxis.endSketchPoint, pointC)
+        gc.addCoincident(drivingRootAxis.startSketchPoint, apexPoint)
+        gc.addCoincident(drivingRootAxis.endSketchPoint, pointD)
 
+        pinionRootAxis = lines.addByTwoPoints(
+            adsk.core.Point3D.create(apex2d[0], apex2d[1], 0),
+            adsk.core.Point3D.create(Cseed[0], Cseed[1], 0))
+        pinionRootAxis.isConstruction = True
+        gc.addCoincident(pinionRootAxis.startSketchPoint, apexPoint)
+        gc.addCoincident(pinionRootAxis.endSketchPoint, pointC)
+
+        # Module-length extensions.
         mod_cm = to_cm(module)
 
-        # ---- A->E : collinear with Apex->A, length module (undimensioned) ----
-        # seed E one module beyond A along Apex->A direction
-        aSeedDir = (paxd_x, paxd_y)  # unit Apex->A
-        eSeed = (ag.x + aSeedDir[0] * mod_cm, ag.y + aSeedDir[1] * mod_cm)
-        lineAE = lines.addByTwoPoints(P(ag.x, ag.y), P(eSeed[0], eSeed[1]))
-        lineAE.isConstruction = True
-        constraints.addCoincident(lineAE.startSketchPoint, pointA)
-        constraints.addCollinear(lineAE, pinionShaftAxis)
+        def collinear_ext(fromPoint, alongLine, dirVec, baseSeed):
+            seed = (baseSeed[0] + dirVec[0] * mod_cm,
+                    baseSeed[1] + dirVec[1] * mod_cm)
+            ln = lines.addByTwoPoints(
+                adsk.core.Point3D.create(baseSeed[0], baseSeed[1], 0),
+                adsk.core.Point3D.create(seed[0], seed[1], 0))
+            ln.isConstruction = True
+            gc.addCoincident(ln.startSketchPoint, fromPoint)
+            gc.addCollinear(ln, alongLine)
+            return ln, seed
+
+        # A -> E along Apex->A.
+        aDirOut = _norm2((Aseed[0] - apex2d[0], Aseed[1] - apex2d[1]))
+        lineAE, Eseed = collinear_ext(pointA, pinionShaft, aDirOut, Aseed)
         pointE = lineAE.endSketchPoint
 
-        # ---- C->E : perpendicular to A->E ----
-        eg = pointE.geometry
-        lineCE = lines.addByTwoPoints(P(cg2.x, cg2.y), P(eg.x, eg.y))
+        # C -> E perpendicular to A->E.
+        lineCE = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Cseed[0], Cseed[1], 0),
+            adsk.core.Point3D.create(Eseed[0], Eseed[1], 0))
         lineCE.isConstruction = True
-        constraints.addCoincident(lineCE.startSketchPoint, pointC)
-        constraints.addCoincident(lineCE.endSketchPoint, pointE)
-        constraints.addPerpendicular(lineAE, lineCE)
+        gc.addCoincident(lineCE.startSketchPoint, pointC)
+        gc.addCoincident(lineCE.endSketchPoint, pointE)
+        gc.addPerpendicular(lineAE, lineCE)
 
-        # ---- B->F : collinear with Apex->B, length module ----
-        bAxisDir = (dbxd_x, dbxd_y)  # unit Apex->B
-        fSeed = (bg.x + bAxisDir[0] * mod_cm, bg.y + bAxisDir[1] * mod_cm)
-        lineBF = lines.addByTwoPoints(P(bg.x, bg.y), P(fSeed[0], fSeed[1]))
-        lineBF.isConstruction = True
-        constraints.addCoincident(lineBF.startSketchPoint, pointB)
-        constraints.addCollinear(lineBF, drivingShaftAxis)
+        # B -> F along Apex->B.
+        bDirOut = _norm2((Bseed[0] - apex2d[0], Bseed[1] - apex2d[1]))
+        lineBF, Fseed = collinear_ext(pointB, drivingShaft, bDirOut, Bseed)
         pointF = lineBF.endSketchPoint
 
-        # ---- D->F : perpendicular to B->F ----
-        fg = pointF.geometry
-        lineDF = lines.addByTwoPoints(P(dg.x, dg.y), P(fg.x, fg.y))
+        # D -> F perpendicular to B->F.
+        lineDF = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Dseed[0], Dseed[1], 0),
+            adsk.core.Point3D.create(Fseed[0], Fseed[1], 0))
         lineDF.isConstruction = True
-        constraints.addCoincident(lineDF.startSketchPoint, pointD)
-        constraints.addCoincident(lineDF.endSketchPoint, pointF)
-        constraints.addPerpendicular(lineBF, lineDF)
+        gc.addCoincident(lineDF.startSketchPoint, pointD)
+        gc.addCoincident(lineDF.endSketchPoint, pointF)
+        gc.addPerpendicular(lineBF, lineDF)
 
-        # ---- E->G : collinear to A->E, length module ----
-        gSeed = (eg.x + aSeedDir[0] * mod_cm, eg.y + aSeedDir[1] * mod_cm)
-        lineEG = lines.addByTwoPoints(P(eg.x, eg.y), P(gSeed[0], gSeed[1]))
-        lineEG.isConstruction = True
-        constraints.addCoincident(lineEG.startSketchPoint, pointE)
-        constraints.addCollinear(lineEG, lineAE)
+        # E -> G collinear to A->E.
+        lineEG, Gseed = collinear_ext(pointE, lineAE, aDirOut, Eseed)
         pointG = lineEG.endSketchPoint
 
-        # ---- C->H : length module, collinear with Apex2->C ----
-        # direction Apex2 -> C
-        a2cDir = (dirToC[0], dirToC[1])
-        hSeed = (cg2.x + a2cDir[0] * mod_cm, cg2.y + a2cDir[1] * mod_cm)
-        lineCH = lines.addByTwoPoints(P(cg2.x, cg2.y), P(hSeed[0], hSeed[1]))
+        # C -> H collinear to Apex2->C (pinion dedendum line).
+        Hseed = (Cseed[0] + cDir[0] * mod_cm, Cseed[1] + cDir[1] * mod_cm)
+        lineCH = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Cseed[0], Cseed[1], 0),
+            adsk.core.Point3D.create(Hseed[0], Hseed[1], 0))
         lineCH.isConstruction = True
-        constraints.addCoincident(lineCH.startSketchPoint, pointC)
-        constraints.addCollinear(lineCH, pinionDedendum)
+        gc.addCoincident(lineCH.startSketchPoint, pointC)
+        gc.addCollinear(lineCH, pinionDedendum)
         pointH = lineCH.endSketchPoint
 
-        # ---- G->H : connect, perpendicular E->G and H->G ----
-        gg = pointG.geometry
-        hg = pointH.geometry
-        lineGH = lines.addByTwoPoints(P(gg.x, gg.y), P(hg.x, hg.y))
+        # G -> H, with E->G perpendicular to H->G.
+        lineGH = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Gseed[0], Gseed[1], 0),
+            adsk.core.Point3D.create(Hseed[0], Hseed[1], 0))
         lineGH.isConstruction = True
-        constraints.addCoincident(lineGH.startSketchPoint, pointG)
-        constraints.addCoincident(lineGH.endSketchPoint, pointH)
-        constraints.addPerpendicular(lineEG, lineGH)
+        gc.addCoincident(lineGH.startSketchPoint, pointG)
+        gc.addCoincident(lineGH.endSketchPoint, pointH)
+        gc.addPerpendicular(lineEG, lineGH)
 
-        # ---- F->I : collinear to B->F, length module ----
-        iSeed = (fg.x + bAxisDir[0] * mod_cm, fg.y + bAxisDir[1] * mod_cm)
-        lineFI = lines.addByTwoPoints(P(fg.x, fg.y), P(iSeed[0], iSeed[1]))
-        lineFI.isConstruction = True
-        constraints.addCoincident(lineFI.startSketchPoint, pointF)
-        constraints.addCollinear(lineFI, lineBF)
+        # F -> I collinear to B->F.
+        lineFI, Iseed = collinear_ext(pointF, lineBF, bDirOut, Fseed)
         pointI = lineFI.endSketchPoint
 
-        # ---- D->J : length module, collinear with Apex2->D ----
-        a2dDir = (dirToD[0], dirToD[1])
-        jSeed = (dg.x + a2dDir[0] * mod_cm, dg.y + a2dDir[1] * mod_cm)
-        lineDJ = lines.addByTwoPoints(P(dg.x, dg.y), P(jSeed[0], jSeed[1]))
+        # D -> J collinear to Apex2->D (driving dedendum line).
+        Jseed = (Dseed[0] + dDir[0] * mod_cm, Dseed[1] + dDir[1] * mod_cm)
+        lineDJ = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Dseed[0], Dseed[1], 0),
+            adsk.core.Point3D.create(Jseed[0], Jseed[1], 0))
         lineDJ.isConstruction = True
-        constraints.addCoincident(lineDJ.startSketchPoint, pointD)
-        constraints.addCollinear(lineDJ, drivingDedendum)
+        gc.addCoincident(lineDJ.startSketchPoint, pointD)
+        gc.addCollinear(lineDJ, drivingDedendum)
         pointJ = lineDJ.endSketchPoint
 
-        # ---- I->J : connect, perpendicular F->I and J->I ----
-        ig = pointI.geometry
-        jg = pointJ.geometry
-        lineIJ = lines.addByTwoPoints(P(ig.x, ig.y), P(jg.x, jg.y))
+        # I -> J, with F->I perpendicular to J->I.
+        lineIJ = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Iseed[0], Iseed[1], 0),
+            adsk.core.Point3D.create(Jseed[0], Jseed[1], 0))
         lineIJ.isConstruction = True
-        constraints.addCoincident(lineIJ.startSketchPoint, pointI)
-        constraints.addCoincident(lineIJ.endSketchPoint, pointJ)
-        constraints.addPerpendicular(lineFI, lineIJ)
+        gc.addCoincident(lineIJ.startSketchPoint, pointI)
+        gc.addCoincident(lineIJ.endSketchPoint, pointJ)
+        gc.addPerpendicular(lineFI, lineIJ)
 
-        # ---- offset dim between B->Apex2 drop (dropB) and J->I, = driving base height ----
-        if self._drivingBaseHeight_cm > 0:
-            drivingBaseHeight_cm = self._drivingBaseHeight_cm
-        else:
+        # Driving base-height offset: between B->Apex2 drop and J->I.
+        drivingBaseHeight_cm = self._drivingBaseHeight_cm
+        if drivingBaseHeight_cm <= 0:
             drivingBaseHeight_cm = to_cm(module * drivingTeeth / 8.0)
-        dimensions.addOffsetDimension(
-            dropB, lineIJ, P(ig.x, ig.y)).parameter.value = drivingBaseHeight_cm
+        dims.addOffsetDimension(
+            bToApex2, lineIJ,
+            adsk.core.Point3D.create(
+                (Jseed[0] + apex2seedB[0]) / 2.0,
+                (Jseed[1] + apex2seedB[1]) / 2.0, 0)
+        ).parameter.value = drivingBaseHeight_cm
 
-        # ---- offset dim between A->Apex2 drop (dropA) and G->H, = pinion base height ----
-        if self._pinionBaseHeight_cm > 0:
-            pinionBaseHeight_cm = self._pinionBaseHeight_cm
-        else:
-            pinionBaseHeight_cm = drivingBaseHeight_cm * (pinionTeeth / drivingTeeth)
-        dimensions.addOffsetDimension(
-            dropA, lineGH, P(gg.x, gg.y)).parameter.value = pinionBaseHeight_cm
+        # Pinion base-height offset: between A->Apex2 drop and G->H.
+        pinionBaseHeight_cm = self._pinionBaseHeight_cm
+        if pinionBaseHeight_cm <= 0:
+            pinionBaseHeight_cm = drivingBaseHeight_cm * (
+                pinionTeeth / float(drivingTeeth))
+        dims.addOffsetDimension(
+            aToApex2, lineGH,
+            adsk.core.Point3D.create(
+                (Hseed[0] + apex2seedA[0]) / 2.0,
+                (Hseed[1] + apex2seedA[1]) / 2.0, 0)
+        ).parameter.value = pinionBaseHeight_cm
 
-        # ---- A->G connector ----
-        lineAG = lines.addByTwoPoints(P(ag.x, ag.y), P(gg.x, gg.y))
+        # Line A -> G.
+        lineAG = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Aseed[0], Aseed[1], 0),
+            adsk.core.Point3D.create(Gseed[0], Gseed[1], 0))
         lineAG.isConstruction = True
-        constraints.addCoincident(lineAG.startSketchPoint, pointA)
-        constraints.addCoincident(lineAG.endSketchPoint, pointG)
+        gc.addCoincident(lineAG.startSketchPoint, pointA)
+        gc.addCoincident(lineAG.endSketchPoint, pointG)
 
-        # ---- Constrain Point I with center point ----
-        constraints.addCoincident(pointI, projectedCenter)
+        # Constrain point I with the (projected) center point.
+        gc.addCoincident(pointI, c_pt)
 
-        # ---- K: point on Apex->A and on Pinion Dedendum (Apex2->C extended) ----
-        # seed K near intersection of Apex->A extended and dedendum line
-        kSeed = (gg.x, gg.y)
-        lineGK = lines.addByTwoPoints(P(gg.x, gg.y), P(kSeed[0] + aSeedDir[0] * mod_cm,
-                                                      kSeed[1] + aSeedDir[1] * mod_cm))
-        lineGK.isConstruction = True
-        constraints.addCoincident(lineGK.startSketchPoint, pointG)
-        pointK = lineGK.endSketchPoint
-        constraints.addCoincident(pointK, pinionShaftAxis)
-        constraints.addCoincident(pointK, pinionDedendum)
-        kg = pointK.geometry
-        # reference line C->K
-        lineCK = lines.addByTwoPoints(P(cg2.x, cg2.y), P(kg.x, kg.y))
-        lineCK.isConstruction = True
-        constraints.addCoincident(lineCK.startSketchPoint, pointC)
-        constraints.addCoincident(lineCK.endSketchPoint, pointK)
-
-        # ---- K' tooth-center (Tooth Spacing offset) ----
-        pinionCenterRefLine = lineCK
-        pinionCenterPoint = pointK
-        if self._toothSpacing_cm > 0:
-            # direction C -> K (away from C, the lower corner) along dedendum
-            ckdir = adsk.core.Vector3D.create(kg.x - cg2.x, kg.y - cg2.y, 0)
-            ckdir.normalize()
-            kpSeed = (kg.x + ckdir.x * self._toothSpacing_cm,
-                      kg.y + ckdir.y * self._toothSpacing_cm)
-            lineKKp = lines.addByTwoPoints(P(kg.x, kg.y), P(kpSeed[0], kpSeed[1]))
-            lineKKp.isConstruction = True
-            constraints.addCoincident(lineKKp.startSketchPoint, pointK)
-            pointKp = lineKKp.endSketchPoint
-            constraints.addCoincident(pointKp, pinionDedendum)
-            dimensions.addDistanceDimension(
-                lineKKp.startSketchPoint, lineKKp.endSketchPoint,
-                adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-                P(kpSeed[0], kpSeed[1])).parameter.value = self._toothSpacing_cm
-            kpg = pointKp.geometry
-            lineCKp = lines.addByTwoPoints(P(cg2.x, cg2.y), P(kpg.x, kpg.y))
-            lineCKp.isConstruction = True
-            constraints.addCoincident(lineCKp.startSketchPoint, pointC)
-            constraints.addCoincident(lineCKp.endSketchPoint, pointKp)
-            pinionCenterRefLine = lineCKp
-            pinionCenterPoint = pointKp
-
-        # ---- Maximum Face Width from SOLVED geometry ----
-        maxFaceWidth_cm = self._computeMaxFaceWidth(
-            pointA, pointB, pointC, pointD, pointH, pointJ)
-        # Apply the Face Width bound.
-        if self._faceWidth_cm > 0:
-            if self._faceWidth_cm > maxFaceWidth_cm:
-                raise Exception(
-                    f'Face Width exceeds maximum allowed ({to_mm(maxFaceWidth_cm):.3f} mm)')
-            faceWidth_cm = self._faceWidth_cm
-        else:
-            faceWidth_cm = min(self._coneDistance_cm / 6.0, maxFaceWidth_cm)
-        self._resolvedFaceWidth_cm = faceWidth_cm
-
-        # ---- M->N (pinion toe line) ----
-        # seed M near midpoint of Apex->C, N slid along C->H toward line A->Apex2
-        apexG = apex.geometry
-        mSeedX = (apexG.x + cg2.x) / 2.0
-        mSeedY = (apexG.y + cg2.y) / 2.0
-        # C->H direction
-        chdir = adsk.core.Vector3D.create(hg.x - cg2.x, hg.y - cg2.y, 0)
-        chdir.normalize()
-        # distance from M-seed to A as the slide amount
-        slideMN = math.hypot(ag.x - mSeedX, ag.y - mSeedY)
-        nSeedX = mSeedX + chdir.x * slideMN
-        nSeedY = mSeedY + chdir.y * slideMN
-        lineMN = lines.addByTwoPoints(P(mSeedX, mSeedY), P(nSeedX, nSeedY))
-        lineMN.isConstruction = True
-        pointM = lineMN.startSketchPoint
-        pointN = lineMN.endSketchPoint
-        constraints.addCoincident(pointM, pinionRootAxis)
-        constraints.addCoincident(pointN, dropA)
-        constraints.addParallel(lineMN, lineCH)
-        dimensions.addOffsetDimension(
-            lineCH, lineMN, P(nSeedX, nSeedY)).parameter.value = faceWidth_cm
-        mg = pointM.geometry
-        ng = pointN.geometry
-        # M->C and N->A reference lines
-        lineMC = lines.addByTwoPoints(P(mg.x, mg.y), P(cg2.x, cg2.y))
-        lineMC.isConstruction = True
-        constraints.addCoincident(lineMC.startSketchPoint, pointM)
-        constraints.addCoincident(lineMC.endSketchPoint, pointC)
-        lineNA = lines.addByTwoPoints(P(ng.x, ng.y), P(ag.x, ag.y))
-        lineNA.isConstruction = True
-        constraints.addCoincident(lineNA.startSketchPoint, pointN)
-        constraints.addCoincident(lineNA.endSketchPoint, pointA)
-
-        # ---- L: point on Apex->B and on Driving Dedendum (Apex2->D extended) ----
-        lineIL = lines.addByTwoPoints(P(ig.x, ig.y), P(ig.x + bAxisDir[0] * mod_cm,
-                                                      ig.y + bAxisDir[1] * mod_cm))
-        lineIL.isConstruction = True
-        constraints.addCoincident(lineIL.startSketchPoint, pointI)
-        pointL = lineIL.endSketchPoint
-        constraints.addCoincident(pointL, drivingShaftAxis)
-        constraints.addCoincident(pointL, drivingDedendum)
-        lg = pointL.geometry
-        lineDL = lines.addByTwoPoints(P(dg.x, dg.y), P(lg.x, lg.y))
-        lineDL.isConstruction = True
-        constraints.addCoincident(lineDL.startSketchPoint, pointD)
-        constraints.addCoincident(lineDL.endSketchPoint, pointL)
-
-        # ---- L' tooth-center ----
-        drivingCenterRefLine = lineDL
-        drivingCenterPoint = pointL
-        if self._toothSpacing_cm > 0:
-            dldir = adsk.core.Vector3D.create(lg.x - dg.x, lg.y - dg.y, 0)
-            dldir.normalize()
-            lpSeed = (lg.x + dldir.x * self._toothSpacing_cm,
-                      lg.y + dldir.y * self._toothSpacing_cm)
-            lineLLp = lines.addByTwoPoints(P(lg.x, lg.y), P(lpSeed[0], lpSeed[1]))
-            lineLLp.isConstruction = True
-            constraints.addCoincident(lineLLp.startSketchPoint, pointL)
-            pointLp = lineLLp.endSketchPoint
-            constraints.addCoincident(pointLp, drivingDedendum)
-            dimensions.addDistanceDimension(
-                lineLLp.startSketchPoint, lineLLp.endSketchPoint,
-                adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-                P(lpSeed[0], lpSeed[1])).parameter.value = self._toothSpacing_cm
-            lpg = pointLp.geometry
-            lineDLp = lines.addByTwoPoints(P(dg.x, dg.y), P(lpg.x, lpg.y))
-            lineDLp.isConstruction = True
-            constraints.addCoincident(lineDLp.startSketchPoint, pointD)
-            constraints.addCoincident(lineDLp.endSketchPoint, pointLp)
-            drivingCenterRefLine = lineDLp
-            drivingCenterPoint = pointLp
-
-        # ---- O->P (driving toe line) ----
-        oSeedX = (apexG.x + dg.x) / 2.0
-        oSeedY = (apexG.y + dg.y) / 2.0
-        djdir = adsk.core.Vector3D.create(jg.x - dg.x, jg.y - dg.y, 0)
-        djdir.normalize()
-        slideOP = math.hypot(bg.x - oSeedX, bg.y - oSeedY)
-        pSeedX = oSeedX + djdir.x * slideOP
-        pSeedY = oSeedY + djdir.y * slideOP
-        lineOP = lines.addByTwoPoints(P(oSeedX, oSeedY), P(pSeedX, pSeedY))
-        lineOP.isConstruction = True
-        pointO = lineOP.startSketchPoint
-        pointP = lineOP.endSketchPoint
-        constraints.addCoincident(pointO, drivingRootAxis)
-        constraints.addCoincident(pointP, dropB)
-        constraints.addParallel(lineOP, lineDJ)
-        dimensions.addOffsetDimension(
-            lineDJ, lineOP, P(pSeedX, pSeedY)).parameter.value = faceWidth_cm
-        og = pointO.geometry
-        pg = pointP.geometry
-        lineOD = lines.addByTwoPoints(P(og.x, og.y), P(dg.x, dg.y))
-        lineOD.isConstruction = True
-        constraints.addCoincident(lineOD.startSketchPoint, pointO)
-        constraints.addCoincident(lineOD.endSketchPoint, pointD)
-        linePB = lines.addByTwoPoints(P(pg.x, pg.y), P(bg.x, bg.y))
-        linePB.isConstruction = True
-        constraints.addCoincident(linePB.startSketchPoint, pointP)
-        constraints.addCoincident(linePB.endSketchPoint, pointB)
-        lineBI = lines.addByTwoPoints(P(bg.x, bg.y), P(ig.x, ig.y))
+        # Line B -> I.
+        lineBI = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Bseed[0], Bseed[1], 0),
+            adsk.core.Point3D.create(Iseed[0], Iseed[1], 0))
         lineBI.isConstruction = True
-        constraints.addCoincident(lineBI.startSketchPoint, pointB)
-        constraints.addCoincident(lineBI.endSketchPoint, pointI)
+        gc.addCoincident(lineBI.startSketchPoint, pointB)
+        gc.addCoincident(lineBI.endSketchPoint, pointI)
 
-        # ---- full-constraint gate on the Gear Profiles sketch ----
+        # K (pinion): from G along Apex->A, end pinned to Apex->A and the
+        # pinion dedendum line (Apex2->C extended).
+        Kseed = (Gseed[0] + aDirOut[0] * mod_cm, Gseed[1] + aDirOut[1] * mod_cm)
+        lineGK = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Gseed[0], Gseed[1], 0),
+            adsk.core.Point3D.create(Kseed[0], Kseed[1], 0))
+        lineGK.isConstruction = True
+        gc.addCoincident(lineGK.startSketchPoint, pointG)
+        pointK = lineGK.endSketchPoint
+        gc.addCoincident(pointK, pinionShaft)
+        gc.addCoincident(pointK, pinionDedendum)
+        # Reference line C -> K.
+        lineCK = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Cseed[0], Cseed[1], 0),
+            adsk.core.Point3D.create(Kseed[0], Kseed[1], 0))
+        lineCK.isConstruction = True
+        gc.addCoincident(lineCK.startSketchPoint, pointC)
+        gc.addCoincident(lineCK.endSketchPoint, pointK)
+
+        # K' tooth-center (Tooth Spacing offset along the dedendum, away from C).
+        pointKp, lineCKp = self._buildToothCenter(
+            sketch, pointK, pointC, pinionDedendum, Cseed, Kseed, cDir)
+
+        # L (driving): from I along Apex->B, pinned to Apex->B and the driving
+        # dedendum line (Apex2->D extended).
+        Lseed = (Iseed[0] + bDirOut[0] * mod_cm, Iseed[1] + bDirOut[1] * mod_cm)
+        lineIL = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Iseed[0], Iseed[1], 0),
+            adsk.core.Point3D.create(Lseed[0], Lseed[1], 0))
+        lineIL.isConstruction = True
+        gc.addCoincident(lineIL.startSketchPoint, pointI)
+        pointL = lineIL.endSketchPoint
+        gc.addCoincident(pointL, drivingShaft)
+        gc.addCoincident(pointL, drivingDedendum)
+        lineDL = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Dseed[0], Dseed[1], 0),
+            adsk.core.Point3D.create(Lseed[0], Lseed[1], 0))
+        lineDL.isConstruction = True
+        gc.addCoincident(lineDL.startSketchPoint, pointD)
+        gc.addCoincident(lineDL.endSketchPoint, pointL)
+
+        pointLp, lineDLp = self._buildToothCenter(
+            sketch, pointL, pointD, drivingDedendum, Dseed, Lseed, dDir)
+
+        # --- Maximum Face Width from SOLVED geometry ([PB-SOLVED-GEOMETRY]) ---
+        gA = pointA.geometry
+        gB = pointB.geometry
+        gC = pointC.geometry
+        gD = pointD.geometry
+        gH = pointH.geometry
+        gJ = pointJ.geometry
+        distA = self._perpDistPointToLine(
+            (gA.x, gA.y), (gC.x, gC.y), (gH.x, gH.y))
+        distB = self._perpDistPointToLine(
+            (gB.x, gB.y), (gD.x, gD.y), (gJ.x, gJ.y))
+        maxFaceWidth_cm = 0.95 * min(distA, distB)
+
+        faceWidth_cm = self._faceWidth_cm
+        if faceWidth_cm <= 0:
+            faceWidth_cm = min(self._coneDistance_cm / 6.0, maxFaceWidth_cm)
+        elif faceWidth_cm > maxFaceWidth_cm:
+            raise Exception(
+                'Face Width %.4f cm exceeds the maximum %.4f cm' % (
+                    faceWidth_cm, maxFaceWidth_cm))
+        self._faceWidthResolved_cm = faceWidth_cm
+
+        # M -> N (pinion toe line).
+        pointM, pointN = self._buildToeLine(
+            sketch, pinionRootAxis, aToApex2, lineCH, pointC, pointA,
+            (gC.x, gC.y), (gH.x, gH.y), apex2d, faceWidth_cm)
+
+        # O -> P (driving toe line).
+        pointO, pointP = self._buildToeLine(
+            sketch, drivingRootAxis, bToApex2, lineDJ, pointD, pointB,
+            (gD.x, gD.y), (gJ.x, gJ.y), apex2d, faceWidth_cm)
+
+        # B -> I already drawn above (spec also lists "draw line from B to I"
+        # in the O->P paragraph; it is the same single line — created once,
+        # [BEVEL-F-LINE-ONCE]).
+
+        # Full-constraint gate for the permanent Gear Profiles sketch.
         if not sketch.isFullyConstrained:
             raise Exception('Gear Profiles sketch is not fully constrained')
 
-        # ---- world apex sketch point for lofts ----
-        self._apexSketchPoint = apex
+        # Stash everything the per-gear body steps need.
+        self._gpSketch = sketch
+        self._apexSketchPoint = apexPoint
+        self._apex2d = apex2d
 
-        # ===================================================================
-        # §3 + per-gear bodies (pinion first, then driving)
-        # ===================================================================
-        # Pinion
-        pinionProfile = self._buildVirtualSpurProfile(
-            designComponent, sketch, gearProfilesPlane,
-            module, self._pinionTeeth, self._gamma_p,
-            pinionCenterRefLine, pinionCenterPoint, 'Pinion')
-        self._createGearBody(
-            designComponent, designOccurrence, bevelComponent,
-            sketch, gearProfilesPlane, apex,
-            'Pinion', self._pinionTeeth, pinionBore_cm,
-            [pointA, pointG, pointH, pointC, pointM, pointN],
-            (pointM, pointN), (pointC, pointH),
-            pinionProfile, isDriving=False)
+        # §3 + per-gear bodies: pinion first, driving second.
+        pinionCtx = {
+            'gearLabel': 'Pinion',
+            'teeth': pinionTeeth,
+            'pitchDia_cm': ppd_cm,
+            'gamma': self._gamma_p,
+            'toothCenterPoint': pointKp,
+            'toothCenterRefLine': lineCKp,
+            'hexVerts': [pointA, pointG, pointH, pointC, pointM, pointN],
+            'shaftEdgePoints': (pointA, pointG),
+            'toeEdge': (pointM, pointN),
+            'heelEdge': (pointC, pointH),
+            'toeConePoint': pointM,
+            'heelConePoint': pointC,
+            'rootAxis': pinionRootAxis,
+            'boreDia_cm': pinionBoreDia_cm,
+            'meshAngle': self._pinionMeshPhase(pinionTeeth),
+        }
+        drivingCtx = {
+            'gearLabel': 'Driving',
+            'teeth': drivingTeeth,
+            'pitchDia_cm': dpd_cm,
+            'gamma': self._gamma_g,
+            'toothCenterPoint': pointLp,
+            'toothCenterRefLine': lineDLp,
+            'hexVerts': [pointB, pointI, pointJ, pointD, pointO, pointP],
+            'shaftEdgePoints': (pointB, pointI),
+            'toeEdge': (pointO, pointP),
+            'heelEdge': (pointD, pointJ),
+            'toeConePoint': pointO,
+            'heelConePoint': pointD,
+            'rootAxis': drivingRootAxis,
+            'boreDia_cm': drivingBoreDia_cm,
+            'meshAngle': math.radians(180.0) / drivingTeeth,
+        }
 
-        # Driving
-        drivingProfile = self._buildVirtualSpurProfile(
-            designComponent, sketch, gearProfilesPlane,
-            module, self._drivingTeeth, self._gamma_g,
-            drivingCenterRefLine, drivingCenterPoint, 'Driving')
-        self._createGearBody(
-            designComponent, designOccurrence, bevelComponent,
-            sketch, gearProfilesPlane, apex,
-            'Driving', self._drivingTeeth, drivingBore_cm,
-            [pointB, pointI, pointJ, pointD, pointO, pointP],
-            (pointO, pointP), (pointD, pointJ),
-            drivingProfile, isDriving=True)
+        for ctx in (pinionCtx, drivingCtx):
+            self._buildVirtualSpurProfile(designComponent, module, ctx)
+            self._createGearBody(designComponent, module, ctx)
 
-    def _computeMaxFaceWidth(self, pointA, pointB, pointC, pointD, pointH, pointJ):
-        # perpendicular distance from A to line through C and H (pinion dedendum)
-        def perpDist(p, l0, l1):
-            pg = p.geometry
-            g0 = l0.geometry
-            g1 = l1.geometry
-            dx = g1.x - g0.x
-            dy = g1.y - g0.y
-            ln = math.hypot(dx, dy)
-            if ln == 0:
-                return float('inf')
-            # cross product magnitude / length
-            return abs((pg.x - g0.x) * dy - (pg.y - g0.y) * dx) / ln
-        dA = perpDist(pointA, pointC, pointH)
-        dB = perpDist(pointB, pointD, pointJ)
-        return 0.95 * min(dA, dB)
+    # -- Tooth-center (K' / L') --------------------------------------------
+    def _buildToothCenter(self, sketch, basePoint, lowerCorner, dedendumLine,
+                          cornerSeed, baseSeed, awayDir):
+        """Build the tooth-center point shifted from basePoint outward along the
+        dedendum line (away from lowerCorner) by Tooth Spacing. When spacing is
+        0, returns basePoint and the C->K / D->L reference line."""
+        lines = sketch.sketchCurves.sketchLines
+        gc = sketch.geometricConstraints
+        dims = sketch.sketchDimensions
+        spacing = self._toothSpacing_cm
+        if spacing <= 0:
+            # K' == K; reuse the C->K reference line (drawn by the caller).
+            refLine = lines.addByTwoPoints(
+                adsk.core.Point3D.create(cornerSeed[0], cornerSeed[1], 0),
+                adsk.core.Point3D.create(baseSeed[0], baseSeed[1], 0))
+            refLine.isConstruction = True
+            gc.addCoincident(refLine.startSketchPoint, lowerCorner)
+            gc.addCoincident(refLine.endSketchPoint, basePoint)
+            return basePoint, refLine
 
-    # =======================================================================
-    # §3 -- build the virtual spur tooth profile for one gear
-    # =======================================================================
-    def _buildVirtualSpurProfile(self, designComponent, gearProfilesSketch,
-                                 gearProfilesPlane, module, teeth, gamma,
-                                 centerRefLine, centerPoint, gearLabel):
-        # 1. virtual (back-cone) tooth number
-        thisPitchRadius_mm = (teeth * module) / 2.0
-        virtualPitchRadius_mm = thisPitchRadius_mm / math.cos(gamma)
+        kpSeed = (baseSeed[0] + awayDir[0] * spacing,
+                  baseSeed[1] + awayDir[1] * spacing)
+        offLine = lines.addByTwoPoints(
+            adsk.core.Point3D.create(baseSeed[0], baseSeed[1], 0),
+            adsk.core.Point3D.create(kpSeed[0], kpSeed[1], 0))
+        offLine.isConstruction = True
+        gc.addCoincident(offLine.startSketchPoint, basePoint)
+        kpPoint = offLine.endSketchPoint
+        gc.addCoincident(kpPoint, dedendumLine)
+        dims.addDistanceDimension(
+            offLine.startSketchPoint, offLine.endSketchPoint,
+            adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
+            adsk.core.Point3D.create(
+                (baseSeed[0] + kpSeed[0]) / 2.0,
+                (baseSeed[1] + kpSeed[1]) / 2.0 + 0.05, 0)
+        ).parameter.value = spacing
+        # Tooth-center reference line C->K' / D->L'.
+        refLine = lines.addByTwoPoints(
+            adsk.core.Point3D.create(cornerSeed[0], cornerSeed[1], 0),
+            adsk.core.Point3D.create(kpSeed[0], kpSeed[1], 0))
+        refLine.isConstruction = True
+        gc.addCoincident(refLine.startSketchPoint, lowerCorner)
+        gc.addCoincident(refLine.endSketchPoint, kpPoint)
+        return kpPoint, refLine
+
+    # -- Toe line (M->N / O->P) --------------------------------------------
+    def _buildToeLine(self, sketch, rootAxis, dropLine, heelLine,
+                      cornerPoint, axisPoint, cornerSeed, heelEndSeed,
+                      apex2d, faceWidth_cm):
+        lines = sketch.sketchCurves.sketchLines
+        gc = sketch.geometricConstraints
+        dims = sketch.sketchDimensions
+
+        # Seed M near midpoint of Apex->corner; seed N by sliding from M along
+        # corner->heelEnd direction far enough to roughly reach the drop line.
+        Mseed = ((apex2d[0] + cornerSeed[0]) / 2.0,
+                 (apex2d[1] + cornerSeed[1]) / 2.0)
+        chDir = _norm2(_sub2(heelEndSeed, cornerSeed))
+        aPt = axisPoint.geometry
+        distMtoA = math.hypot(Mseed[0] - aPt.x, Mseed[1] - aPt.y)
+        Nseed = (Mseed[0] + chDir[0] * distMtoA, Mseed[1] + chDir[1] * distMtoA)
+
+        toeLine = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Mseed[0], Mseed[1], 0),
+            adsk.core.Point3D.create(Nseed[0], Nseed[1], 0))
+        toeLine.isConstruction = True
+        pointM = toeLine.startSketchPoint
+        pointN = toeLine.endSketchPoint
+        gc.addCoincident(pointM, rootAxis)
+        gc.addCoincident(pointN, dropLine)
+        gc.addParallel(toeLine, heelLine)
+        textPt = ((Mseed[0] + cornerSeed[0]) / 2.0,
+                  (Mseed[1] + cornerSeed[1]) / 2.0)
+        dims.addOffsetDimension(
+            heelLine, toeLine,
+            adsk.core.Point3D.create(textPt[0], textPt[1], 0)
+        ).parameter.value = faceWidth_cm
+
+        # M -> corner, N -> axisPoint reference lines.
+        lineMC = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Mseed[0], Mseed[1], 0),
+            adsk.core.Point3D.create(cornerSeed[0], cornerSeed[1], 0))
+        lineMC.isConstruction = True
+        gc.addCoincident(lineMC.startSketchPoint, pointM)
+        gc.addCoincident(lineMC.endSketchPoint, cornerPoint)
+
+        aSeed = (aPt.x, aPt.y)
+        lineNA = lines.addByTwoPoints(
+            adsk.core.Point3D.create(Nseed[0], Nseed[1], 0),
+            adsk.core.Point3D.create(aSeed[0], aSeed[1], 0))
+        lineNA.isConstruction = True
+        gc.addCoincident(lineNA.startSketchPoint, pointN)
+        gc.addCoincident(lineNA.endSketchPoint, axisPoint)
+
+        return pointM, pointN
+
+    # -- §3: virtual spur tooth profile ------------------------------------
+    def _buildVirtualSpurProfile(self, designComponent, module, ctx):
+        gearLabel = ctx['gearLabel']
+        gamma = ctx['gamma']
+        toothCenterPoint = ctx['toothCenterPoint']
+        refLine = ctx['toothCenterRefLine']
+
+        # Virtual (back-cone / Tredgold) tooth number from closed form.
+        virtualPitchRadius_mm = (
+            (ctx['pitchDia_cm'] * 10.0 / 2.0) / math.cos(gamma))
         virtualTeeth = int(math.floor(2.0 * virtualPitchRadius_mm / module))
 
-        planes = designComponent.constructionPlanes
+        # Tooth plane: includes the tooth-center reference line, perpendicular
+        # to the Gear Profiles sketch plane.
+        toothPlane = plane_by_angle(
+            designComponent, refLine, self._gearProfilesPlane, 90)
+        toothPlane.name = '%s Plane' % gearLabel
 
-        # 2. plane that includes the tooth-center reference line, perpendicular
-        #    to the Gear Profiles sketch plane.
-        tpInput = planes.createInput()
-        tpInput.setByAngle(centerRefLine,
-                          adsk.core.ValueInput.createByString('90 deg'),
-                          gearProfilesPlane)
-        toothPlane = planes.add(tpInput)
-        toothPlane.name = f'{gearLabel} Plane'
-
-        # 3. create the spur tooth profile, rotated 180deg.
         toothSketch = designComponent.sketches.add(toothPlane)
-        toothSketch.name = f'{gearLabel} Tooth'
-        toothSketch.isVisible = True
+        toothSketch.name = '%s Tooth' % gearLabel
 
-        proxy = _VirtualSpurProxy(module_mm=module, virtualTeeth=virtualTeeth)
+        proxy = VirtualSpurProxy(module_mm=module, virtualTeeth=virtualTeeth)
         drawer = SpurGearInvoluteToothDesignGenerator(toothSketch, proxy)
-        # The tooth-center sketch point is the anchor for the draw projection.
-        drawer.draw(centerPoint, angle=math.radians(180))
+        drawer.draw(toothCenterPoint, angle=math.radians(180))
+
         embedded = proxy._lastToothEmbedded
 
         if not toothSketch.isFullyConstrained:
-            futil.log(f'{gearLabel} tooth sketch is not fully constrained (expected for embedded teeth)')
+            futil.log('%s Tooth sketch is not fully constrained '
+                      '(exempt from the gate)' % gearLabel)
 
-        # 4. construction axis through the tooth-center, normal to the tooth plane.
-        helperInput = planes.createInput()
-        helperInput.setByDistanceOnPath(centerRefLine,
-                                       adsk.core.ValueInput.createByReal(1.0))
-        helperPlane = planes.add(helperInput)
-        helperPlane.name = f'{gearLabel} Tooth Axis Helper'
-        axisInput = designComponent.constructionAxes.createInput()
-        axisInput.setByTwoPlanes(gearProfilesPlane, helperPlane)
-        toothAxis = designComponent.constructionAxes.add(axisInput)
-        toothAxis.name = f'{gearLabel} Tooth Axis'
+        # Tooth axis through the tooth-center point, normal to the tooth plane,
+        # via setByTwoPlanes ([PB-CONSTRUCTION-AXES]).
+        helperPlanes = designComponent.constructionPlanes
+        hpInput = helperPlanes.createInput()
+        hpInput.setByDistanceOnPath(
+            refLine, adsk.core.ValueInput.createByReal(1.0))
+        helperPlane = helperPlanes.add(hpInput)
 
-        return {
-            'toothSketch': toothSketch,
-            'toothPlane': toothPlane,
-            'toothAxis': toothAxis,
-            'embedded': embedded,
-            'virtualTeeth': virtualTeeth,
-            'gamma': gamma,
-        }
+        axes = designComponent.constructionAxes
+        axInput = axes.createInput()
+        axInput.setByTwoPlanes(self._gearProfilesPlane, helperPlane)
+        toothAxis = axes.add(axInput)
+        toothAxis.name = '%s Tooth Axis' % gearLabel
 
-    def _findSpurToothProfile(self, toothSketch, embedded):
-        wantLines = 0 if embedded else 2
-        Curve3DTypes = adsk.core.Curve3DTypes
-        for profile in toothSketch.profiles:
-            for loop in profile.profileLoops:
-                nurbs = arcs = linesN = others = 0
-                for pc in loop.profileCurves:
-                    ct = pc.geometry.curveType
-                    if ct == Curve3DTypes.NurbsCurve3DCurveType:
-                        nurbs += 1
-                    elif ct == Curve3DTypes.Arc3DCurveType:
-                        arcs += 1
-                    elif ct == Curve3DTypes.Line3DCurveType:
-                        linesN += 1
-                    else:
-                        others += 1
-                if nurbs == 2 and arcs == 2 and linesN == wantLines and others == 0:
-                    return profile
-        raise Exception(
-            f'Could not find spur tooth profile (2 NURBS + 2 arcs + {wantLines} lines)')
+        ctx['toothSketch'] = toothSketch
+        ctx['toothPlane'] = toothPlane
+        ctx['embedded'] = embedded
+        ctx['virtualTeeth'] = virtualTeeth
 
-    # =======================================================================
-    # Per-gear body creation
-    # =======================================================================
-    def _createGearBody(self, designComponent, designOccurrence, bevelComponent,
-                        gearProfilesSketch, gearProfilesPlane, apexSketchPoint,
-                        gearLabel, teethNumber, boreDiameter_cm,
-                        hexVertices, toeEdge, heelEdge,
-                        profileInfo, isDriving):
+    # -- Create the Gear Bodies --------------------------------------------
+    def _createGearBody(self, designComponent, module, ctx):
+        gearLabel = ctx['gearLabel']
         features = designComponent.features
 
-        # Output component for this gear, child of Bevel Gear.
-        gearOccurrence = bevelComponent.occurrences.addNewComponent(
+        # New component under Bevel Gear for the finished bodies.
+        gearOccurrence = self.bevelComponent.occurrences.addNewComponent(
             adsk.core.Matrix3D.create())
         gearComponent = gearOccurrence.component
-        gearComponent.name = f'{gearLabel} Gear'
+        gearComponent.name = '%s Gear' % gearLabel
 
-        # ---- Profile sketch (fresh, on the axial Gear Profiles plane) ----
-        profileSketch = designComponent.sketches.add(gearProfilesPlane)
-        profileSketch.name = f'{gearLabel} Profile'
-        profileSketch.isVisible = True
-        plines = profileSketch.sketchCurves.sketchLines
+        # Profile sketch on the axial (Gear Profiles) plane — one per gear.
+        profSketch = designComponent.sketches.add(self._gearProfilesPlane)
+        profSketch.name = '%s Profile' % gearLabel
+        lines = profSketch.sketchCurves.sketchLines
 
-        # recreate the six vertices as new points at their world-mapped positions
-        verts = []
-        for v in hexVertices:
-            local = profileSketch.modelToSketchSpace(v.worldGeometry)
-            verts.append(profileSketch.sketchPoints.add(local))
-        # draw the closed hexagon sharing those points
+        # Recreate the six §2 vertices as new points at their world positions
+        # ([PB-PROJECT-NOT-FIXED] recreate-share-fix recipe).
+        verts = [
+            profSketch.sketchPoints.add(
+                profSketch.modelToSketchSpace(v.worldGeometry))
+            for v in ctx['hexVerts']
+        ]
         hexLines = []
-        for i in range(len(verts)):
-            ln = plines.addByTwoPoints(verts[i], verts[(i + 1) % len(verts)])
-            hexLines.append(ln)
-        # fix the lines' endpoints AFTER the lines exist
+        n = len(verts)
+        for i in range(n):
+            hexLines.append(
+                lines.addByTwoPoints(verts[i], verts[(i + 1) % n]))
+        # Fix the lines' endpoints AFTER the lines exist.
         for ln in hexLines:
             ln.startSketchPoint.isFixed = True
             ln.endSketchPoint.isFixed = True
 
-        if not profileSketch.isFullyConstrained:
-            raise Exception(f'{gearLabel} Profile sketch is not fully constrained')
+        if not profSketch.isFullyConstrained:
+            raise Exception('%s Profile sketch is not fully constrained'
+                            % gearLabel)
 
-        # the shaft-axis edge is the hexagon's FIRST edge
-        shaftAxisEdge = hexLines[0]
+        shaftAxisEdge = hexLines[0]  # A->G (pinion) / B->I (driving).
 
-        # ---- Revolve the single hexagon profile around the shaft axis ----
-        profile = profileSketch.profiles.item(0)
-        revInput = features.revolveFeatures.createInput(
+        # Revolve the single profile around the shaft-axis edge -> Gear Body.
+        profile = profSketch.profiles.item(0)
+        revolves = features.revolveFeatures
+        revInput = revolves.createInput(
             profile, shaftAxisEdge,
             adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
-        revInput.setAngleExtent(False, adsk.core.ValueInput.createByString('360 deg'))
-        revolve = features.revolveFeatures.add(revInput)
+        revInput.setAngleExtent(
+            False, adsk.core.ValueInput.createByString('360 deg'))
+        revolve = revolves.add(revInput)
         gearBody = revolve.bodies.item(0)
-        gearBody.name = f'{gearLabel} Gear Body'
 
-        # ---- Tooth loft: §2 Apex sketch point -> §3 tooth profile ----
-        toothProfile = self._findSpurToothProfile(
-            profileInfo['toothSketch'], profileInfo['embedded'])
-        loftInput = features.loftFeatures.createInput(
+        # Tooth loft: Apex sketch point -> §3 tooth profile.
+        toothProfile = find_profile_by_curve_counts(
+            ctx['toothSketch'], nurbs=2, arcs=2,
+            lines=(0 if ctx['embedded'] else 2))
+        lofts = features.loftFeatures
+        loftInput = lofts.createInput(
             adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
-        loftInput.loftSections.add(apexSketchPoint)
+        loftInput.loftSections.add(self._apexSketchPoint)
         loftInput.loftSections.add(toothProfile)
-        loft = features.loftFeatures.add(loftInput)
+        loft = lofts.add(loftInput)
         toothBody = loft.bodies.item(0)
-        toothBody.name = f'{gearLabel} Tooth'
 
-        # ---- world hand-off points per §3a "Caller hand-off" table ----
-        apexWorld = apexSketchPoint.worldGeometry
-        toeStartW = toeEdge[0].worldGeometry   # M / O
-        toeEndW = toeEdge[1].worldGeometry     # N / P
-        heelStartW = heelEdge[0].worldGeometry  # C / D
-        heelEndW = heelEdge[1].worldGeometry    # H / J
-        toeMid = adsk.core.Point3D.create(
-            (toeStartW.x + toeEndW.x) / 2.0,
-            (toeStartW.y + toeEndW.y) / 2.0,
-            (toeStartW.z + toeEndW.z) / 2.0)
-        heelMid = adsk.core.Point3D.create(
-            (heelStartW.x + heelEndW.x) / 2.0,
-            (heelStartW.y + heelEndW.y) / 2.0,
-            (heelStartW.z + heelEndW.z) / 2.0)
-        toeConeWorld = toeStartW    # M / O (on root cone element)
-        heelConeWorld = heelStartW  # C / D (dedendum corner, on root axis)
+        # World hand-off points (§3a "Caller hand-off" table).
+        toeEdge = ctx['toeEdge']
+        heelEdge = ctx['heelEdge']
+        toeMid = _midpoint(toeEdge[0].worldGeometry, toeEdge[1].worldGeometry)
+        heelMid = _midpoint(heelEdge[0].worldGeometry,
+                            heelEdge[1].worldGeometry)
+        toeConeWorld = ctx['toeConePoint'].worldGeometry
+        heelConeWorld = ctx['heelConePoint'].worldGeometry
+        apexWorld = self._apexSketchPoint.worldGeometry
 
-        # ---- tooth-body step (straight cut OR spiral build) ----
+        # The tooth-body step (straight = 2 conical trims; spiral = curved).
         toothBody = self._transformToothBody(
-            designComponent, designOccurrence, toothBody, gearBody, shaftAxisEdge,
-            apexWorld, apexSketchPoint, toeMid, heelMid, toeConeWorld, heelConeWorld,
-            profileInfo['toothPlane'], gearLabel, teethNumber)
+            designComponent, toothBody, gearBody, shaftAxisEdge, apexWorld,
+            self._apexSketchPoint, toeMid, heelMid, toeConeWorld,
+            heelConeWorld, ctx['toothPlane'], gearLabel, ctx['teeth'],
+            ctx['gamma'])
 
-        # ---- pattern around the shaft-axis edge ----
-        patternEntities = adsk.core.ObjectCollection.create()
-        patternEntities.add(toothBody)
-        patInput = features.circularPatternFeatures.createInput(
-            patternEntities, shaftAxisEdge)
-        patInput.quantity = adsk.core.ValueInput.createByReal(teethNumber)
+        # Pattern around the shaft-axis edge.
+        patterns = features.circularPatternFeatures
+        bodyColl = adsk.core.ObjectCollection.create()
+        bodyColl.add(toothBody)
+        patInput = patterns.createInput(
+            bodyColl, shaftAxisEdge)
+        patInput.quantity = adsk.core.ValueInput.createByReal(ctx['teeth'])
         patInput.totalAngle = adsk.core.ValueInput.createByString('360 deg')
         patInput.isSymmetric = False
-        pattern = features.circularPatternFeatures.add(patInput)
+        pattern = patterns.add(patInput)
 
-        # ---- combine: join all patterned tooth pieces into the gear body ----
-        toolBodies = adsk.core.ObjectCollection.create()
-        for b in pattern.bodies:
-            toolBodies.add(b)
-        combineInput = features.combineFeatures.createInput(gearBody, toolBodies)
-        combineInput.operation = adsk.fusion.FeatureOperations.JoinFeatureOperation
-        features.combineFeatures.add(combineInput)
+        # Combine-Join: gear body (target) + all patterned tooth bodies (tools).
+        tools = adsk.core.ObjectCollection.create()
+        for i in range(pattern.bodies.count):
+            tools.add(pattern.bodies.item(i))
+        combines = features.combineFeatures
+        combInput = combines.createInput(gearBody, tools)
+        combInput.operation = adsk.fusion.FeatureOperations.JoinFeatureOperation
+        combines.add(combInput)
 
-        # ---- bore ----
+        # Bore.
         if self._boreEnable:
-            self._cutBore(designComponent, gearBody, shaftAxisEdge, boreDiameter_cm)
+            self._cutBore(designComponent, gearComponent, gearBody,
+                          shaftAxisEdge, ctx['boreDia_cm'], gearLabel)
 
-        # ---- mesh-rotate ----
-        if isDriving:
-            self._rotateBodyAboutEdge(
-                designComponent, gearBody, shaftAxisEdge,
-                math.radians(180.0) / teethNumber)
-        else:
-            phase = self._pinionMeshPhase()
-            if phase != 0:
-                self._rotateBodyAboutEdge(
-                    designComponent, gearBody, shaftAxisEdge,
-                    phase * (2.0 * math.pi / teethNumber))
+        # Meshing rotation about the shaft axis.
+        meshAngle = ctx['meshAngle']
+        if meshAngle != 0:
+            rotate_body_about_edge(
+                designComponent, gearBody, shaftAxisEdge, meshAngle)
 
-        # ---- move the finished body to its gear component ----
+        # Relocate the finished body into its gear component.
         gearBody.moveToComponent(gearOccurrence)
 
-    def _pinionMeshPhase(self):
-        # 0 by default (mid-face section unrotated and already meshes).
-        return self._PINION_MESH_PHASE_TEETH
-
-    def _rotateBodyAboutEdge(self, designComponent, body, edge, angle):
-        startW = edge.startSketchPoint.worldGeometry
-        endW = edge.endSketchPoint.worldGeometry
-        axisVec = adsk.core.Vector3D.create(
-            endW.x - startW.x, endW.y - startW.y, endW.z - startW.z)
-        axisVec.normalize()
-        matrix = adsk.core.Matrix3D.create()
-        matrix.setToRotation(angle, axisVec, startW)
-        bodies = adsk.core.ObjectCollection.create()
-        bodies.add(body)
-        moveInput = designComponent.features.moveFeatures.createInput2(bodies)
-        moveInput.defineAsFreeMove(matrix)
-        designComponent.features.moveFeatures.add(moveInput)
-
-    # =======================================================================
-    # Tooth-body hook (the spiral gate)
-    # =======================================================================
-    def _transformToothBody(self, designComponent, designOccurrence, toothBody, gearBody,
+    # -- Tooth-body hook ----------------------------------------------------
+    def _transformToothBody(self, designComponent, toothBody, gearBody,
                             shaftAxisEdge, apexWorld, apexSketchPoint,
                             toeMid, heelMid, toeConeWorld, heelConeWorld,
-                            parentToothPlane, gearLabel, teethNumber):
+                            parentToothPlane, gearLabel, teethNumber, gamma):
+        # Straight bevel: byte-for-byte the prior two-cone flush trim.
         if self._spiralAngle_rad <= 0:
-            return self._cutConicalEnds(
+            return cut_conical_ends(
                 designComponent, toothBody, gearBody, toeMid, heelMid,
                 apexWorld, gearLabel)
+        # Spiral build (psi > 0).
+        return self._buildSpiralTooth(
+            designComponent, toothBody, gearBody, shaftAxisEdge, apexWorld,
+            toeMid, heelMid, toeConeWorld, heelConeWorld, parentToothPlane,
+            gearLabel, gamma)
 
-        # ===== ψ > 0 : spiral tooth body =====
+    def _pinionMeshPhase(self, pinionTeeth):
+        return self._PINION_MESH_PHASE_TEETH * 2.0 * math.pi / pinionTeeth
+
+    # -- §3a: spiral tooth body --------------------------------------------
+    def _buildSpiralTooth(self, designComponent, toothBody, gearBody,
+                          shaftAxisEdge, apexWorld, toeMid, heelMid,
+                          toeConeWorld, heelConeWorld, parentToothPlane,
+                          gearLabel, gamma):
+        features = designComponent.features
+
         # A. Gate & frame.
-        sStart = shaftAxisEdge.startSketchPoint.worldGeometry
-        sEnd = shaftAxisEdge.endSketchPoint.worldGeometry
-        axisDir = adsk.core.Vector3D.create(
-            sEnd.x - sStart.x, sEnd.y - sStart.y, sEnd.z - sStart.z)
+        startW = shaftAxisEdge.startSketchPoint.worldGeometry
+        endW = shaftAxisEdge.endSketchPoint.worldGeometry
+        axisDir = _vec(startW, endW)
         axisDir.normalize()
-
         apex = apexWorld
 
-        # swap-guard: heel must be the OUTER end
+        # Fix swapped toe/heel: heel must be the OUTER end.
         if apex.distanceTo(heelMid) < apex.distanceTo(toeMid):
             toeMid, heelMid = heelMid, toeMid
             toeConeWorld, heelConeWorld = heelConeWorld, toeConeWorld
 
-        coneVec = adsk.core.Vector3D.create(
-            heelConeWorld.x - apex.x, heelConeWorld.y - apex.y, heelConeWorld.z - apex.z)
+        coneVec = _vec(apex, heelConeWorld)
         coneVec.normalize()
         v = axisDir.crossProduct(coneVec)
         v.normalize()
@@ -1239,286 +1225,193 @@ class BevelGearGenerator:
         tpNormal.normalize()
 
         def distAlong(p):
-            return ((p.x - apex.x) * coneVec.x +
-                    (p.y - apex.y) * coneVec.y +
-                    (p.z - apex.z) * coneVec.z)
+            return ((p.x - apex.x) * coneVec.x
+                    + (p.y - apex.y) * coneVec.y
+                    + (p.z - apex.z) * coneVec.z)
 
         R_toe = distAlong(toeMid)
         R_heel = distAlong(heelMid)
         R_mean = 0.5 * (R_toe + R_heel)
         span = R_heel - R_toe
 
-        gamma = self._gamma_p if gearLabel == 'Pinion' else self._gamma_g
-
         # B. Cutter-arc geometry.
-        if self._cutterRadius_cm > 0:
-            r_c = self._cutterRadius_cm
-        else:
-            r_c = R_mean
         psi = self._spiralAngle_rad
-        handSign = 1.0 if self._spiralHand == _HAND_RIGHT else -1.0
+        r_c = self._cutterRadius_cm if self._cutterRadius_cm > 0 else R_mean
+        handSign = 1.0 if self._hand == _HAND_RIGHT else -1.0
         if gearLabel == 'Pinion':
             handSign = -handSign
         Cx = R_mean - r_c * math.sin(psi)
         Cy = handSign * r_c * math.cos(psi)
-
         R_lo = R_toe - 0.06 * span
         R_hi = R_heel + 0.06 * span
-        toe2d = self._circleIntersectNearest(R_lo, Cx, Cy, r_c, R_mean, 0.0)
-        heel2d = self._circleIntersectNearest(R_hi, Cx, Cy, r_c, R_mean, 0.0)
+        toe2d = circle_intersect_nearest(R_lo, Cx, Cy, r_c, R_mean, 0.0)
+        heel2d = circle_intersect_nearest(R_hi, Cx, Cy, r_c, R_mean, 0.0)
 
-        # helper: tangent-plane 2-D coords -> world point
-        def tanW(px, py):
-            return self._combine(apex, px, coneVec, py, v)
+        # C. 2-D trace sketch (genuine cutter arc).
+        axialPlane = self._gearProfilesPlane
+        coneSketch = designComponent.sketches.add(axialPlane)
+        coneSketch.name = '%s Cone Element' % gearLabel
+        coneEnd = combine_point(apex, R_heel, coneVec)
+        coneElementLine = coneSketch.sketchCurves.sketchLines.addByTwoPoints(
+            apex, coneEnd)
 
-        # C. 2-D trace sketch.
-        # cone-element construction line on the axial plane.
-        coneSketch = designComponent.sketches.add(self._gearProfilesPlane)
-        coneSketch.name = f'{gearLabel} Cone Element'
-        coneSketch.isVisible = True
-        clines = coneSketch.sketchCurves.sketchLines
-        apexHeel = self._combine(apex, R_heel, coneVec, 0.0, v)
-        coneElementLine = clines.addByTwoPoints(
-            coneSketch.modelToSketchSpace(apex),
-            coneSketch.modelToSketchSpace(apexHeel))
-
-        tracePlane = self._planeByAngle(
-            designComponent, coneElementLine, self._gearProfilesPlane, 90.0)
-        tracePlane.name = f'{gearLabel} Trace Plane'
+        tracePlane = plane_by_angle(
+            designComponent, coneElementLine, axialPlane, 90)
+        tracePlane.name = '%s Trace Plane' % gearLabel
 
         traceSketch = designComponent.sketches.add(tracePlane)
-        traceSketch.name = f'{gearLabel} 2D Tooth Trace'
-        traceSketch.isVisible = True
-        tcircles = traceSketch.sketchCurves.sketchCircles
-        tarcs = traceSketch.sketchCurves.sketchArcs
+        traceSketch.name = '%s 2D Tooth Trace' % gearLabel
+
+        def tanW(px, py):
+            return combine_point(apex, px, coneVec, py, v)
+
+        circles = traceSketch.sketchCurves.sketchCircles
+        arcs = traceSketch.sketchCurves.sketchArcs
         tdims = traceSketch.sketchDimensions
-        tcons = traceSketch.geometricConstraints
 
         cutterCenterW = tanW(Cx, Cy)
-        cutterCircle = tcircles.addByCenterRadius(
-            traceSketch.modelToSketchSpace(cutterCenterW), r_c)
+        cutterCircle = circles.addByCenterRadius(cutterCenterW, r_c)
         cutterCircle.isConstruction = True
         cutterCircle.centerSketchPoint.isFixed = True
         tdims.addDiameterDimension(
-            cutterCircle,
-            traceSketch.modelToSketchSpace(tanW(Cx + r_c, Cy))).parameter.value = 2.0 * r_c
+            cutterCircle, tanW(Cx + r_c, Cy)).parameter.value = 2.0 * r_c
 
-        toeW = tanW(toe2d[0], toe2d[1])
-        meanW = tanW(R_mean, 0.0)
-        heelW = tanW(heel2d[0], heel2d[1])
-        traceArc = tarcs.addByThreePoints(
-            traceSketch.modelToSketchSpace(toeW),
-            traceSketch.modelToSketchSpace(meanW),
-            traceSketch.modelToSketchSpace(heelW))
-        tcons.addCoincident(traceArc.centerSketchPoint, cutterCircle.centerSketchPoint)
+        traceArc = arcs.addByThreePoints(
+            tanW(toe2d[0], toe2d[1]),
+            tanW(R_mean, 0.0),
+            tanW(heel2d[0], heel2d[1]))
+        traceSketch.geometricConstraints.addCoincident(
+            traceArc.centerSketchPoint, cutterCircle.centerSketchPoint)
         tdims.addRadialDimension(
-            traceArc,
-            traceSketch.modelToSketchSpace(meanW)).parameter.value = r_c
-        # (deliberately left with free DOF -- exempt from the gate)
+            traceArc, tanW(R_mean, 0.0)).parameter.value = r_c
 
-        # E. Slice the straight tooth.
-        segments = self._sliceTooth(
-            designComponent, toothBody, parentToothPlane, apex, coneVec,
-            span, distAlong, gearLabel)
+        # E. Slice the straight tooth into cross-section slabs.
+        normal = self._planeNormalWorld(parentToothPlane)
+        planeOrigin = self._planeOriginWorld(parentToothPlane)
+        toApex = _vec(planeOrigin, apex)
+        dotv = (toApex.x * normal.x + toApex.y * normal.y + toApex.z * normal.z)
+        sign = 1.0 if dotv >= 0 else -1.0
+
+        def do_slice(sgn):
+            offsets = [sgn * (k + 1) * span / 6.0 for k in range(8)]
+            return slice_body_by_offset_planes(
+                designComponent, toothBody, parentToothPlane, offsets)
+
+        pieces = do_slice(sign)
+        if len(pieces) <= 1:
+            # Retry with the opposite sign.
+            pieces = do_slice(-sign)
+            if len(pieces) <= 1:
+                raise RuntimeError(
+                    '%s spiral: slice produced %d piece(s) (span=%.4f, '
+                    'sign=%s) — cut planes missed' % (
+                        gearLabel, len(pieces), span, sign))
 
         # F. Order & drop scrap.
-        def centroidDist(body):
-            return distAlong(body.physicalProperties.centerOfMass)
-        segments.sort(key=centroidDist)
-        scrap = segments[0]
-        segments = segments[1:]
-        designComponent.features.removeFeatures.add(scrap)
+        def centroid(piece):
+            return piece.physicalProperties.centerOfMass
+
+        pieces.sort(key=lambda p: distAlong(centroid(p)))
+        scrap = pieces[0]
+        segments = pieces[1:]
+        features.removeFeatures.add(scrap)
         if len(segments) == 0:
-            raise Exception(
-                f'{gearLabel}: spiral slice left no working segments after dropping scrap')
+            raise RuntimeError(
+                '%s spiral: no segments after dropping scrap' % gearLabel)
 
         # G. Twist.
-        phi_crown = (math.atan2(heel2d[1], heel2d[0]) -
-                     math.atan2(toe2d[1], toe2d[0]))
+        phi_crown = (math.atan2(heel2d[1], heel2d[0])
+                     - math.atan2(toe2d[1], toe2d[0]))
         total = abs(phi_crown) / math.sin(gamma)
 
-        def slabHeelFace(seg):
+        def slabFaceByExtreme(seg, want_max):
             best = None
-            bestD = -float('inf')
-            for f in seg.faces:
-                d = distAlong(f.centroid)
-                if d > bestD:
-                    bestD = d
-                    best = f
-            return best, bestD
+            bestVal = None
+            for face in seg.faces:
+                cen = face.centroid
+                val = distAlong(cen)
+                if bestVal is None or (val > bestVal if want_max
+                                       else val < bestVal):
+                    bestVal = val
+                    best = face
+            return best, bestVal
 
         for seg in segments:
-            (hf, R_heelFace) = slabHeelFace(seg)
+            heelFace, R_heelFace = slabFaceByExtreme(seg, want_max=True)
             ang = -handSign * total * (R_mean - R_heelFace) / span
             matrix = adsk.core.Matrix3D.create()
             matrix.setToRotation(ang, axisDir, apex)
             bodies = adsk.core.ObjectCollection.create()
             bodies.add(seg)
-            moveInput = designComponent.features.moveFeatures.createInput2(bodies)
+            moveInput = features.moveFeatures.createInput2(bodies)
             moveInput.defineAsFreeMove(matrix)
-            designComponent.features.moveFeatures.add(moveInput)
+            features.moveFeatures.add(moveInput)
 
         # H. Lengthwise crown (relief).
-        # Sort by post-twist heel-face distance to find the outermost (heel) seg.
-        segOrder = sorted(
-            segments, key=lambda s: slabHeelFace(s)[1])
-        heelSeg = segOrder[-1]
+        # Sort by post-twist heel-face cone distance to find the outermost.
+        segHeel = []
+        for seg in segments:
+            hf, rhf = slabFaceByExtreme(seg, want_max=True)
+            segHeel.append((seg, hf, rhf))
+        segHeel.sort(key=lambda t: t[2])
+        outermostIdx = len(segHeel) - 1  # greatest distAlong -> heel
 
-        designOccurrence.activate()
+        self.designOccurrence.activate()
         try:
-            for seg in segments:
-                if seg is heelSeg:
-                    continue  # skip the outermost (heel) segment
-                (hf, R_heelFace) = slabHeelFace(seg)
+            for idx, (seg, heelFace, R_heelFace) in enumerate(segHeel):
+                if idx == outermostIdx:
+                    continue  # skip the heel segment (kept full).
                 u = (R_heel - R_heelFace) / span
                 factor = 1.0 - self._CROWN_PER_RAD * (abs(total) / 2.0) * u
-                basePoint = self._heelFaceRootBasePoint(
-                    designComponent, hf, apex, axisDir)
-                scaleEntities = adsk.core.ObjectCollection.create()
-                scaleEntities.add(seg)
-                scaleInput = designComponent.features.scaleFeatures.createInput(
-                    scaleEntities, basePoint,
-                    adsk.core.ValueInput.createByReal(factor))
-                designComponent.features.scaleFeatures.add(scaleInput)
+                if factor <= 0:
+                    raise RuntimeError(
+                        '%s spiral: crown factor %.4f <= 0 (u=%.4f)' % (
+                            gearLabel, factor, u))
+                self._scaleSegment(designComponent, seg, heelFace, factor,
+                                   apex, axisDir)
         finally:
             self.design.activateRootComponent()
 
-        # I. Loft -> curved tooth.
-        order = sorted(
-            range(len(segments)),
-            key=lambda i: slabHeelFace(segments[i])[1])
-
-        def slabToeFace(seg):
-            best = None
-            bestD = float('inf')
-            for f in seg.faces:
-                d = distAlong(f.centroid)
-                if d < bestD:
-                    bestD = d
-                    best = f
-            return best
-
-        loftInput = designComponent.features.loftFeatures.createInput(
-            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
-        # toe-most segment's toe-facing face first
-        toeSeg = segments[order[0]]
-        loftInput.loftSections.add(slabToeFace(toeSeg))
-        for i in order:
-            (hf, _d) = slabHeelFace(segments[i])
-            loftInput.loftSections.add(hf)
-        curvedLoft = designComponent.features.loftFeatures.add(loftInput)
-        curvedTooth = curvedLoft.bodies.item(0)
-        curvedTooth.name = f'{gearLabel} Spiral Tooth'
-
-        # remove the segment scaffolding (loft captured their faces)
+        # I. Loft -> curved tooth (re-sort by post-twist heel-face distance).
+        indexed = []
         for seg in segments:
-            try:
-                designComponent.features.removeFeatures.add(seg)
-            except:
-                pass
+            hf, rhf = slabFaceByExtreme(seg, want_max=True)
+            indexed.append((seg, hf, rhf))
+        indexed.sort(key=lambda t: t[2])
+
+        toeSeg = indexed[0][0]
+        toeFace, _ = slabFaceByExtreme(toeSeg, want_max=False)
+
+        lofts = features.loftFeatures
+        loftInput = lofts.createInput(
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        loftInput.loftSections.add(toeFace)
+        for (seg, heelFace, rhf) in indexed:
+            loftInput.loftSections.add(heelFace)
+        loft = lofts.add(loftInput)
+        curvedTooth = loft.bodies.item(0)
+        curvedTooth.name = '%s Spiral Tooth' % gearLabel
+
+        # Remove the segment scaffolding (loft has captured their faces).
+        for seg in segments:
+            features.removeFeatures.add(seg)
 
         # J. Flush trim.
-        return self._cutConicalEnds(
+        return cut_conical_ends(
             designComponent, curvedTooth, gearBody, toeMid, heelMid,
             apexWorld, gearLabel)
 
-    # =======================================================================
-    # Spiral helpers
-    # =======================================================================
-    def _combine(self, base, a, e1, b=0.0, e2=None):
-        x = base.x + a * e1.x
-        y = base.y + a * e1.y
-        z = base.z + a * e1.z
-        if e2 is not None:
-            x += b * e2.x
-            y += b * e2.y
-            z += b * e2.z
-        return adsk.core.Point3D.create(x, y, z)
-
-    def _planeByAngle(self, designComponent, line, refPlane, angleDeg):
-        planes = designComponent.constructionPlanes
-        pinput = planes.createInput()
-        pinput.setByAngle(line,
-                         adsk.core.ValueInput.createByString(f'{angleDeg} deg'),
-                         refPlane)
-        return planes.add(pinput)
-
-    def _circleIntersectNearest(self, R, Cx, Cy, r_c, refX, refY):
-        # intersect apex circle radius R (center origin) with cutter circle
-        # (center (Cx,Cy), radius r_c); keep the solution nearest (refX,refY).
-        d = math.hypot(Cx, Cy)
-        if d == 0:
-            raise Exception('cutter circle centered at apex; cannot intersect')
-        # distance from origin to the radical line
-        a = (R * R - r_c * r_c + d * d) / (2.0 * d)
-        h2 = R * R - a * a
-        if h2 < 0:
-            h2 = 0.0
-        h = math.sqrt(h2)
-        # base point along the center line
-        ux, uy = Cx / d, Cy / d
-        px = a * ux
-        py = a * uy
-        # perpendicular offset
-        s1 = (px - h * uy, py + h * ux)
-        s2 = (px + h * uy, py - h * ux)
-        d1 = math.hypot(s1[0] - refX, s1[1] - refY)
-        d2 = math.hypot(s2[0] - refX, s2[1] - refY)
-        return s1 if d1 <= d2 else s2
-
-    def _sliceTooth(self, designComponent, toothBody, parentToothPlane, apex,
-                    coneVec, span, distAlong, gearLabel):
-        planes = designComponent.constructionPlanes
-        features = designComponent.features
-
-        # choose the sign so the offset moves toward the apex
-        planeOrigin = parentToothPlane.geometry.origin
-        normal = parentToothPlane.geometry.normal
-        toApex = adsk.core.Vector3D.create(
-            apex.x - planeOrigin.x, apex.y - planeOrigin.y, apex.z - planeOrigin.z)
-        sign = 1.0 if (toApex.dotProduct(normal) > 0) else -1.0
-
-        def attemptCut(useSign):
-            pieces = [toothBody]
-            step = span / 6.0
-            for k in range(_SPIRAL_SLICE_COUNT):
-                offset = useSign * (k + 1) * step
-                cpInput = planes.createInput()
-                cpInput.setByOffset(parentToothPlane,
-                                   adsk.core.ValueInput.createByReal(offset))
-                cutPlane = planes.add(cpInput)
-                newPieces = []
-                for piece in pieces:
-                    try:
-                        splitInput = features.splitBodyFeatures.createInput(
-                            piece, cutPlane, True)
-                        split = features.splitBodyFeatures.add(splitInput)
-                        for b in split.bodies:
-                            newPieces.append(b)
-                    except:
-                        newPieces.append(piece)
-                pieces = newPieces
-            return pieces
-
-        pieces = attemptCut(sign)
-        if len(pieces) == 1:
-            # retry with the opposite sign
-            pieces = attemptCut(-sign)
-        if len(pieces) == 1:
-            raise Exception(
-                f'{gearLabel}: spiral slice failed to cut the tooth '
-                f'(1 piece; span={span:.4f}, sign tried={sign})')
-        return pieces
-
-    def _heelFaceRootBasePoint(self, designComponent, heelFace, apex, axisDir):
-        # root corners = the two vertices nearest the shaft axis.
+    def _scaleSegment(self, designComponent, seg, heelFace, factor, apex,
+                      axisDir):
+        # Base point on the heel face's ROOT edge (gotcha 3): midpoint of the
+        # two vertices nearest the shaft axis.
         verts = []
         for vtx in heelFace.vertices:
             verts.append(vtx.geometry)
 
         def perpDist(p):
-            ap = adsk.core.Vector3D.create(p.x - apex.x, p.y - apex.y, p.z - apex.z)
-            along = ap.dotProduct(axisDir)
+            ap = _vec(apex, p)
+            along = (ap.x * axisDir.x + ap.y * axisDir.y + ap.z * axisDir.z)
             perp = adsk.core.Vector3D.create(
                 ap.x - along * axisDir.x,
                 ap.y - along * axisDir.y,
@@ -1526,167 +1419,100 @@ class BevelGearGenerator:
             return perp.length
 
         verts.sort(key=perpDist)
-        r1 = verts[0]
-        r2 = verts[1]
-        midW = adsk.core.Point3D.create(
-            (r1.x + r2.x) / 2.0, (r1.y + r2.y) / 2.0, (r1.z + r2.z) / 2.0)
-        # place a sketch point on the heel face mapped via a sketch on that face.
-        faceSketch = designComponent.sketches.add(heelFace)
-        faceSketch.isVisible = False
-        return faceSketch.sketchPoints.add(faceSketch.modelToSketchSpace(midW))
+        rootCorners = verts[:2]
+        baseWorld = adsk.core.Point3D.create(
+            (rootCorners[0].x + rootCorners[1].x) / 2.0,
+            (rootCorners[0].y + rootCorners[1].y) / 2.0,
+            (rootCorners[0].z + rootCorners[1].z) / 2.0)
 
-    # =======================================================================
-    # Conical cuts / straight-tooth flush trim
-    # =======================================================================
-    def _surfaceDistance(self, surface, worldPoint):
-        try:
-            evaluator = surface.evaluator
-            (ok, param) = evaluator.getParameterAtPoint(worldPoint)
-            if not ok:
-                return float('inf')
-            (ok2, projected) = evaluator.getPointAtParameter(param)
-            if not ok2:
-                return float('inf')
-            return projected.distanceTo(worldPoint)
-        except:
-            return float('inf')
+        # A sketch point on the heel face for the scale base.
+        baseSketch = designComponent.sketches.add(heelFace)
+        basePt = baseSketch.sketchPoints.add(
+            baseSketch.modelToSketchSpace(baseWorld))
 
-    def _findConeFacesByMidpoint(self, frustumBody, edgeMidWorld):
-        coneFaces = []
-        for face in frustumBody.faces:
-            if face.geometry.surfaceType == adsk.core.SurfaceTypes.ConeSurfaceType:
-                dist = self._surfaceDistance(face.geometry, edgeMidWorld)
-                coneFaces.append((dist, face))
-        coneFaces.sort(key=lambda t: t[0])
-        return coneFaces
+        bodies = adsk.core.ObjectCollection.create()
+        bodies.add(seg)
+        scales = designComponent.features.scaleFeatures
+        scaleInput = scales.createInput(
+            bodies, basePt, adsk.core.ValueInput.createByReal(factor))
+        scales.add(scaleInput)
 
-    def _applyConicalCut(self, designComponent, targetBody, frustumBody,
-                        edgeMidWorld, apexWorld, gearLabel, cutLabel,
-                        lenient=False):
-        features = designComponent.features
-        coneFaces = self._findConeFacesByMidpoint(frustumBody, edgeMidWorld)
-        history = []
-        for (dist, face) in coneFaces:
-            try:
-                splitInput = features.splitBodyFeatures.createInput(
-                    targetBody, face, True)
-                split = features.splitBodyFeatures.add(splitInput)
-                if split.bodies.count > 1:
-                    pieces = [split.bodies.item(i) for i in range(split.bodies.count)]
-                    keeper = self._selectKeeper(
-                        designComponent, pieces, apexWorld, gearLabel, cutLabel)
-                    futil.log(
-                        f'{gearLabel} {cutLabel}: split into {split.bodies.count} '
-                        f'pieces (face dist={dist})', force_console=True)
-                    return keeper
-                else:
-                    history.append(f'dist={dist}: split produced <=1 piece')
-            except RuntimeError as e:
-                history.append(f'dist={dist}: {str(e)}')
-        # no face split the target
-        message = (f'{gearLabel} {cutLabel}: no cone face split the tooth body '
-                   f'(faces found={len(coneFaces)}; history={history})')
-        if lenient:
-            # propagate the non-intersect signal as a RuntimeError carrying the text
-            raise RuntimeError(message)
-        raise RuntimeError(message)
-
-    def _selectKeeper(self, designComponent, pieces, apexWorld, gearLabel, cutLabel):
-        nonApex = []
-        for piece in pieces:
-            containment = piece.pointContainment(apexWorld)
-            if containment == adsk.fusion.PointContainment.PointInsidePointContainment:
-                designComponent.features.removeFeatures.add(piece)
-            else:
-                nonApex.append(piece)
-        if len(nonApex) == 0:
-            raise RuntimeError(
-                f'{gearLabel} {cutLabel}: no non-apex piece after cut')
-        nonApex.sort(key=lambda b: b.physicalProperties.volume, reverse=True)
-        keeper = nonApex[0]
-        for extra in nonApex[1:]:
-            designComponent.features.removeFeatures.add(extra)
-        return keeper
-
-    def _cutConicalEnds(self, designComponent, toothBody, gearBody,
-                       toeMid, heelMid, apexWorld, gearLabel):
-        # toe cut first
-        keeper = self._applyConicalCut(
-            designComponent, toothBody, gearBody, toeMid, apexWorld,
-            gearLabel, 'toe cut (#1)', lenient=False)
-        # heel cut on the keeper alone -- lenient on non-intersection
-        try:
-            keeper = self._applyConicalCut(
-                designComponent, keeper, gearBody, heelMid, apexWorld,
-                gearLabel, 'heel cut (#2)', lenient=True)
-        except RuntimeError as e:
-            msg = str(e)
-            if 'SPLIT_TARGET_TOOL_NOT_INTERSECT' in msg or '交差' in msg:
-                futil.log(
-                    f'{gearLabel} heel cut (#2): tool did not intersect, kept intact',
-                    force_console=True)
-            else:
-                raise
-        return keeper
-
-    def _cutBore(self, designComponent, gearBody, shaftAxisEdge, boreDiameter_cm):
-        features = designComponent.features
+    # -- Bore ---------------------------------------------------------------
+    def _cutBore(self, designComponent, gearComponent, gearBody, shaftAxisEdge,
+                 boreDia_cm, gearLabel):
         planes = designComponent.constructionPlanes
-
-        # bore plane normal to the shaft at its start
         bpInput = planes.createInput()
-        bpInput.setByDistanceOnPath(shaftAxisEdge,
-                                   adsk.core.ValueInput.createByReal(0.0))
+        bpInput.setByDistanceOnPath(
+            shaftAxisEdge, adsk.core.ValueInput.createByReal(0.0))
         borePlane = planes.add(bpInput)
-        borePlane.name = f'{gearBody.name} Bore Plane'
 
-        boreSketch = designComponent.sketches.add(borePlane)
-        boreSketch.name = f'{gearBody.name} Bore'
-        boreSketch.isVisible = True
-        circles = boreSketch.sketchCurves.sketchCircles
-        dims = boreSketch.sketchDimensions
+        sketch = designComponent.sketches.add(borePlane)
+        sketch.name = '%s Bore' % gearLabel
+        circles = sketch.sketchCurves.sketchCircles
+        boreCircle = circles.addByCenterRadius(
+            adsk.core.Point3D.create(0, 0, 0), boreDia_cm / 2.0)
+        boreCircle.centerSketchPoint.isFixed = True
+        sketch.sketchDimensions.addDiameterDimension(
+            boreCircle,
+            adsk.core.Point3D.create(boreDia_cm / 2.0, 0, 0)
+        ).parameter.value = boreDia_cm
 
-        circle = circles.addByCenterRadius(
-            boreSketch.originPoint.geometry, boreDiameter_cm / 2.0)
-        circle.centerSketchPoint.isFixed = True
-        dims.addDiameterDimension(
-            circle,
-            adsk.core.Point3D.create(boreDiameter_cm / 2.0, 0, 0)).parameter.value = boreDiameter_cm
+        if not sketch.isFullyConstrained:
+            raise Exception('%s Bore sketch is not fully constrained'
+                            % gearLabel)
 
-        if not boreSketch.isFullyConstrained:
-            raise Exception(f'{gearBody.name} bore sketch is not fully constrained')
-
-        boreProfile = boreSketch.profiles.item(0)
-        extInput = features.extrudeFeatures.createInput(
-            boreProfile, adsk.fusion.FeatureOperations.CutFeatureOperation)
-        largeDist = adsk.core.ValueInput.createByReal(self._coneDistance_cm * 2.0)
-        extInput.setSymmetricExtent(largeDist, False)
+        profile = sketch.profiles.item(0)
+        extrudes = designComponent.features.extrudeFeatures
+        extInput = extrudes.createInput(
+            profile, adsk.fusion.FeatureOperations.CutFeatureOperation)
+        extInput.setSymmetricExtent(
+            adsk.core.ValueInput.createByReal(2.0 * self._coneDistance_cm),
+            False)
         extInput.participantBodies = [gearBody]
-        features.extrudeFeatures.add(extInput)
+        extrudes.add(extInput)
 
-    # =======================================================================
-    # Cleanup
-    # =======================================================================
+    # -- Cleanup ------------------------------------------------------------
     def _hideConstructionGeometry(self, bevelComponent):
-        seen = set()
+        hide_construction_geometry(bevelComponent)
 
-        def walk(component):
-            for sketch in component.sketches:
-                token = sketch.entityToken
-                if token not in seen:
-                    seen.add(token)
-                    sketch.isLightBulbOn = False
-            for plane in component.constructionPlanes:
-                token = plane.entityToken
-                if token not in seen:
-                    seen.add(token)
-                    plane.isLightBulbOn = False
-            for axis in component.constructionAxes:
-                token = axis.entityToken
-                if token not in seen:
-                    seen.add(token)
-                    axis.isLightBulbOn = False
-            for occ in component.occurrences:
-                walk(occ.component)
+    # -- small geometry helpers --------------------------------------------
+    def _targetNormal(self, targetPlane):
+        if targetPlane.objectType == adsk.fusion.BRepFace.classType():
+            return targetPlane.geometry.normal
+        return targetPlane.geometry.normal
 
-        walk(bevelComponent)
+    def _planeNormalWorld(self, plane):
+        return plane.geometry.normal
+
+    def _planeOriginWorld(self, plane):
+        return plane.geometry.origin
+
+    def _perpDistPointToLine(self, p, a, b):
+        # Perpendicular distance from 2-D point p to the line through a and b.
+        ab = _sub2(b, a)
+        n = math.hypot(ab[0], ab[1])
+        if n == 0:
+            return float('inf')
+        ap = _sub2(p, a)
+        cross = ap[0] * ab[1] - ap[1] * ab[0]
+        return abs(cross) / n
+
+    def _perpToAxis(self, p, apex, axisDir):
+        ap = _vec(apex, p)
+        along = (ap.x * axisDir.x + ap.y * axisDir.y + ap.z * axisDir.z)
+        perp = adsk.core.Vector3D.create(
+            ap.x - along * axisDir.x,
+            ap.y - along * axisDir.y,
+            ap.z - along * axisDir.z)
+        return perp.length
+
+    def _bottomEdgeMid(self, edge):
+        return _midpoint(edge[0].worldGeometry, edge[1].worldGeometry)
+
+    def _distDim(self, sketch, p0, p1, value, textPoint):
+        dim = sketch.sketchDimensions.addDistanceDimension(
+            p0, p1,
+            adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
+            textPoint)
+        dim.parameter.value = value
+        return dim

--- a/lib/geargen/helicalgear.py
+++ b/lib/geargen/helicalgear.py
@@ -1,3 +1,5 @@
+import math
+import adsk.core, adsk.fusion
 from .spurgear import *
 from .misc import *
 
@@ -31,7 +33,7 @@ class HelicalGearGenerator(SpurGearGenerator):
     def generateName(self):
         module = self.getParameter(PARAM_MODULE)
         toothNumber = self.getParameter(PARAM_TOOTH_NUMBER)
-        thickness = self.getParameter('Thickness')
+        thickness = self.getParameter(PARAM_THICKNESS)
         helixAngle = self.getParameter(PARAM_HELIX_ANGLE)
         return 'Helical Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(
             module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
@@ -49,7 +51,7 @@ class HelicalGearGenerator(SpurGearGenerator):
     # relative to the base plane. Herringbone halves this so the mirror plane
     # sits in the middle of the gear body.
     def helicalPlaneOffset(self) -> adsk.core.ValueInput:
-        return self.getParameterAsValueInput('Thickness')
+        return self.getParameterAsValueInput(PARAM_THICKNESS)
 
     def chamferWantEdges(self):
         return 4

--- a/lib/geargen/helicalgear.py
+++ b/lib/geargen/helicalgear.py
@@ -1,7 +1,12 @@
 import math
 import adsk.core, adsk.fusion
-from .spurgear import *
-from .misc import *
+from .base import GenerationContext, get_value
+from .utilities import find_profile_by_curve_counts
+from .spurgear import (
+    PARAM_MODULE, PARAM_TOOTH_NUMBER, PARAM_THICKNESS,
+    SpurGearCommandInputsConfigurator, SpurGearGenerationContext,
+    SpurGearGenerator, SpurGearInvoluteToothDesignGenerator,
+)
 
 PARAM_HELIX_ANGLE = 'HelixAngle'
 INPUT_ID_HELIX_ANGLE = 'helixAngle'
@@ -39,9 +44,7 @@ class HelicalGearGenerator(SpurGearGenerator):
             module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
 
     def addExtraPrimaryParameters(self, inputs: adsk.core.CommandInputs):
-        (helixAngle, ok) = get_value(inputs, INPUT_ID_HELIX_ANGLE, 'rad')
-        if not ok:
-            raise Exception('Invalid helix angle value')
+        helixAngle = get_value(inputs, INPUT_ID_HELIX_ANGLE, 'rad')
         self.addParameter(PARAM_HELIX_ANGLE, helixAngle, 'rad', 'Helix angle for the helical gear')
 
     def filletHelixFactorExpression(self) -> str:
@@ -82,17 +85,10 @@ class HelicalGearGenerator(SpurGearGenerator):
 
         lofts = self.getComponent().features.loftFeatures
 
-        def findProfile(profiles):
-            for profile in profiles:
-                for loop in profile.profileLoops:
-                    if loop.profileCurves.count == 6:
-                        return profile
-            return None
-
-        bottomToothProfile = findProfile(bottomSketch.profiles)
-        topToothProfile = findProfile(topSketch.profiles)
-        if not bottomToothProfile or not topToothProfile:
-            raise Exception('could not find tooth profile for loft')
+        bottomToothProfile = find_profile_by_curve_counts(
+            bottomSketch, nurbs=2, arcs=2, lines=2)
+        topToothProfile = find_profile_by_curve_counts(
+            topSketch, nurbs=2, arcs=2, lines=2)
 
         loftInput = lofts.createInput(adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
         loftInput.loftSections.add(bottomToothProfile)

--- a/lib/geargen/herringbonegear.py
+++ b/lib/geargen/herringbonegear.py
@@ -1,5 +1,10 @@
 import adsk.core, adsk.fusion
-from .helicalgear import *
+from .base import GenerationContext
+from .spurgear import PARAM_MODULE, PARAM_TOOTH_NUMBER, PARAM_THICKNESS
+from .helicalgear import (
+    PARAM_HELIX_ANGLE, HelicalGearCommandConfigurator,
+    HelicalGearGenerationContext, HelicalGearGenerator,
+)
 
 class HerringboneGearCommandConfigurator(HelicalGearCommandConfigurator): pass
 

--- a/lib/geargen/herringbonegear.py
+++ b/lib/geargen/herringbonegear.py
@@ -1,10 +1,9 @@
+import adsk.core, adsk.fusion
 from .helicalgear import *
 
 class HerringboneGearCommandConfigurator(HelicalGearCommandConfigurator): pass
 
-class HerringboneGearGenerationContext(HelicalGearGenerationContext):
-    def __init__(self):
-        super().__init__()
+class HerringboneGearGenerationContext(HelicalGearGenerationContext): pass
 
 class HerringboneGearGenerator(HelicalGearGenerator):
     def newContext(self):
@@ -16,7 +15,7 @@ class HerringboneGearGenerator(HelicalGearGenerator):
     def generateName(self):
         module = self.getParameter(PARAM_MODULE)
         toothNumber = self.getParameter(PARAM_TOOTH_NUMBER)
-        thickness = self.getParameter('Thickness')
+        thickness = self.getParameter(PARAM_THICKNESS)
         helixAngle = self.getParameter(PARAM_HELIX_ANGLE)
         return 'Herringbone Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(
             module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
@@ -24,7 +23,7 @@ class HerringboneGearGenerator(HelicalGearGenerator):
     # The mirror plane sits in the middle of the body, so the loft only covers
     # half the thickness.
     def helicalPlaneOffset(self) -> adsk.core.ValueInput:
-        thickness = self.getParameter('Thickness').value
+        thickness = self.getParameter(PARAM_THICKNESS).value
         return adsk.core.ValueInput.createByReal(thickness / 2)
 
     def buildTooth(self, ctx: GenerationContext):

--- a/lib/geargen/misc.py
+++ b/lib/geargen/misc.py
@@ -1,4 +1,3 @@
-import math
 import adsk.core
 
 def to_cm(mm):
@@ -6,12 +5,6 @@ def to_cm(mm):
 
 def to_mm(cm):
     return cm*10
-
-def get_ui(app=adsk.core.Application.get()):
-    ui = app.userInterface
-    if not ui:
-        raise Exception('No UI object available. Please run this script from within Fusion 360')
-    return ui
 
 def get_design(app=adsk.core.Application.get()):
     des = adsk.fusion.Design.cast(app.activeProduct)

--- a/lib/geargen/solids.py
+++ b/lib/geargen/solids.py
@@ -1,0 +1,250 @@
+# Gear-agnostic solid-body helpers shared by the gear generators.
+#
+# These functions encode hard-won Fusion behaviors (face-by-midpoint cone
+# selection, keeper selection, lenient non-intersecting cuts, piece-wise
+# slicing) that were proven in the bevel generator. They are framework code:
+# gear generators MUST call them rather than re-implement the patterns — see
+# PLAYBOOK.md "Shared geargen helper library".
+
+import math
+import adsk.core, adsk.fusion
+from ...lib import fusion360utils as futil
+
+
+# Fusion reports a split whose tool does not touch the target with this code
+# (message text may be localized — '交差' is the Japanese fragment).
+_NON_INTERSECT_MARKERS = ('SPLIT_TARGET_TOOL_NOT_INTERSECT', '交差')
+
+
+class NonIntersectError(RuntimeError):
+    """A conical cut found cone faces, but every attempt failed with Fusion's
+    tool-does-not-intersect signal. Callers for which a non-intersecting cut
+    is a legitimate no-op (e.g. a heel cone that never overshoots the tooth)
+    catch THIS type; any other split failure stays a plain RuntimeError."""
+
+
+def surface_distance(surface, worldPoint):
+    # Distance from worldPoint to its projection onto the (infinite) surface.
+    # Returns float('inf') when the evaluator cannot project the point (e.g.
+    # near a cone's apex singularity) — "try last", never "disqualified"
+    # ([PB-FACE-BY-MIDPOINT]).
+    try:
+        evaluator = surface.evaluator
+        (ok, param) = evaluator.getParameterAtPoint(worldPoint)
+        if not ok:
+            return float('inf')
+        (ok2, projected) = evaluator.getPointAtParameter(param)
+        if not ok2:
+            return float('inf')
+        return projected.distanceTo(worldPoint)
+    except Exception:
+        return float('inf')
+
+
+def find_cone_faces_by_midpoint(frustumBody, edgeMidWorld):
+    # All ConeSurfaceType faces of frustumBody as (distance, face) pairs,
+    # ordered best-first by the distance of edgeMidWorld to the face's
+    # surface ([PB-FACE-BY-MIDPOINT]).
+    coneFaces = []
+    for face in frustumBody.faces:
+        if face.geometry.surfaceType == adsk.core.SurfaceTypes.ConeSurfaceType:
+            dist = surface_distance(face.geometry, edgeMidWorld)
+            coneFaces.append((dist, face))
+    coneFaces.sort(key=lambda t: t[0])
+    return coneFaces
+
+
+def select_keeper(component, pieces, apexWorld, label):
+    # Keeper rule after a conical cut: remove every piece that contains the
+    # apex, keep the single largest remaining piece, remove the rest
+    # ([PB-REMOVE-PIECES]). Raises when no non-apex piece exists.
+    nonApex = []
+    for piece in pieces:
+        containment = piece.pointContainment(apexWorld)
+        if containment == adsk.fusion.PointContainment.PointInsidePointContainment:
+            component.features.removeFeatures.add(piece)
+        else:
+            nonApex.append(piece)
+    if len(nonApex) == 0:
+        raise RuntimeError(f'{label}: no non-apex piece after cut')
+    nonApex.sort(key=lambda b: b.physicalProperties.volume, reverse=True)
+    keeper = nonApex[0]
+    for extra in nonApex[1:]:
+        component.features.removeFeatures.add(extra)
+    return keeper
+
+
+def apply_conical_cut(component, targetBody, frustumBody, edgeMidWorld,
+                      apexWorld, label):
+    # Split targetBody with a cone face of frustumBody: order the candidate
+    # faces best-first by edge-midpoint distance and try each as the split
+    # tool (isSplittingToolExtended=True), keeping the first that actually
+    # splits (>1 piece); returns the keeper piece per select_keeper.
+    #
+    # When no face splits the target: raises NonIntersectError if the
+    # per-face failures carried Fusion's non-intersect signal, else a plain
+    # RuntimeError. Either way the message preserves the full per-face
+    # distance/error history ([PB-SELF-DIAGNOSING]).
+    features = component.features
+    coneFaces = find_cone_faces_by_midpoint(frustumBody, edgeMidWorld)
+    history = []
+    for (dist, face) in coneFaces:
+        try:
+            splitInput = features.splitBodyFeatures.createInput(
+                targetBody, face, True)
+            split = features.splitBodyFeatures.add(splitInput)
+            if split.bodies.count > 1:
+                pieces = [split.bodies.item(i) for i in range(split.bodies.count)]
+                keeper = select_keeper(component, pieces, apexWorld, label)
+                futil.log(
+                    f'{label}: split into {split.bodies.count} '
+                    f'pieces (face dist={dist})', force_console=True)
+                return keeper
+            else:
+                history.append(f'dist={dist}: split produced <=1 piece')
+        except RuntimeError as e:
+            history.append(f'dist={dist}: {str(e)}')
+    message = (f'{label}: no cone face split the tooth body '
+               f'(faces found={len(coneFaces)}; history={history})')
+    if any(marker in entry for entry in history for marker in _NON_INTERSECT_MARKERS):
+        raise NonIntersectError(message)
+    raise RuntimeError(message)
+
+
+def cut_conical_ends(component, toothBody, gearBody, toeMid, heelMid,
+                     apexWorld, label):
+    # The toe-then-heel two-cone flush trim. The toe cut must split (any
+    # failure propagates); the heel cone may legitimately not reach the
+    # keeper (common on ratio pairs) — a NonIntersectError there keeps the
+    # tooth intact.
+    keeper = apply_conical_cut(
+        component, toothBody, gearBody, toeMid, apexWorld,
+        f'{label} toe cut (#1)')
+    try:
+        keeper = apply_conical_cut(
+            component, keeper, gearBody, heelMid, apexWorld,
+            f'{label} heel cut (#2)')
+    except NonIntersectError:
+        futil.log(
+            f'{label} heel cut (#2): tool did not intersect, kept intact',
+            force_console=True)
+    return keeper
+
+
+def slice_body_by_offset_planes(component, body, basePlane, offsets):
+    # Split `body` piece-by-piece with construction planes offset from
+    # basePlane by each value in `offsets` (cm). A plane that misses a piece
+    # leaves that piece whole (the split's RuntimeError is absorbed).
+    # Returns the resulting pieces; the caller asserts the expected count
+    # ([PB-EMPTY-RESULT]).
+    planes = component.constructionPlanes
+    features = component.features
+    pieces = [body]
+    for offset in offsets:
+        cpInput = planes.createInput()
+        cpInput.setByOffset(basePlane, adsk.core.ValueInput.createByReal(offset))
+        cutPlane = planes.add(cpInput)
+        newPieces = []
+        for piece in pieces:
+            try:
+                splitInput = features.splitBodyFeatures.createInput(
+                    piece, cutPlane, True)
+                split = features.splitBodyFeatures.add(splitInput)
+                for b in split.bodies:
+                    newPieces.append(b)
+            except RuntimeError:
+                newPieces.append(piece)
+        pieces = newPieces
+    return pieces
+
+
+def rotate_body_about_edge(component, body, edge, angle):
+    # Rotate `body` by `angle` (radians) about the axis through the sketch
+    # edge's WORLD endpoints, via a free-move matrix ([PB-MOVE-ROTATE]).
+    startW = edge.startSketchPoint.worldGeometry
+    endW = edge.endSketchPoint.worldGeometry
+    axisVec = adsk.core.Vector3D.create(
+        endW.x - startW.x, endW.y - startW.y, endW.z - startW.z)
+    axisVec.normalize()
+    matrix = adsk.core.Matrix3D.create()
+    matrix.setToRotation(angle, axisVec, startW)
+    bodies = adsk.core.ObjectCollection.create()
+    bodies.add(body)
+    moveInput = component.features.moveFeatures.createInput2(bodies)
+    moveInput.defineAsFreeMove(matrix)
+    component.features.moveFeatures.add(moveInput)
+
+
+def plane_by_angle(component, line, refPlane, angleDeg):
+    # Construction plane through the sketch line, at angleDeg to refPlane.
+    # Pass the line directly — never wrap it in Path.create
+    # ([PB-CONSTRUCTION-PLANES]).
+    planes = component.constructionPlanes
+    pinput = planes.createInput()
+    pinput.setByAngle(line,
+                      adsk.core.ValueInput.createByString(f'{angleDeg} deg'),
+                      refPlane)
+    return planes.add(pinput)
+
+
+def combine_point(base, a, e1, b=0.0, e2=None):
+    # World point base + a*e1 (+ b*e2); lengths in internal cm.
+    x = base.x + a * e1.x
+    y = base.y + a * e1.y
+    z = base.z + a * e1.z
+    if e2 is not None:
+        x += b * e2.x
+        y += b * e2.y
+        z += b * e2.z
+    return adsk.core.Point3D.create(x, y, z)
+
+
+def circle_intersect_nearest(R, Cx, Cy, r_c, refX, refY):
+    # Intersect the apex-centred circle of radius R (centre at the origin)
+    # with the cutter circle (centre (Cx, Cy), radius r_c); return the
+    # intersection (x, y) nearest the reference point (refX, refY). A
+    # non-overlapping pair is clamped to the radical-line tangency point.
+    d = math.hypot(Cx, Cy)
+    if d == 0:
+        raise Exception('cutter circle centered at apex; cannot intersect')
+    a = (R * R - r_c * r_c + d * d) / (2.0 * d)
+    h2 = R * R - a * a
+    if h2 < 0:
+        h2 = 0.0
+    h = math.sqrt(h2)
+    ux, uy = Cx / d, Cy / d
+    px = a * ux
+    py = a * uy
+    s1 = (px - h * uy, py + h * ux)
+    s2 = (px + h * uy, py - h * ux)
+    d1 = math.hypot(s1[0] - refX, s1[1] - refY)
+    d2 = math.hypot(s2[0] - refX, s2[1] - refY)
+    return s1 if d1 <= d2 else s2
+
+
+def hide_construction_geometry(component):
+    # Recursively hide every sketch, construction plane, and construction
+    # axis under `component` (dedupe by entityToken), leaving only bodies
+    # visible ([PB-TREE-CLEANUP]).
+    seen = set()
+
+    def walk(comp):
+        for sketch in comp.sketches:
+            token = sketch.entityToken
+            if token not in seen:
+                seen.add(token)
+                sketch.isLightBulbOn = False
+        for plane in comp.constructionPlanes:
+            token = plane.entityToken
+            if token not in seen:
+                seen.add(token)
+                plane.isLightBulbOn = False
+        for axis in comp.constructionAxes:
+            token = axis.entityToken
+            if token not in seen:
+                seen.add(token)
+                axis.isLightBulbOn = False
+        for occ in comp.occurrences:
+            walk(occ.component)
+
+    walk(component)

--- a/lib/geargen/spurgear.py
+++ b/lib/geargen/spurgear.py
@@ -1,10 +1,9 @@
 import math
-from ...lib import fusion360utils as futil
-from .misc import *        # to_cm, to_mm, get_design, get_ui
-from .base import *        # Generator, GenerationContext, get_value/get_boolean/get_selection, ParamNamePrefix, ComponentCleaner
-from .utilities import *   # get_normal
-
 import adsk.core, adsk.fusion
+from ...lib import fusion360utils as futil
+from .misc import to_cm, get_design
+from .base import Generator, GenerationContext, get_value, get_boolean, get_selection
+from .utilities import find_profile_by_curve_counts
 
 # ---------------------------------------------------------------------------
 # Dialog input ids
@@ -21,7 +20,7 @@ INPUT_ID_CHAMFER_TOOTH = 'chamferTooth'
 INPUT_ID_SKETCH_ONLY = 'sketchOnly'
 
 # ---------------------------------------------------------------------------
-# Registered user-parameter names
+# User-parameter names (the <prefix>_<name> table)
 # ---------------------------------------------------------------------------
 PARAM_MODULE = 'Module'
 PARAM_TOOTH_NUMBER = 'ToothNumber'
@@ -31,66 +30,75 @@ PARAM_THICKNESS = 'Thickness'
 PARAM_CHAMFER_TOOTH = 'ChamferTooth'
 PARAM_SKETCH_ONLY = 'SketchOnly'
 
-PARAM_PITCH_DIAMETER = 'PitchCircleDiameter'
-PARAM_PITCH_RADIUS = 'PitchCircleRadius'
-PARAM_BASE_DIAMETER = 'BaseCircleDiameter'
-PARAM_BASE_RADIUS = 'BaseCircleRadius'
-PARAM_ROOT_DIAMETER = 'RootCircleDiameter'
-PARAM_ROOT_RADIUS = 'RootCircleRadius'
-PARAM_TIP_DIAMETER = 'TipCircleDiameter'
-PARAM_TIP_RADIUS = 'TipCircleRadius'
+PARAM_PITCH_CIRCLE_DIAMETER = 'PitchCircleDiameter'
+PARAM_PITCH_CIRCLE_RADIUS = 'PitchCircleRadius'
+PARAM_BASE_CIRCLE_DIAMETER = 'BaseCircleDiameter'
+PARAM_BASE_CIRCLE_RADIUS = 'BaseCircleRadius'
+PARAM_ROOT_CIRCLE_DIAMETER = 'RootCircleDiameter'
+PARAM_ROOT_CIRCLE_RADIUS = 'RootCircleRadius'
+PARAM_TIP_CIRCLE_DIAMETER = 'TipCircleDiameter'
+PARAM_TIP_CIRCLE_RADIUS = 'TipCircleRadius'
 PARAM_INVOLUTE_STEPS = 'InvoluteSteps'
 PARAM_TOOTH_SPACE_ANGLE_AT_ROOT = 'ToothSpaceAngleAtRoot'
 PARAM_TOOTH_SPACE_ARC_AT_ROOT = 'ToothSpaceArcAtRoot'
 PARAM_FILLET_CLEARANCE = 'FilletClearance'
 PARAM_FILLET_RADIUS = 'FilletRadius'
 
+INVOLUTE_STEPS = 15
+FILLET_CLEARANCE = 0.9
 
-# ---------------------------------------------------------------------------
-# 1. Command inputs configurator
-# ---------------------------------------------------------------------------
+
 class SpurGearCommandInputsConfigurator:
+    """Adds the dialog inputs, in the fixed display order, to the command."""
+
     @classmethod
     def configure(cls, cmd):
         inputs = cmd.commandInputs
-
-        # Dialog display order is fixed (see spec): plane, anchorPoint, module,
-        # toothNumber, pressureAngle, boreDiameter, thickness, chamferTooth,
-        # sketchOnly, parentComponent (last). Do NOT reorder by input type.
+        design = get_design()
 
         # 1. Target Plane
         planeInput = inputs.addSelectionInput(
-            INPUT_ID_PLANE, 'Target Plane', 'Select the plane to sketch the gear on')
-        planeInput.addSelectionFilter(adsk.core.SelectionCommandInput.ConstructionPlanes)
-        planeInput.addSelectionFilter(adsk.core.SelectionCommandInput.PlanarFaces)
-        planeInput.setSelectionLimits(1)
+            INPUT_ID_PLANE, 'Target Plane',
+            'Plane on which the gear front face is sketched')
+        planeInput.addSelectionFilter(
+            adsk.core.SelectionCommandInput.ConstructionPlanes)
+        planeInput.addSelectionFilter(
+            adsk.core.SelectionCommandInput.PlanarFaces)
+        planeInput.setSelectionLimits(1, 1)
 
         # 2. Anchor Point
         anchorInput = inputs.addSelectionInput(
-            INPUT_ID_ANCHOR_POINT, 'Anchor Point', 'Select the point to center the gear on')
-        anchorInput.addSelectionFilter(adsk.core.SelectionCommandInput.ConstructionPoints)
-        anchorInput.addSelectionFilter(adsk.core.SelectionCommandInput.SketchPoints)
-        anchorInput.setSelectionLimits(1)
+            INPUT_ID_ANCHOR_POINT, 'Anchor Point',
+            'Point the gear center is aligned with')
+        anchorInput.addSelectionFilter(
+            adsk.core.SelectionCommandInput.ConstructionPoints)
+        anchorInput.addSelectionFilter(
+            adsk.core.SelectionCommandInput.SketchPoints)
+        anchorInput.setSelectionLimits(1, 1)
 
         # 3. Module
         inputs.addValueInput(
-            INPUT_ID_MODULE, 'Module', '', adsk.core.ValueInput.createByReal(1))
+            INPUT_ID_MODULE, 'Module', '',
+            adsk.core.ValueInput.createByReal(1))
 
         # 4. Tooth Number
         inputs.addValueInput(
-            INPUT_ID_TOOTH_NUMBER, 'Tooth Number', '', adsk.core.ValueInput.createByReal(17))
+            INPUT_ID_TOOTH_NUMBER, 'Tooth Number', '',
+            adsk.core.ValueInput.createByReal(17))
 
         # 5. Pressure Angle
         inputs.addValueInput(
             INPUT_ID_PRESSURE_ANGLE, 'Pressure Angle', 'deg',
             adsk.core.ValueInput.createByReal(math.radians(20)))
 
-        # 6. Bore Diameter (string value input so it accepts expressions)
-        inputs.addStringValueInput(INPUT_ID_BORE_DIAMETER, 'Bore Diameter', '0 mm')
+        # 6. Bore Diameter (string input so it accepts expressions)
+        inputs.addStringValueInput(
+            INPUT_ID_BORE_DIAMETER, 'Bore Diameter', '0 mm')
 
         # 7. Thickness
         inputs.addValueInput(
-            INPUT_ID_THICKNESS, 'Thickness', 'mm', adsk.core.ValueInput.createByReal(to_cm(10)))
+            INPUT_ID_THICKNESS, 'Thickness', 'mm',
+            adsk.core.ValueInput.createByReal(to_cm(10)))
 
         # 8. Apply chamfer to teeth
         inputs.addValueInput(
@@ -99,22 +107,25 @@ class SpurGearCommandInputsConfigurator:
 
         # 9. Generate sketches, but do not build body
         inputs.addBoolValueInput(
-            INPUT_ID_SKETCH_ONLY, 'Generate sketches, but do not build body', True,
-            '', False)
+            INPUT_ID_SKETCH_ONLY, 'Generate sketches, but do not build body',
+            True, '', False)
 
-        # 10. Parent Component (last; default pre-selected to root component)
+        # 10. Parent Component (last; defaults to the root component)
         parentInput = inputs.addSelectionInput(
-            INPUT_ID_PARENT, 'Parent Component', 'Select the parent component')
-        parentInput.addSelectionFilter(adsk.core.SelectionCommandInput.Occurrences)
-        parentInput.addSelectionFilter(adsk.core.SelectionCommandInput.RootComponents)
-        parentInput.setSelectionLimits(1)
-        parentInput.addSelection(get_design().rootComponent)
+            INPUT_ID_PARENT, 'Parent Component',
+            'Component the new gear occurrence is nested under')
+        parentInput.addSelectionFilter(
+            adsk.core.SelectionCommandInput.Occurrences)
+        parentInput.addSelectionFilter(
+            adsk.core.SelectionCommandInput.RootComponents)
+        parentInput.setSelectionLimits(0, 1)
+        parentInput.addSelection(design.rootComponent)
 
 
-# ---------------------------------------------------------------------------
-# 2. Generation context
-# ---------------------------------------------------------------------------
 class SpurGearGenerationContext(GenerationContext):
+    """Data carrier passed between generation steps; subclasses read these
+    field names, so they are public API."""
+
     def __init__(self):
         self.plane = adsk.fusion.ConstructionPlane.cast(None)
         self.anchorPoint = adsk.fusion.SketchPoint.cast(None)
@@ -127,66 +138,77 @@ class SpurGearGenerationContext(GenerationContext):
         self.toothProfileIsEmbedded = False
 
 
-# ---------------------------------------------------------------------------
-# 3. Involute tooth design generator
-# ---------------------------------------------------------------------------
 class SpurGearInvoluteToothDesignGenerator:
+    """Draws the involute tooth profile (four circles + a single tooth) into a
+    sketch. Borrowed by the helical/herringbone subclasses and (via a proxy) by
+    the bevel gear."""
+
     def __init__(self, sketch: adsk.fusion.Sketch, parent, angle=0):
         self.sketch = sketch
         self.parent = parent
-        # Retained only as an incidental field; the live rotation always comes
-        # from draw()'s runtime argument. Do NOT use self.toothAngle in drawTooth.
+        # Retained as an incidental field only. drawTooth rotates by the live
+        # argument flowing in from draw(), NOT by this stored value.
         self.toothAngle = angle
-        # The movable local origin: a fresh SketchPoint at (0, 0, 0).
-        self.anchorPoint = sketch.sketchPoints.add(adsk.core.Point3D.create(0, 0, 0))
+        # A fresh movable local origin at (0,0,0) — NOT sketch.originPoint.
+        self.anchorPoint = sketch.sketchPoints.add(
+            adsk.core.Point3D.create(0, 0, 0))
+        # References to the four circles drawn by drawCircles().
+        self.rootCircle = None
+        self.tipCircle = None
+        self.baseCircle = None
+        self.pitchCircle = None
 
-    # --- parameter accessors (reproduced surface) -------------------------
-    def getParameter(self, name: str):
+    # -- parameter accessors (reproduced surface) ---------------------------
+    def getParameter(self, name):
         return self.parent.getParameter(name)
 
-    def getParameterValue(self, name: str):
+    def getParameterValue(self, name):
         return self.parent.getParameter(name).value
 
-    # --- exact involute math (pinned) -------------------------------------
+    # -----------------------------------------------------------------------
     def calculateInvolutePoint(self, baseRadius, intersectionRadius):
+        """Point on the involute of baseRadius where the unrolled string
+        reaches intersectionRadius. Returns None when the sample sits inside
+        the base circle."""
         if intersectionRadius < baseRadius:
             return None
         alpha = math.acos(baseRadius / intersectionRadius)
-        t = math.tan(alpha)
+        t = math.tan(alpha)          # curve parameter is tan(alpha), NOT inv(alpha)
         x = baseRadius * (math.cos(t) + t * math.sin(t))
         y = baseRadius * (math.sin(t) - t * math.cos(t))
         return adsk.core.Point3D.create(x, y, 0)
 
-    # --- entry point ------------------------------------------------------
     def draw(self, anchorPoint, angle=0):
         self.drawCircles()
         self.drawTooth(angle)
 
-        # Step 5: anchor the sketch. Project the Tools-sketch anchor into this
-        # sketch and make it coincident with the local origin.
+        # -- step 5: anchor the sketch (final action of draw()) -------------
         projected = self.sketch.project(anchorPoint)
         projectedPoint = projected.item(0)
-        self.sketch.geometricConstraints.addCoincident(self.anchorPoint, projectedPoint)
+        self.sketch.geometricConstraints.addCoincident(
+            projectedPoint, self.anchorPoint)
 
-    # --- circles ----------------------------------------------------------
     def drawCircles(self):
         sketch = self.sketch
         circles = sketch.sketchCurves.sketchCircles
         dims = sketch.sketchDimensions
 
-        rootRadius = self.getParameterValue(PARAM_ROOT_RADIUS)
-        tipRadius = self.getParameterValue(PARAM_TIP_RADIUS)
-        baseRadius = self.getParameterValue(PARAM_BASE_RADIUS)
-        pitchRadius = self.getParameterValue(PARAM_PITCH_RADIUS)
+        rootRadius = self.getParameterValue(PARAM_ROOT_CIRCLE_RADIUS)
+        tipRadius = self.getParameterValue(PARAM_TIP_CIRCLE_RADIUS)
+        baseRadius = self.getParameterValue(PARAM_BASE_CIRCLE_RADIUS)
+        pitchRadius = self.getParameterValue(PARAM_PITCH_CIRCLE_RADIUS)
 
         size = tipRadius - rootRadius
 
-        def addCircle(name, radius, isConstruction):
+        def make(name, radius, isConstruction):
+            # Share the local origin directly as the center (no separate
+            # coincident) so all four circles share that one point.
             circle = circles.addByCenterRadius(self.anchorPoint, radius)
             circle.isConstruction = isConstruction
-            # off-centre text point for the diameter dimension
-            textPoint = adsk.core.Point3D.create(radius, radius, 0)
-            dims.addDiameterDimension(circle, textPoint)
+            # Driving diameter dimension; text point off-centre.
+            dims.addDiameterDimension(
+                circle, adsk.core.Point3D.create(radius, 0, 0))
+            # Along-path label.
             label = '{} (r={:.2f}, size={:.2f})'.format(name, radius, size)
             textInput = sketch.sketchTexts.createInput2(label, size)
             textInput.setAsAlongPath(
@@ -195,194 +217,196 @@ class SpurGearInvoluteToothDesignGenerator:
             sketch.sketchTexts.add(textInput)
             return circle
 
-        addCircle('Root Circle', rootRadius, False)
-        addCircle('Tip Circle', tipRadius, True)
-        addCircle('Base Circle', baseRadius, True)
-        addCircle('Pitch Circle', pitchRadius, True)
+        self.rootCircle = make('Root Circle', rootRadius, False)
+        self.tipCircle = make('Tip Circle', tipRadius, True)
+        self.baseCircle = make('Base Circle', baseRadius, True)
+        self.pitchCircle = make('Pitch Circle', pitchRadius, True)
 
-    # --- tooth ------------------------------------------------------------
     def drawTooth(self, angle=0):
         sketch = self.sketch
-        rootRadius = self.getParameterValue(PARAM_ROOT_RADIUS)
-        tipRadius = self.getParameterValue(PARAM_TIP_RADIUS)
-        baseRadius = self.getParameterValue(PARAM_BASE_RADIUS)
-        pitchRadius = self.getParameterValue(PARAM_PITCH_RADIUS)
+        baseRadius = self.getParameterValue(PARAM_BASE_CIRCLE_RADIUS)
+        tipRadius = self.getParameterValue(PARAM_TIP_CIRCLE_RADIUS)
+        rootRadius = self.getParameterValue(PARAM_ROOT_CIRCLE_RADIUS)
+        pitchRadius = self.getParameterValue(PARAM_PITCH_CIRCLE_RADIUS)
         toothNumber = self.getParameterValue(PARAM_TOOTH_NUMBER)
-        involuteSteps = int(self.getParameterValue(PARAM_INVOLUTE_STEPS))
+        steps = int(self.getParameterValue(PARAM_INVOLUTE_STEPS))
 
-        # 1. Sample the involute flank from the base circle out to the tip
-        #    circle in equal radial steps. First sample radius is EXACTLY the
-        #    base radius (do not clamp to max(base, root)).
-        samplePoints = []
-        for i in range(0, involuteSteps):
-            r = baseRadius + (tipRadius - baseRadius) * (i / (involuteSteps - 1))
+        # -- step 4.1: sample the involute flank -----------------------------
+        # First sample radius is exactly baseRadius (no clamping to root).
+        samples = []
+        for i in range(steps):
+            r = baseRadius + (tipRadius - baseRadius) * i / (steps - 1)
             p = self.calculateInvolutePoint(baseRadius, r)
             if p is None:
                 continue
-            samplePoints.append(p)
+            samples.append(p)
 
-        # 2. Mirror across +X (negate y) so the spiral matches a left flank.
-        mirrored = [(p.x, -p.y) for p in samplePoints]
+        # -- step 4.2: mirror across +X so the spiral matches a left flank ---
+        mirrored = [adsk.core.Point3D.create(p.x, -p.y, 0) for p in samples]
 
-        # 3. Analytic pitch-circle crossing angle of the (un-mirrored) involute.
-        pitchCrossing = self.calculateInvolutePoint(baseRadius, pitchRadius)
-        # After mirroring (negate y), the crossing angle is negated too.
-        pitchAngle = -math.atan2(pitchCrossing.y, pitchCrossing.x)
-        # Rotate so that the (mirrored) pitch crossing lands at +pi/(2*N).
-        rotate_angle = (math.pi / (2 * toothNumber)) - pitchAngle
+        # -- step 4.3: analytic pitch-circle crossing angle ------------------
+        pitchPoint = self.calculateInvolutePoint(baseRadius, pitchRadius)
+        # Mirror it too (we measure on the mirrored curve).
+        pitchAngle = math.atan2(-pitchPoint.y, pitchPoint.x)
+        # Rotate so that pitch crossing lands at +pi/(2*toothNumber).
+        rotate_angle = (math.pi / (2.0 * toothNumber)) - pitchAngle
 
-        def rotate(points, theta):
-            c = math.cos(theta)
-            s = math.sin(theta)
-            return [(x * c - y * s, x * s + y * c) for (x, y) in points]
+        def rotate(points, a):
+            ca = math.cos(a)
+            sa = math.sin(a)
+            return [adsk.core.Point3D.create(
+                p.x * ca - p.y * sa, p.x * sa + p.y * ca, 0) for p in points]
 
-        # 4. Rotate the mirrored points -> left flank. Then mirror across X -> right.
-        leftFlank = rotate(mirrored, rotate_angle)
-        rightFlank = [(x, -y) for (x, y) in leftFlank]
+        # -- step 4.4: rotate to form the left flank, mirror for the right ---
+        leftPoints = rotate(mirrored, rotate_angle)
+        rightPoints = [adsk.core.Point3D.create(p.x, -p.y, 0) for p in leftPoints]
 
-        # Then apply the requested angle to the whole +X-centered tooth.
-        leftFlank = rotate(leftFlank, angle)
-        rightFlank = rotate(rightFlank, angle)
+        # Apply the requested `angle` to the whole +X-centered tooth.
+        leftPoints = rotate(leftPoints, angle)
+        rightPoints = rotate(rightPoints, angle)
 
-        # 5. Draw the two flanks as fitted splines through the point collections.
-        def toCollection(points):
-            coll = adsk.core.ObjectCollection.create()
-            for (x, y) in points:
-                coll.add(adsk.core.Point3D.create(x, y, 0))
-            return coll
+        # Tooth-top point at the tip circle, rotated by `angle`.
+        toothTopCoord = adsk.core.Point3D.create(
+            tipRadius * math.cos(angle), tipRadius * math.sin(angle), 0)
 
-        splines = sketch.sketchCurves.sketchFittedSplines
-        leftSpline = splines.add(toCollection(leftFlank))
-        rightSpline = splines.add(toCollection(rightFlank))
+        # -- step 4.5: draw the flanks as fitted splines ---------------------
+        fittedSplines = sketch.sketchCurves.sketchFittedSplines
 
-        # 6. Tooth-top arc (minimal constraint set, [SPUR-F-TOOTHTOP-ARC]).
-        toothTopPoint = sketch.sketchPoints.add(
-            adsk.core.Point3D.create(
-                tipRadius * math.cos(angle), tipRadius * math.sin(angle), 0))
-        tipCircle = self._findCircleByRadius(tipRadius)
-        sketch.geometricConstraints.addCoincident(toothTopPoint, tipCircle)
+        leftCollection = adsk.core.ObjectCollection.create()
+        for p in leftPoints:
+            leftCollection.add(p)
+        leftSpline = fittedSplines.add(leftCollection)
 
-        arcs = sketch.sketchCurves.sketchArcs
-        toothTopArc = arcs.addByThreePoints(
+        rightCollection = adsk.core.ObjectCollection.create()
+        for p in rightPoints:
+            rightCollection.add(p)
+        rightSpline = fittedSplines.add(rightCollection)
+
+        # -- step 4.6: tooth-top arc [SPUR-F-TOOTHTOP-ARC] -------------------
+        toothTopPoint = sketch.sketchPoints.add(toothTopCoord)
+        sketch.geometricConstraints.addCoincident(toothTopPoint, self.tipCircle)
+        arc = sketch.sketchCurves.sketchArcs.addByThreePoints(
             rightSpline.endSketchPoint,
             toothTopPoint.geometry,
             leftSpline.endSketchPoint)
         sketch.sketchDimensions.addDiameterDimension(
-            toothTopArc,
-            adsk.core.Point3D.create(tipRadius * math.cos(angle),
-                                     tipRadius * math.sin(angle) + tipRadius * 0.1, 0))
+            arc, adsk.core.Point3D.create(toothTopCoord.x, toothTopCoord.y, 0))
 
-        # 7. Spine + horizontal reference + angular pin ([SPUR-F-SPINE]).
-        lines = sketch.sketchCurves.sketchLines
-        spine = lines.addByTwoPoints(self.anchorPoint, toothTopPoint)
+        # -- step 4.7: spine [SPUR-F-SPINE] ----------------------------------
+        spine = sketch.sketchCurves.sketchLines.addByTwoPoints(
+            self.anchorPoint, toothTopPoint)
         spine.isConstruction = True
+        spineAngularDimension = None
         if angle == 0:
             sketch.geometricConstraints.addHorizontal(spine)
         else:
-            horizontal = lines.addByTwoPoints(
+            horizontal = sketch.sketchCurves.sketchLines.addByTwoPoints(
                 self.anchorPoint,
                 adsk.core.Point3D.create(tipRadius, 0, 0))
             horizontal.isConstruction = True
             sketch.geometricConstraints.addHorizontal(horizontal)
+            # Pin the far endpoint so the reference line's length is fixed.
             sketch.geometricConstraints.addCoincident(
-                horizontal.endSketchPoint, tipCircle)
+                horizontal.endSketchPoint, self.tipCircle)
+            # Angular dimension from spine to horizontal; text on the bisector.
+            bisR = tipRadius * 0.5
             spineAngularDimension = sketch.sketchDimensions.addAngularDimension(
                 spine, horizontal,
                 adsk.core.Point3D.create(
-                    tipRadius * 0.5 * math.cos(angle / 2),
-                    tipRadius * 0.5 * math.sin(angle / 2), 0))
+                    bisR * math.cos(angle / 2.0),
+                    bisR * math.sin(angle / 2.0), 0))
 
-        # 8. Ribs ([SPUR-F-RIBS]).
-        leftFitPoints = leftSpline.fitPoints
-        rightFitPoints = rightSpline.fitPoints
-        previousMid = self.anchorPoint
-        for i in range(0, leftFitPoints.count):
-            leftFit = leftFitPoints.item(i)
-            rightFit = rightFitPoints.item(i)
-
-            rib = lines.addByTwoPoints(leftFit, rightFit)
+        # -- step 4.8: ribs [SPUR-F-RIBS] ------------------------------------
+        leftFit = leftSpline.fitPoints
+        rightFit = rightSpline.fitPoints
+        previousMidpoint = self.anchorPoint
+        ribCount = min(leftFit.count, rightFit.count)
+        for i in range(ribCount):
+            lp = leftFit.item(i)
+            rp = rightFit.item(i)
+            # 1. rib shares the two fit points; construction.
+            rib = sketch.sketchCurves.sketchLines.addByTwoPoints(lp, rp)
             rib.isConstruction = True
-            # 2. Dimension the rib's aligned length to its current measured value.
-            ribLen = rib.startSketchPoint.geometry.distanceTo(rib.endSketchPoint.geometry)
-            sketch.sketchDimensions.addDistanceDimension(
+            # 2. dimension the rib's aligned length to its measured value.
+            ribLen = lp.geometry.distanceTo(rp.geometry)
+            ribMidText = adsk.core.Point3D.create(
+                (lp.geometry.x + rp.geometry.x) / 2.0,
+                (lp.geometry.y + rp.geometry.y) / 2.0, 0)
+            ribDim = sketch.sketchDimensions.addDistanceDimension(
                 rib.startSketchPoint, rib.endSketchPoint,
                 adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-                adsk.core.Point3D.create(0, 0, 0))
-
-            # 3. Midpoint seeded on the spine: foot of left fit point on the
-            #    line at `angle` through the local origin.
-            fitX = leftFit.geometry.x
-            fitY = leftFit.geometry.y
+                ribMidText)
+            ribDim.parameter.value = ribLen
+            # 3. midpoint seeded on the spine (foot of the left fit point).
+            fitX = lp.geometry.x
+            fitY = lp.geometry.y
             t = fitX * math.cos(angle) + fitY * math.sin(angle)
-            midpoint = sketch.sketchPoints.add(
-                adsk.core.Point3D.create(t * math.cos(angle), t * math.sin(angle), 0))
-
-            # 4. coincident midpoint on spine first
+            midpoint = sketch.sketchPoints.add(adsk.core.Point3D.create(
+                t * math.cos(angle), t * math.sin(angle), 0))
+            # 4. pin the midpoint onto the spine first.
             sketch.geometricConstraints.addCoincident(midpoint, spine)
-            # 5. make it the rib's midpoint
+            # 5. make it the rib's midpoint.
             sketch.geometricConstraints.addMidPoint(midpoint, rib)
-            # 6. make the rib perpendicular to the spine
+            # 6. make the rib perpendicular to the spine.
             sketch.geometricConstraints.addPerpendicular(spine, rib)
-
-            # distance from previous midpoint (origin for the first rib)
-            midDist = previousMid.geometry.distanceTo(midpoint.geometry)
-            sketch.sketchDimensions.addDistanceDimension(
-                previousMid, midpoint,
+            # chain: dimension distance from previous midpoint to this one.
+            chainText = adsk.core.Point3D.create(
+                midpoint.geometry.x, midpoint.geometry.y, 0)
+            chainDim = sketch.sketchDimensions.addDistanceDimension(
+                previousMidpoint, midpoint,
                 adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-                adsk.core.Point3D.create(0, 0, 0))
-            previousMid = midpoint
+                chainText)
+            chainDim.parameter.value = previousMidpoint.geometry.distanceTo(
+                midpoint.geometry)
+            previousMidpoint = midpoint
 
-        # 9. Close the tooth at the root ([SPUR-F-FLANK-ROOT]).
-        flankStartRadius = leftSpline.startSketchPoint.geometry.distanceTo(
-            adsk.core.Point3D.create(0, 0, 0))
-        embedded = flankStartRadius < rootRadius
-        if not embedded:
-            self._drawFlankToRoot(leftSpline.startSketchPoint, rootRadius, angle)
-            self._drawFlankToRoot(rightSpline.startSketchPoint, rootRadius, angle)
+        # -- step 4.9: close the tooth at the root [SPUR-F-FLANK-ROOT] -------
+        leftStart = leftSpline.startSketchPoint
+        rightStart = rightSpline.startSketchPoint
+        flankStartRadius = math.sqrt(
+            leftStart.geometry.x ** 2 + leftStart.geometry.y ** 2)
 
-        # Record the embedded flag on the parent generator.
-        self.parent._lastToothEmbedded = embedded
+        if flankStartRadius > rootRadius:
+            # Flank starts outside the root circle: draw radial flank-to-root
+            # lines on each side. 6-curve loop.
+            self.parent._lastToothEmbedded = False
+            for flankStart in (leftStart, rightStart):
+                gx = flankStart.geometry.x
+                gy = flankStart.geometry.y
+                norm = math.sqrt(gx * gx + gy * gy)
+                rootEndSeed = adsk.core.Point3D.create(
+                    gx / norm * rootRadius, gy / norm * rootRadius, 0)
+                line = sketch.sketchCurves.sketchLines.addByTwoPoints(
+                    rootEndSeed, flankStart)
+                # (a) root-end coincident to the root circle.
+                sketch.geometricConstraints.addCoincident(
+                    line.startSketchPoint, self.rootCircle)
+                # (b) local origin coincident to the line (radial direction).
+                sketch.geometricConstraints.addCoincident(
+                    self.anchorPoint, line)
+        else:
+            # Embedded profile: no flank-to-root lines. 4-curve loop.
+            self.parent._lastToothEmbedded = True
 
-    def _drawFlankToRoot(self, flankStartPoint, rootRadius, angle):
-        sketch = self.sketch
-        lines = sketch.sketchCurves.sketchLines
-        rootCircle = self._findCircleByRadius(rootRadius)
+        # -- step 7 (continued): confirm the rotation [SPUR-F-ROTATE-CONFIRM]
+        if angle != 0 and spineAngularDimension is not None:
+            spineAngularDimension.parameter.value = angle
 
-        # The root end is seeded radially inward from the flank start.
-        startGeom = flankStartPoint.geometry
-        ang = math.atan2(startGeom.y, startGeom.x)
-        rootEndGeometry = adsk.core.Point3D.create(
-            rootRadius * math.cos(ang), rootRadius * math.sin(ang), 0)
-
-        line = lines.addByTwoPoints(rootEndGeometry, flankStartPoint)
-        # (a) root-end coincident to the root circle
-        sketch.geometricConstraints.addCoincident(line.startSketchPoint, rootCircle)
-        # (b) local origin coincident to the line (point-on-line, infinite)
-        sketch.geometricConstraints.addCoincident(self.anchorPoint, line)
-
-    def _findCircleByRadius(self, radius):
-        circles = self.sketch.sketchCurves.sketchCircles
-        for i in range(0, circles.count):
-            c = circles.item(i)
-            if abs(c.radius - radius) < 0.0001:
-                return c
-        return circles.item(0)
-
-    # --- bore -------------------------------------------------------------
     def drawBore(self, anchorPoint, diameter):
+        """Draws the bore circle of `diameter` (cm) centered on the projected
+        anchor, with a driving diameter dimension. Returns the circle."""
         sketch = self.sketch
         projected = sketch.project(anchorPoint)
-        projectedPoint = projected.item(0)
-        circles = sketch.sketchCurves.sketchCircles
-        circle = circles.addByCenterRadius(projectedPoint, diameter / 2)
+        center = projected.item(0)
+        radius = diameter / 2.0
+        circle = sketch.sketchCurves.sketchCircles.addByCenterRadius(
+            center, radius)
         sketch.sketchDimensions.addDiameterDimension(
-            circle, adsk.core.Point3D.create(diameter / 2, diameter / 2, 0))
+            circle, adsk.core.Point3D.create(
+                center.geometry.x + radius, center.geometry.y, 0))
         return circle
 
 
-# ---------------------------------------------------------------------------
-# 4. The orchestrator
-# ---------------------------------------------------------------------------
 class SpurGearGenerator(Generator):
     def __init__(self, design: adsk.fusion.Design):
         super().__init__(design)
@@ -391,23 +415,24 @@ class SpurGearGenerator(Generator):
         self.toolsSketch = None
         self.boreSketch = None
         self._lastToothEmbedded = False
-        self.normalizedPlane = None
+        self._normalizedPlane = None
 
+    # -- subclass hooks ------------------------------------------------------
     def prefixBase(self) -> str:
         return 'SpurGear'
 
-    def newContext(self):
+    def newContext(self) -> SpurGearGenerationContext:
         return SpurGearGenerationContext()
 
-    # --- subclass hooks ---------------------------------------------------
-    def addExtraPrimaryParameters(self, inputs: adsk.core.CommandInputs):
-        pass
+    def chamferWantEdges(self):
+        return 6
 
     def filletHelixFactorExpression(self) -> str:
         return '1'
 
-    def chamferWantEdges(self):
-        return 6
+    def addExtraPrimaryParameters(self, inputs: adsk.core.CommandInputs):
+        # Spur base has no extra primary parameters; subclasses inject theirs.
+        pass
 
     def generateName(self):
         module = self.getParameter(PARAM_MODULE)
@@ -416,151 +441,134 @@ class SpurGearGenerator(Generator):
         return 'Spur Gear (M={}, Tooth={}, Thickness={})'.format(
             module.expression, toothNumber.expression, thickness.expression)
 
-    # --- input processing -------------------------------------------------
+    # -- input reading -------------------------------------------------------
     def processInputs(self, inputs: adsk.core.CommandInputs):
-        # 1. Pull every selection input out FIRST (before occurrence creation),
-        #    to dodge the context shift. (Generation Order / [PB-SELECTION-STASH].)
-        (parentList, _) = get_selection(inputs, INPUT_ID_PARENT)
-        if len(parentList) != 1:
+        # 1. Pull every selection out FIRST (before occurrence creation).
+        parents = get_selection(inputs, INPUT_ID_PARENT)
+        if len(parents) != 1:
             raise Exception('Exactly one Parent Component must be selected')
-        parentEntity = parentList[0]
-        if parentEntity.objectType == adsk.fusion.Occurrence.classType():
-            self.parentComponent = parentEntity.component
+        parent = parents[0]
+        if parent.objectType == adsk.fusion.Occurrence.classType():
+            self.parentComponent = parent.component
         else:
-            self.parentComponent = parentEntity
+            self.parentComponent = parent
 
-        (planeList, _) = get_selection(inputs, INPUT_ID_PLANE)
-        if len(planeList) != 1:
+        planes = get_selection(inputs, INPUT_ID_PLANE)
+        if len(planes) != 1:
             raise Exception('Exactly one Target Plane must be selected')
-        self.plane = planeList[0]
+        self.plane = planes[0]
 
-        (anchorList, _) = get_selection(inputs, INPUT_ID_ANCHOR_POINT)
-        if len(anchorList) != 1:
+        anchors = get_selection(inputs, INPUT_ID_ANCHOR_POINT)
+        if len(anchors) != 1:
             raise Exception('Exactly one Anchor Point must be selected')
-        self.anchorPoint = anchorList[0]
+        self.anchorPoint = anchors[0]
 
-        # 2/3. Register input-sourced numeric/boolean parameters. The first
-        #      addParameter call triggers occurrence creation.
-        (module, ok) = get_value(inputs, INPUT_ID_MODULE, '')
-        self.addParameter(PARAM_MODULE, module, '', 'Module of the gear')
+        # 2/3. Register the input-sourced numeric/bool parameters. The first
+        # addParameter call creates the occurrence (context shift), but the
+        # selections are already stashed on self.
+        self.addParameter(
+            PARAM_MODULE, get_value(inputs, INPUT_ID_MODULE, ''),
+            '', 'Module of the gear')
+        self.addParameter(
+            PARAM_TOOTH_NUMBER, get_value(inputs, INPUT_ID_TOOTH_NUMBER, ''),
+            '', 'Number of teeth')
+        self.addParameter(
+            PARAM_PRESSURE_ANGLE, get_value(inputs, INPUT_ID_PRESSURE_ANGLE, 'rad'),
+            'rad', 'Pressure angle')
+        self.addParameter(
+            PARAM_BORE_DIAMETER, get_value(inputs, INPUT_ID_BORE_DIAMETER, 'mm'),
+            'mm', 'Bore diameter (0 = no bore)')
+        self.addParameter(
+            PARAM_THICKNESS, get_value(inputs, INPUT_ID_THICKNESS, 'mm'),
+            'mm', 'Axial thickness of the gear body')
+        self.addParameter(
+            PARAM_CHAMFER_TOOTH, get_value(inputs, INPUT_ID_CHAMFER_TOOTH, 'mm'),
+            'mm', 'Chamfer distance on the tooth front edges (0 = none)')
 
-        (toothNumber, ok) = get_value(inputs, INPUT_ID_TOOTH_NUMBER, '')
-        self.addParameter(PARAM_TOOTH_NUMBER, toothNumber, '', 'Number of teeth')
-
-        (pressureAngle, ok) = get_value(inputs, INPUT_ID_PRESSURE_ANGLE, 'rad')
-        self.addParameter(PARAM_PRESSURE_ANGLE, pressureAngle, 'rad', 'Pressure angle')
-
-        (boreDiameter, ok) = get_value(inputs, INPUT_ID_BORE_DIAMETER, 'mm')
-        if not ok:
-            # get_value returned the evaluated value as a raw number (internal cm).
-            boreDiameter = adsk.core.ValueInput.createByReal(
-                boreDiameter if isinstance(boreDiameter, (int, float)) else 0)
-        self.addParameter(PARAM_BORE_DIAMETER, boreDiameter, 'mm', 'Bore diameter')
-
-        (thickness, ok) = get_value(inputs, INPUT_ID_THICKNESS, 'mm')
-        self.addParameter(PARAM_THICKNESS, thickness, 'mm', 'Thickness of the gear')
-
-        (chamferTooth, ok) = get_value(inputs, INPUT_ID_CHAMFER_TOOTH, 'mm')
-        self.addParameter(PARAM_CHAMFER_TOOTH, chamferTooth, 'mm', 'Chamfer applied to teeth')
-
-        (sketchOnly, ok) = get_boolean(inputs, INPUT_ID_SKETCH_ONLY)
+        sketchOnly = get_boolean(inputs, INPUT_ID_SKETCH_ONLY)
         self.addParameter(
             PARAM_SKETCH_ONLY,
             adsk.core.ValueInput.createByReal(1 if sketchOnly else 0),
-            '', 'Generate sketches only (1=true, 0=false)')
+            '', 'Generate sketches only (1 = true, 0 = false)')
 
-        # 4. subclass primary parameters before derived parameters reference them.
+        # 4. Subclass primary parameters, before derived ones reference them.
         self.addExtraPrimaryParameters(inputs)
 
-        # 5. Register derived parameters as live Fusion expression strings.
-        self.addParameter(
-            PARAM_PITCH_DIAMETER,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_MODULE)} * {self.parameterName(PARAM_TOOTH_NUMBER)}'),
-            'mm', 'Pitch circle diameter')
-        self.addParameter(
-            PARAM_PITCH_RADIUS,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_PITCH_DIAMETER)} / 2'),
-            'mm', 'Pitch circle radius')
-        self.addParameter(
-            PARAM_BASE_DIAMETER,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_PITCH_DIAMETER)} * cos({self.parameterName(PARAM_PRESSURE_ANGLE)})'),
-            'mm', 'Base circle diameter')
-        self.addParameter(
-            PARAM_BASE_RADIUS,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_BASE_DIAMETER)} / 2'),
-            'mm', 'Base circle radius')
-        self.addParameter(
-            PARAM_ROOT_DIAMETER,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_PITCH_DIAMETER)} - 2.5 * {self.parameterName(PARAM_MODULE)}'),
-            'mm', 'Root circle diameter')
-        self.addParameter(
-            PARAM_ROOT_RADIUS,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_ROOT_DIAMETER)} / 2'),
-            'mm', 'Root circle radius')
-        self.addParameter(
-            PARAM_TIP_DIAMETER,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_PITCH_DIAMETER)} + 2 * {self.parameterName(PARAM_MODULE)}'),
-            'mm', 'Tip circle diameter')
-        self.addParameter(
-            PARAM_TIP_RADIUS,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_TIP_DIAMETER)} / 2'),
-            'mm', 'Tip circle radius')
-        self.addParameter(
-            PARAM_INVOLUTE_STEPS,
-            adsk.core.ValueInput.createByReal(15),
-            '', 'Number of involute samples')
+        # 5. Derived parameters as live Fusion expression strings.
+        def addDerived(name, expr, units, comment):
+            self.addParameter(
+                name, adsk.core.ValueInput.createByString(expr), units, comment)
 
-        # Tooth Space Angle At Root: pre-evaluated in Python (Fusion's expr
-        # engine refuses to mix unitless tan() with the radian PressureAngle).
-        # Register UNITLESS (''), not 'rad' -- it is multiplied by a length below.
+        nMod = self.parameterName(PARAM_MODULE)
+        nTooth = self.parameterName(PARAM_TOOTH_NUMBER)
+        nPress = self.parameterName(PARAM_PRESSURE_ANGLE)
+
+        addDerived(PARAM_PITCH_CIRCLE_DIAMETER,
+                   f'{nMod} * {nTooth}', 'mm', 'Pitch circle diameter')
+        nPitchD = self.parameterName(PARAM_PITCH_CIRCLE_DIAMETER)
+        addDerived(PARAM_PITCH_CIRCLE_RADIUS,
+                   f'{nPitchD} / 2', 'mm', 'Pitch circle radius')
+        addDerived(PARAM_BASE_CIRCLE_DIAMETER,
+                   f'{nPitchD} * cos({nPress})', 'mm', 'Base circle diameter')
+        nBaseD = self.parameterName(PARAM_BASE_CIRCLE_DIAMETER)
+        addDerived(PARAM_BASE_CIRCLE_RADIUS,
+                   f'{nBaseD} / 2', 'mm', 'Base circle radius')
+        addDerived(PARAM_ROOT_CIRCLE_DIAMETER,
+                   f'{nPitchD} - 2.5 * {nMod}', 'mm', 'Root circle diameter')
+        nRootD = self.parameterName(PARAM_ROOT_CIRCLE_DIAMETER)
+        addDerived(PARAM_ROOT_CIRCLE_RADIUS,
+                   f'{nRootD} / 2', 'mm', 'Root circle radius')
+        addDerived(PARAM_TIP_CIRCLE_DIAMETER,
+                   f'{nPitchD} + 2 * {nMod}', 'mm', 'Tip circle diameter')
+        nTipD = self.parameterName(PARAM_TIP_CIRCLE_DIAMETER)
+        addDerived(PARAM_TIP_CIRCLE_RADIUS,
+                   f'{nTipD} / 2', 'mm', 'Tip circle radius')
+
+        addDerived(PARAM_INVOLUTE_STEPS,
+                   str(INVOLUTE_STEPS), '', 'Number of involute samples')
+
+        # Tooth Space Angle At Root: pre-evaluated in Python, registered
+        # UNITLESS (radian magnitude treated as dimensionless).
         toothNumberValue = self.getParameter(PARAM_TOOTH_NUMBER).value
         pressureAngleValue = self.getParameter(PARAM_PRESSURE_ANGLE).value
-        toothSpaceAngle = (math.pi / toothNumberValue) - 2 * (
+        toothSpaceAngle = (math.pi / toothNumberValue) - 2.0 * (
             math.tan(pressureAngleValue) - pressureAngleValue)
         self.addParameter(
             PARAM_TOOTH_SPACE_ANGLE_AT_ROOT,
             adsk.core.ValueInput.createByReal(toothSpaceAngle),
-            '', 'Tooth space angle at the root circle (radian magnitude, unitless)')
+            '', 'Angular width of the valley at the root circle (radians)')
 
-        self.addParameter(
-            PARAM_TOOTH_SPACE_ARC_AT_ROOT,
-            adsk.core.ValueInput.createByString(
-                f'{self.parameterName(PARAM_ROOT_RADIUS)} * {self.parameterName(PARAM_TOOTH_SPACE_ANGLE_AT_ROOT)}'),
-            'mm', 'Tooth space arc length at the root circle')
+        nRootR = self.parameterName(PARAM_ROOT_CIRCLE_RADIUS)
+        nSpaceAngle = self.parameterName(PARAM_TOOTH_SPACE_ANGLE_AT_ROOT)
+        addDerived(PARAM_TOOTH_SPACE_ARC_AT_ROOT,
+                   f'{nRootR} * {nSpaceAngle}', 'mm',
+                   'Arc length of the valley along the root circle')
 
-        self.addParameter(
-            PARAM_FILLET_CLEARANCE,
-            adsk.core.ValueInput.createByReal(0.9),
-            '', 'Fraction of half-valley arc used for the fillet radius')
+        addDerived(PARAM_FILLET_CLEARANCE,
+                   str(FILLET_CLEARANCE), '',
+                   'Fraction of the half-valley arc used for the fillet radius')
 
-        self.addParameter(
-            PARAM_FILLET_RADIUS,
-            adsk.core.ValueInput.createByString(
-                f'({self.parameterName(PARAM_TOOTH_SPACE_ARC_AT_ROOT)} / 2) * '
-                f'{self.parameterName(PARAM_FILLET_CLEARANCE)} * {self.filletHelixFactorExpression()}'),
-            'mm', 'Fillet radius at the tooth root')
+        nSpaceArc = self.parameterName(PARAM_TOOTH_SPACE_ARC_AT_ROOT)
+        nFilletClear = self.parameterName(PARAM_FILLET_CLEARANCE)
+        addDerived(PARAM_FILLET_RADIUS,
+                   f'({nSpaceArc} / 2) * {nFilletClear} * '
+                   f'{self.filletHelixFactorExpression()}',
+                   'mm', 'Root fillet radius')
 
-    # --- top-level orchestration -----------------------------------------
+    # -- orchestration -------------------------------------------------------
     def generate(self, inputs: adsk.core.CommandInputs):
         self.processInputs(inputs)
 
         component = self.getComponent()
         component.name = self.generateName()
 
-        # Normalize self.plane to a ConstructionPlane.
+        # Normalize the plane to a ConstructionPlane.
         if self.plane.objectType != adsk.fusion.ConstructionPlane.classType():
-            planeInput = self.getComponent().constructionPlanes.createInput()
-            planeInput.setByOffset(self.plane, adsk.core.ValueInput.createByReal(0))
-            self.plane = self.getComponent().constructionPlanes.add(planeInput)
-            self.normalizedPlane = self.plane
+            planeInput = component.constructionPlanes.createInput()
+            planeInput.setByOffset(
+                self.plane, adsk.core.ValueInput.createByReal(0))
+            self.plane = component.constructionPlanes.add(planeInput)
+            self._normalizedPlane = self.plane
 
         ctx = self.newContext()
         ctx.plane = self.plane
@@ -569,22 +577,6 @@ class SpurGearGenerator(Generator):
         self.buildMainGearBody(ctx)
         self.buildBore(ctx)
         self.cleanup(ctx)
-
-    # --- steps 1-2 --------------------------------------------------------
-    def prepareTools(self, ctx: SpurGearGenerationContext):
-        # Tools sketch + ctx.anchorPoint
-        toolsSketch = self.createSketchObject('Tools', plane=self.plane)
-        toolsSketch.isVisible = True
-        self.toolsSketch = toolsSketch
-        projected = toolsSketch.project(self.anchorPoint)
-        ctx.anchorPoint = projected.item(0)
-
-        # Extrusion End Plane at distance Thickness from the target plane.
-        planeInput = self.getComponent().constructionPlanes.createInput()
-        planeInput.setByOffset(self.plane, self.getParameterAsValueInput(PARAM_THICKNESS))
-        endPlane = self.getComponent().constructionPlanes.add(planeInput)
-        endPlane.name = 'Extrusion End Plane'
-        ctx.extrusionEndPlane = endPlane
 
     def buildMainGearBody(self, ctx: SpurGearGenerationContext):
         self.buildSketches(ctx)
@@ -598,72 +590,85 @@ class SpurGearGenerator(Generator):
         self.buildBody(ctx)
         self.patternTeeth(ctx)
 
-    # --- step 3-5 ---------------------------------------------------------
+    # -- step 1-2 ------------------------------------------------------------
+    def prepareTools(self, ctx: SpurGearGenerationContext):
+        # Step 2: Tools sketch + projected anchor.
+        toolsSketch = self.createSketchObject('Tools', plane=self.plane)
+        toolsSketch.isVisible = True
+        self.toolsSketch = toolsSketch
+
+        projected = toolsSketch.project(self.anchorPoint)
+        ctx.anchorPoint = projected.item(0)
+
+        # Offset construction plane used as the to-entity for the extrudes.
+        thicknessValue = self.getParameter(PARAM_THICKNESS).value
+        planeInput = self.getComponent().constructionPlanes.createInput()
+        planeInput.setByOffset(
+            self.plane, adsk.core.ValueInput.createByReal(thicknessValue))
+        endPlane = self.getComponent().constructionPlanes.add(planeInput)
+        endPlane.name = 'Extrusion End Plane'
+        ctx.extrusionEndPlane = endPlane
+
+    # -- step 3-5 ------------------------------------------------------------
     def buildSketches(self, ctx: SpurGearGenerationContext):
-        gearProfileSketch = self.createSketchObject('Gear Profile', plane=self.plane)
+        gearProfileSketch = self.createSketchObject(
+            'Gear Profile', plane=self.plane)
         gearProfileSketch.isVisible = True
         ctx.gearProfileSketch = gearProfileSketch
 
-        generator = SpurGearInvoluteToothDesignGenerator(gearProfileSketch, self)
+        generator = SpurGearInvoluteToothDesignGenerator(
+            gearProfileSketch, self)
         generator.draw(ctx.anchorPoint, angle=0)
 
         ctx.toothProfileIsEmbedded = self._lastToothEmbedded
 
-    # --- step 7-8 ---------------------------------------------------------
+    # -- step 7-8 ------------------------------------------------------------
     def buildTooth(self, ctx: SpurGearGenerationContext):
-        profile = self._findToothProfile(ctx)
+        sketch = ctx.gearProfileSketch
+        lines = 0 if ctx.toothProfileIsEmbedded else 2
+        toothProfile = find_profile_by_curve_counts(
+            sketch, nurbs=2, arcs=2, lines=lines)
+
         extrudes = self.getComponent().features.extrudeFeatures
         extrudeInput = extrudes.createInput(
-            profile, adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
-        extent = adsk.fusion.ToEntityExtentDefinition.create(ctx.extrusionEndPlane, False)
-        extrudeInput.setOneSideExtent(extent, adsk.fusion.ExtentDirections.PositiveExtentDirection)
+            toothProfile,
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        extent = adsk.fusion.ToEntityExtentDefinition.create(
+            ctx.extrusionEndPlane, False)
+        extrudeInput.setOneSideExtent(
+            extent, adsk.fusion.ExtentDirections.PositiveExtentDirection)
         extrude = extrudes.add(extrudeInput)
         extrude.name = 'Extrude tooth'
         ctx.toothBody = extrude.bodies.item(0)
 
         self.chamferTooth(ctx)
 
-    def _findToothProfile(self, ctx: SpurGearGenerationContext):
-        if ctx.toothProfileIsEmbedded:
-            expectedCount = 4
-        else:
-            expectedCount = 6
-        sketch = ctx.gearProfileSketch
-        for profile in sketch.profiles:
-            for loop in profile.profileLoops:
-                if loop.profileCurves.count != expectedCount:
-                    continue
-                nurbs = 0
-                arcs = 0
-                lineCount = 0
-                for k in range(0, loop.profileCurves.count):
-                    curveType = loop.profileCurves.item(k).geometry.curveType
-                    if curveType == adsk.core.Curve3DTypes.NurbsCurve3DCurveType:
-                        nurbs += 1
-                    elif curveType == adsk.core.Curve3DTypes.Arc3DCurveType:
-                        arcs += 1
-                    elif curveType == adsk.core.Curve3DTypes.Line3DCurveType:
-                        lineCount += 1
-                expectedLines = 0 if ctx.toothProfileIsEmbedded else 2
-                if nurbs == 2 and arcs == 2 and lineCount == expectedLines:
-                    return profile
-        raise Exception('Could not find the tooth cross-section profile')
-
     def chamferTooth(self, ctx: SpurGearGenerationContext):
         chamferValue = self.getParameter(PARAM_CHAMFER_TOOTH).value
         if chamferValue <= 0:
             return
 
-        rootRadius = self.getParameter(PARAM_ROOT_RADIUS).value
+        wantEdges = self.chamferWantEdges()
+        sketchPlane = ctx.gearProfileSketch.referencePlane.geometry
+        rootRadius = self.getParameter(PARAM_ROOT_CIRCLE_RADIUS).value
 
-        frontFace = self._findToothFrontFace(ctx)
+        frontFace = None
+        for face in ctx.toothBody.faces:
+            if face.edges.count != wantEdges:
+                continue
+            if sketchPlane.isCoPlanarTo(face.geometry):
+                frontFace = face
+                break
+        if frontFace is None:
+            raise Exception('Chamfer: tooth front face not found '
+                            f'(want {wantEdges} edges, coplanar with sketch)')
+
         edges = adsk.core.ObjectCollection.create()
-        for i in range(0, frontFace.edges.count):
-            edge = frontFace.edges.item(i)
-            geom = edge.geometry
-            if geom.curveType == adsk.core.Curve3DTypes.Arc3DCurveType:
-                if abs(geom.radius - rootRadius) < 0.001:
-                    continue
+        for edge in frontFace.edges:
+            curve = edge.geometry
+            if (curve.curveType == adsk.core.Curve3DTypes.Arc3DCurveType and
+                    abs(curve.radius - rootRadius) < 0.001):
+                continue  # skip the root arc
             edges.add(edge)
 
         chamfers = self.getComponent().features.chamferFeatures
@@ -672,72 +677,53 @@ class SpurGearGenerator(Generator):
             edges, adsk.core.ValueInput.createByReal(chamferValue), False)
         chamfers.add(chamferInput)
 
-    def _findToothFrontFace(self, ctx: SpurGearGenerationContext):
-        wantEdges = self.chamferWantEdges()
-        for i in range(0, ctx.toothBody.faces.count):
-            face = ctx.toothBody.faces.item(i)
-            if face.edges.count == wantEdges:
-                return face
-        raise Exception(
-            'Could not find the tooth front face (expected {} edges)'.format(wantEdges))
-
-    # --- step 9 -----------------------------------------------------------
+    # -- step 9 --------------------------------------------------------------
     def buildBody(self, ctx: SpurGearGenerationContext):
-        bodyProfile = self._findBodyProfile(ctx)
+        sketch = ctx.gearProfileSketch
+        bodyProfile = find_profile_by_curve_counts(sketch, arcs=2)
+
         extrudes = self.getComponent().features.extrudeFeatures
         extrudeInput = extrudes.createInput(
-            bodyProfile, adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
-        extent = adsk.fusion.ToEntityExtentDefinition.create(ctx.extrusionEndPlane, False)
-        extrudeInput.setOneSideExtent(extent, adsk.fusion.ExtentDirections.PositiveExtentDirection)
+            bodyProfile,
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        extent = adsk.fusion.ToEntityExtentDefinition.create(
+            ctx.extrusionEndPlane, False)
+        extrudeInput.setOneSideExtent(
+            extent, adsk.fusion.ExtentDirections.PositiveExtentDirection)
         extrude = extrudes.add(extrudeInput)
         extrude.name = 'Extrude body'
-        gearBody = extrude.bodies.item(0)
-        gearBody.name = 'Gear Body'
+
+        body = extrude.bodies.item(0)
+        body.name = 'Gear Body'
 
         sketchPlane = ctx.gearProfileSketch.referencePlane.geometry
-
         centerAxis = None
         extrusionExtent = None
-        for i in range(0, gearBody.faces.count):
-            face = gearBody.faces.item(i)
+        for face in body.faces:
             surfaceType = face.geometry.surfaceType
-            if surfaceType == adsk.core.SurfaceTypes.CylinderSurfaceType and centerAxis is None:
-                axes = self.getComponent().constructionAxes
-                axisInput = axes.createInput()
-                axisInput.setByCircularFace(face)
-                centerAxis = axes.add(axisInput)
-                centerAxis.name = 'Gear Center'
-                centerAxis.isLightBulbOn = False
+            if surfaceType == adsk.core.SurfaceTypes.CylinderSurfaceType:
+                if centerAxis is None:
+                    axisInput = self.getComponent().constructionAxes.createInput()
+                    axisInput.setByCircularFace(face)
+                    centerAxis = self.getComponent().constructionAxes.add(
+                        axisInput)
+                    centerAxis.name = 'Gear Center'
+                    centerAxis.isLightBulbOn = False
             elif surfaceType == adsk.core.SurfaceTypes.PlaneSurfaceType:
-                faceGeom = face.geometry
-                if sketchPlane.isParallelToPlane(faceGeom) and not sketchPlane.isCoPlanarTo(faceGeom):
+                if (sketchPlane.isParallelToPlane(face.geometry) and
+                        not sketchPlane.isCoPlanarTo(face.geometry)):
                     extrusionExtent = face
 
         if centerAxis is None:
-            raise Exception('Could not build the Gear Center axis (no cylindrical face found)')
+            raise Exception('Gear body: no cylindrical face for Gear Center axis')
         if extrusionExtent is None:
-            raise Exception('Could not find the far end-cap face for the bore extent')
+            raise Exception('Gear body: far end-cap face not found')
 
         ctx.centerAxis = centerAxis
         ctx.extrusionExtent = extrusionExtent
-        ctx.gearBody = gearBody
+        ctx.gearBody = body
 
-    def _findBodyProfile(self, ctx: SpurGearGenerationContext):
-        sketch = ctx.gearProfileSketch
-        for profile in sketch.profiles:
-            for loop in profile.profileLoops:
-                if loop.profileCurves.count != 2:
-                    continue
-                allArcs = True
-                for k in range(0, loop.profileCurves.count):
-                    if loop.profileCurves.item(k).geometry.curveType != adsk.core.Curve3DTypes.Arc3DCurveType:
-                        allArcs = False
-                        break
-                if allArcs:
-                    return profile
-        raise Exception('Could not find the annular gear body profile (2 arcs)')
-
-    # --- step 10-11 -------------------------------------------------------
+    # -- step 10-11 ----------------------------------------------------------
     def patternTeeth(self, ctx: SpurGearGenerationContext):
         toothNumber = int(self.getParameter(PARAM_TOOTH_NUMBER).value)
 
@@ -748,16 +734,16 @@ class SpurGearGenerator(Generator):
         patternInput = patterns.createInput(inputBodies, ctx.centerAxis)
         patternInput.quantity = adsk.core.ValueInput.createByReal(toothNumber)
         patternInput.totalAngle = adsk.core.ValueInput.createByString('360 deg')
-        patternResult = patterns.add(patternInput)
+        patternInput.isSymmetric = False
+        pattern = patterns.add(patternInput)
 
-        # CircularPatternFeature.bodies already includes ALL N tooth bodies
-        # (original + N-1 copies). Feed the whole collection -- do not re-add.
-        combineTools = adsk.core.ObjectCollection.create()
-        for i in range(0, patternResult.bodies.count):
-            combineTools.add(patternResult.bodies.item(i))
+        # pattern.bodies already includes all N tooth bodies (seed + copies).
+        toolBodies = adsk.core.ObjectCollection.create()
+        for i in range(pattern.bodies.count):
+            toolBodies.add(pattern.bodies.item(i))
 
         combines = self.getComponent().features.combineFeatures
-        combineInput = combines.createInput(ctx.gearBody, combineTools)
+        combineInput = combines.createInput(ctx.gearBody, toolBodies)
         combineInput.operation = adsk.fusion.FeatureOperations.JoinFeatureOperation
         combines.add(combineInput)
 
@@ -768,22 +754,21 @@ class SpurGearGenerator(Generator):
         if filletRadius <= 0:
             return
 
-        rootRadius = self.getParameter(PARAM_ROOT_RADIUS).value
-        axisNormal = get_normal(self.plane)
+        rootRadius = self.getParameter(PARAM_ROOT_CIRCLE_RADIUS).value
+        axisNormal = self.plane.geometry.normal
+        axisNormal.normalize()
 
         edges = adsk.core.ObjectCollection.create()
-        for i in range(0, ctx.gearBody.faces.count):
-            face = ctx.gearBody.faces.item(i)
+        for face in ctx.gearBody.faces:
             if face.geometry.surfaceType != adsk.core.SurfaceTypes.CylinderSurfaceType:
                 continue
             if abs(face.geometry.radius - rootRadius) >= 0.001:
                 continue
-            for j in range(0, face.edges.count):
-                edge = face.edges.item(j)
-                geom = edge.geometry
-                if geom.curveType != adsk.core.Curve3DTypes.Line3DCurveType:
+            for edge in face.edges:
+                curve = edge.geometry
+                if curve.curveType != adsk.core.Curve3DTypes.Line3DCurveType:
                     continue
-                direction = geom.startPoint.vectorTo(geom.endPoint)
+                direction = curve.startPoint.vectorTo(curve.endPoint)
                 direction.normalize()
                 dot = direction.dotProduct(axisNormal)
                 if abs(abs(dot) - 1.0) < 0.01:
@@ -794,11 +779,11 @@ class SpurGearGenerator(Generator):
 
         fillets = self.getComponent().features.filletFeatures
         filletInput = fillets.createInput()
-        filletInput.edgeSetInputs.addConstantRadiusEdgeSet(
+        filletInput.addConstantRadiusEdgeSet(
             edges, adsk.core.ValueInput.createByReal(filletRadius), False)
         fillets.add(filletInput)
 
-    # --- step 12 ----------------------------------------------------------
+    # -- step 12 -------------------------------------------------------------
     def buildBore(self, ctx: SpurGearGenerationContext):
         if self.getParameterAsBoolean(PARAM_SKETCH_ONLY):
             return
@@ -810,35 +795,33 @@ class SpurGearGenerator(Generator):
         boreSketch.isVisible = True
         self.boreSketch = boreSketch
 
-        projected = boreSketch.project(ctx.anchorPoint)
-        projectedPoint = projected.item(0)
-        circles = boreSketch.sketchCurves.sketchCircles
-        circle = circles.addByCenterRadius(projectedPoint, boreDiameter / 2)
-        boreSketch.sketchDimensions.addDiameterDimension(
-            circle, adsk.core.Point3D.create(boreDiameter / 2, boreDiameter / 2, 0))
+        generator = SpurGearInvoluteToothDesignGenerator(boreSketch, self)
+        circle = generator.drawBore(ctx.anchorPoint, boreDiameter)
 
-        profile = boreSketch.profiles.item(0)
+        boreProfile = boreSketch.profiles.item(0)
         extrudes = self.getComponent().features.extrudeFeatures
         extrudeInput = extrudes.createInput(
-            profile, adsk.fusion.FeatureOperations.CutFeatureOperation)
-        extent = adsk.fusion.ToEntityExtentDefinition.create(ctx.extrusionExtent, False)
-        extrudeInput.setOneSideExtent(extent, adsk.fusion.ExtentDirections.PositiveExtentDirection)
+            boreProfile, adsk.fusion.FeatureOperations.CutFeatureOperation)
+        extent = adsk.fusion.ToEntityExtentDefinition.create(
+            ctx.extrusionExtent, False)
+        extrudeInput.setOneSideExtent(
+            extent, adsk.fusion.ExtentDirections.PositiveExtentDirection)
         extrudeInput.participantBodies = [ctx.gearBody]
         extrudes.add(extrudeInput)
 
-    # --- cleanup ----------------------------------------------------------
+    # -- cleanup (last action of generate) -----------------------------------
     def cleanup(self, ctx: SpurGearGenerationContext):
         sketchOnly = self.getParameterAsBoolean(PARAM_SKETCH_ONLY)
 
-        # Construction-plane/axis hiding ALWAYS runs (both modes).
+        # Construction plane/axis hiding ALWAYS runs (both modes).
         if ctx.extrusionEndPlane is not None:
             ctx.extrusionEndPlane.isLightBulbOn = False
         if ctx.centerAxis is not None:
             ctx.centerAxis.isLightBulbOn = False
-        if self.normalizedPlane is not None:
-            self.normalizedPlane.isLightBulbOn = False
+        if self._normalizedPlane is not None:
+            self._normalizedPlane.isLightBulbOn = False
 
-        # Sketch hiding runs only on the full-build path.
+        # Sketch hiding runs ONLY on the full-build path.
         if not sketchOnly:
             if self.toolsSketch is not None:
                 self.toolsSketch.isVisible = False

--- a/lib/geargen/spurproxy.py
+++ b/lib/geargen/spurproxy.py
@@ -1,0 +1,45 @@
+# A fake spur `parent` for SpurGearInvoluteToothDesignGenerator, so a gear
+# can borrow the spur tooth drawer without registering Fusion user parameters
+# ([PB-PRECOMPUTED-MODE]). It serves, in internal cm, exactly the parameter
+# keys the spur drawer reads, and carries the `_lastToothEmbedded` output
+# slot the drawer writes during draw() — read it back after drawing.
+
+import math
+from .misc import to_cm
+
+
+class Val:
+    def __init__(self, value):
+        self.value = value
+
+
+class VirtualSpurProxy:
+    def __init__(self, module_mm, virtualTeeth,
+                 pressureAngleRad=math.radians(20.0), involuteSteps=15):
+        # OUTPUT slot the spur drawer writes during draw().
+        self._lastToothEmbedded = False
+
+        # Standard spur formulas (Module here is raw mm):
+        pitch = virtualTeeth * module_mm               # pitch diameter (mm)
+        base = pitch * math.cos(pressureAngleRad)      # base diameter (mm)
+        root = pitch - 2.5 * module_mm                 # root diameter (mm)
+        tip = pitch + 2.0 * module_mm                  # tip diameter (mm)
+
+        # Serve every key the spur drawer reads, in internal cm.
+        self._params = {
+            'Module': to_cm(module_mm),
+            'ToothNumber': virtualTeeth,
+            'PressureAngle': pressureAngleRad,
+            'PitchCircleDiameter': to_cm(pitch),
+            'PitchCircleRadius': to_cm(pitch / 2.0),
+            'BaseCircleDiameter': to_cm(base),
+            'BaseCircleRadius': to_cm(base / 2.0),
+            'RootCircleDiameter': to_cm(root),
+            'RootCircleRadius': to_cm(root / 2.0),
+            'TipCircleDiameter': to_cm(tip),
+            'TipCircleRadius': to_cm(tip / 2.0),
+            'InvoluteSteps': involuteSteps,
+        }
+
+    def getParameter(self, name):
+        return Val(self._params[name])

--- a/lib/geargen/utilities.py
+++ b/lib/geargen/utilities.py
@@ -1,5 +1,41 @@
 import adsk.core, adsk.fusion
 
+def find_profile_by_curve_counts(sketch, nurbs=0, arcs=0, lines=0):
+    """Return the profile whose loop has exactly the given curve-type counts
+    (NURBS / arcs / lines, and no curves of any other type). Raises with a
+    self-diagnosing message when no loop matches ([PB-PROFILE-MATCH]) — never
+    falls back to a wrong profile."""
+    Curve3DTypes = adsk.core.Curve3DTypes
+    for profile in sketch.profiles:
+        for loop in profile.profileLoops:
+            nurbsN = arcsN = linesN = othersN = 0
+            for pc in loop.profileCurves:
+                ct = pc.geometry.curveType
+                if ct == Curve3DTypes.NurbsCurve3DCurveType:
+                    nurbsN += 1
+                elif ct == Curve3DTypes.Arc3DCurveType:
+                    arcsN += 1
+                elif ct == Curve3DTypes.Line3DCurveType:
+                    linesN += 1
+                else:
+                    othersN += 1
+            if nurbsN == nurbs and arcsN == arcs and linesN == lines and othersN == 0:
+                return profile
+    raise Exception(
+        f'Could not find profile in sketch "{sketch.name}" '
+        f'({nurbs} NURBS + {arcs} arcs + {lines} lines)')
+
+def find_circle_by_radius(sketch, radius, tolerance=0.0001):
+    """Return the sketch circle whose radius matches within tolerance (cm).
+    Raises when no circle matches — never falls back to a wrong circle."""
+    circles = sketch.sketchCurves.sketchCircles
+    for i in range(0, circles.count):
+        c = circles.item(i)
+        if abs(c.radius - radius) < tolerance:
+            return c
+    raise Exception(
+        f'No circle of radius {radius} (tolerance {tolerance}) in sketch "{sketch.name}"')
+
 def get_normal(entity) -> adsk.core.Vector3D:
     otyp = entity.objectType 
     if otyp == adsk.fusion.BRepFace.classType():

--- a/spec/bevelgear/fusion.md
+++ b/spec/bevelgear/fusion.md
@@ -124,4 +124,5 @@ in `PLAYBOOK.md` still apply).
   (dedupe by `entityToken`) and set `isLightBulbOn = False` on every sketch, construction plane, and
   construction axis (construction planes/axes are **not** hidden by `isVisible` — see
   `[PB-HIDE-AFTER-USE]`). There is no sketch-only mode and no per-mode guard — bevel always builds
-  solids.
+  solids. (Realized by the framework's `solids.hide_construction_geometry(bevelComponent)` — call
+  it, don't re-implement the walk.)

--- a/spec/bevelgear/instructions.md
+++ b/spec/bevelgear/instructions.md
@@ -92,10 +92,13 @@ numeric/bool fields. Module-level constants name the input ids (`INPUT_ID_PLANE 
 | 15 | Mean Spiral Angle | `spiralAngle` | `addValueInput` | `deg` | `createByString('35 deg')` | — |
 | 16 | Hand of Spiral | `spiralHand` | `addDropDownCommandInput` (text-list) | — | items `Right` (selected), `Left` | — |
 | 17 | Cutter Radius | `cutterRadius` | `addValueInput` | `mm` | `createByReal(to_cm(0))` | — |
-There are now **17** dialog inputs and **17 `INPUT_ID_*`** module constants (the 14 above plus
-`INPUT_ID_SPIRAL_ANGLE='spiralAngle'`, `INPUT_ID_HAND='spiralHand'`,
-`INPUT_ID_CUTTER_RADIUS='cutterRadius'`). Inputs 15–17 are
-appended **after** Tooth Spacing in display order. The Hand dropdown is a
+There are now **17** dialog inputs and **17 `INPUT_ID_*`** module constants, named exactly:
+`INPUT_ID_PLANE`, `INPUT_ID_CENTER_POINT`, `INPUT_ID_PARENT`, `INPUT_ID_MODULE`,
+`INPUT_ID_SHAFT_ANGLE`, `INPUT_ID_DRIVING_TEETH`, `INPUT_ID_PINION_TEETH`,
+`INPUT_ID_DRIVING_BASE_HEIGHT`, `INPUT_ID_PINION_BASE_HEIGHT`, `INPUT_ID_BORE_ENABLE`,
+`INPUT_ID_DRIVING_BORE`, `INPUT_ID_PINION_BORE`, `INPUT_ID_FACE_WIDTH`, `INPUT_ID_TOOTH_SPACING`,
+`INPUT_ID_SPIRAL_ANGLE`, `INPUT_ID_HAND`, `INPUT_ID_CUTTER_RADIUS` — holding the table's id
+strings in row order. Inputs 15–17 are appended **after** Tooth Spacing in display order. The Hand dropdown is a
 `DropDownStyles.TextListDropDownStyle` with `Right` added selected and `Left` added unselected; read
 its `selectedItem.name` (default `Right` if none). `spiralAngle` reads back in radians (range-check
 [0, 60)° after converting to degrees); `cutterRadius` reads back in internal cm via `'mm'`. Still **no live
@@ -131,7 +134,8 @@ under a prefix. Every value (pitch diameters, cone distance, base heights, bore 
 tooth counts, face width) is **precomputed in Python in internal cm** and written into geometry
 numerically — sketch dimensions via `dimension.parameter.value = <number>` and feature inputs via
 `ValueInput.createByReal(<number>)`. There are therefore no `PARAM_*` name strings to reproduce;
-the only module-level constants are the 14 `INPUT_ID_*` strings. (`[PB-PRECOMPUTED-MODE]`.)
+the only module-level constants are the 17 `INPUT_ID_*` strings plus `_HAND_RIGHT`/`_HAND_LEFT`.
+(`[PB-PRECOMPUTED-MODE]`.)
 
 **Reading the raw numbers.** Read each numeric/angle input by evaluating its expression with units
 `''`/`'mm'`/`'deg'` as appropriate; the values come back in Fusion internal units (cm / radians)
@@ -146,15 +150,15 @@ regardless of the unit string (`[PB-EVAL-EXPRESSION]`).
   module of `1` is 1 mm). Therefore **every length derived from Module must be `to_cm`-converted
   before it touches geometry**: Pitch Diameter = `to_cm(Module * teeth)`, Cone Distance = `to_cm(...)`,
   dedendum = `to_cm(1.25 * Module)`, the module-length construction extensions (E, F, G, H, I, J),
-  and the default Face Width (`Cone Distance / 6`). The `_VirtualSpurProxy` likewise receives Module
+  and the default Face Width (`Cone Distance / 6`). The `VirtualSpurProxy` likewise receives Module
   in mm and applies the standard spur formulas, then `to_cm`'s the resulting circle radii/diameters
   it serves (they must be in cm, matching what the spur tooth generator expects). Mixing a raw-mm
   Module-derived length with an already-cm `'mm'` input (e.g. comparing Face Width against the
   Module-derived Maximum Face Width) without this conversion makes the gear come out ~10× off and
   the Face-Width bound meaningless. The boolean Enable-Bore input is read with
 `get_boolean` (or `input.value`). Read all inputs up front in a single `_readInputs` pass that
-validates ranges (teeth ≥ 3, shaft angle 30–150°, non-negative heights/bores/width/tooth-spacing) and returns the
-primary values, stashing the rest on `self`.
+validates ranges (module > 0, teeth ≥ 3, shaft angle 30–150°, non-negative
+heights/bores/width/tooth-spacing) and returns the primary values, stashing the rest on `self`.
 
 ## Architecture
 
@@ -162,8 +166,8 @@ Bevel uses a **standalone generator** — it does **not** subclass `base.Generat
 `GenerationContext`**. **One** generator handles **both** straight and spiral bevels: the same class
 builds a straight bevel when Mean Spiral Angle ψ = 0 and a curved (spiral) bevel when ψ > 0. There is
 **no separate spiral subclass or command** — the spiral is a branch inside the tooth-body step
-(`_transformToothBody`, see Method contract), gated on ψ. Three plain classes (names are the
-reproduced surface; the entry point binds the first and second by name):
+(`_transformToothBody`, see Method contract), gated on ψ. Two plain classes plus one framework
+import (names are the reproduced surface; the entry point binds the two classes by name):
 
 1. **`BevelGearCommandInputsConfigurator`** — `@classmethod def configure(cls, cmd)` that adds the
    **17** dialog inputs above in display order, plus `@classmethod def handle_input_changed(cls, args)`
@@ -174,11 +178,14 @@ reproduced surface; the entry point binds the first and second by name):
    = None`); `generate(inputs)`; `deleteComponent()`. Creates the occurrence tree directly with
    `parent.occurrences.addNewComponent(...)` — it does **not** use `getOccurrence` / `addParameter`
    / `parameterName` / `createSketchObject` from `base.Generator`, and registers no user parameters.
-3. **`_VirtualSpurProxy`** (with a tiny `_Val` value-wrapper) — a fake spur `parent` so the borrowed
-   spur tooth generator can run without registering Fusion user parameters. See Dependencies.
+3. The virtual-spur proxy is **imported from the framework** — `from .spurproxy import
+   VirtualSpurProxy` — a fake spur `parent` so the borrowed spur tooth generator can run without
+   registering Fusion user parameters. Bevel defines **no local proxy or value-wrapper class**.
+   See Dependencies.
 
-`base.py` is star-imported but its `Generator`/`ParamNamePrefix`/`ComponentCleaner` machinery is
-unused.
+From `base.py` import only the input readers (`get_selection`, `get_boolean`) — its
+`Generator`/`ParamNamePrefix`/`ComponentCleaner` machinery is unused. Imports are explicit per the
+PLAYBOOK's Module-layout rule (no `import *`).
 
 ## Generation Context — none
 
@@ -210,7 +217,7 @@ generate(inputs)
   → _buildGearProfiles(...)                  # §2 + §3 + per-gear body creation; internally:
         → _buildVirtualSpurProfile(...)  ×2  # §3 pinion then driving: tooth plane + spur tooth + axis
         → _createGearBody(...)           ×2  # revolve → loft (uncut tooth) → _transformToothBody → pattern → combine → bore → mesh-rotate → moveToComponent
-              → _transformToothBody(...)     # the tooth-body step. ψ=0 → _cutConicalEnds (2 conical trims, straight bevel). ψ>0 → spiral build (see §3 "Spiral tooth body")
+              → _transformToothBody(...)     # the tooth-body step. ψ=0 → solids.cut_conical_ends (2 conical trims, straight bevel). ψ>0 → spiral build (see §3 "Spiral tooth body")
               # mesh-rotate: driving by 180°/drivingTeeth; pinion by _pinionMeshPhase() (0 unless a spiral pair needs a nudge)
   → _hideConstructionGeometry(bevelComponent)        # Cleanup
 deleteComponent()                            # error rollback (entry point calls on exception)
@@ -223,24 +230,40 @@ builds the four `toeMid / heelMid / toeConeWorld / heelConeWorld` arguments exac
 "Caller hand-off" table — toe edge = M→N (pinion) / O→P (driving), heel edge = C→H / D→J; `toeMid`/
 `heelMid` are the toe/heel edge MIDpoints and `toeConeWorld`/`heelConeWorld` are M/O and C/D. Getting
 this wrong silently inverts the spiral (see §3a).** Its first line is the
-gate `if self._spiralAngle_rad <= 0: return self._cutConicalEnds(...)` — straight bevels are byte-for-
-byte the prior behavior. `_pinionMeshPhase()` returns the pinion's extra mesh rotation about its own
+gate `if self._spiralAngle_rad <= 0: return cut_conical_ends(...)` (the framework helper from
+`.solids` — see "Conical cuts") — straight bevels are byte-for-byte the prior behavior.
+`_pinionMeshPhase()` returns the pinion's extra mesh rotation about its own
 shaft axis (0 for straight; for spiral it is `_PINION_MESH_PHASE_TEETH` tooth-fractions, default 0).
 
-Helpers used by the above (names may vary; behaviour is pinned by the Instructions): `_readInputs`,
-`_pointWorldGeometry` (world Point3D for a SketchPoint via `.worldGeometry` / ConstructionPoint via
-`.geometry`), `_findSpurToothProfile(toothSketch, embedded)` (match the tooth cross-section loop by curve-**type** mix — but the line count is **DETERMINED BY the `embedded` flag, NOT guessed/accepted-either**: `wantLines = 0 if embedded else 2`, then return the loop with exactly **2 NURBS flanks + 2 arcs (tip/root) + `wantLines` lines**. ⚠️ Do **NOT** accept "0 **or** 2 lines" — for a given gear only ONE of those is the real tooth; an **unrelated** loop (e.g. an inter-tooth or annular region between the drawCircles circles) can also have 2 NURBS + 2 arcs but the *other* line count, and selecting it makes the apex→profile loft in "Create the Gear Bodies" fail with `RuntimeError ... ASM_RBI_INTERNAL / LOFT_NO_TOOLBODY` (the impostor loop can't form a loft tool body). The `embedded` flag is read from the borrowed spur generator — see Dependencies (`_lastToothEmbedded`) — and passed into this helper; `embedded` ⇒ tip/root/flanks meet with no connecting lines (4 curves), non-embedded ⇒ 2 connecting lines (6 curves), mirroring spur's own `expectedCount = 4 if embedded else 6`),
-`_applyConicalCut` (sequential split by cone faces; keep the largest non-apex piece),
-`_findConeFaceForCutLine` (the `ConeSurfaceType` face whose surface contains both world endpoints of
-a cut line), `_surfaceDistance`, `_cutBore`, `_cutConicalEnds` (the toe-then-heel two-cone trim that
-trims a tooth body to a flush band; used both for the straight tooth and to flush the spiral tooth's
-ends). **Spiral-only helpers** (used only when ψ > 0): `_combine` (world point = base + a·e1 (+ b·e2),
-lengths in cm), `_planeByAngle` (a construction plane at N° to a reference plane through a sketch
-line, via `ConstructionPlaneInput.setByAngle`), `_circleIntersectNearest` (the two-circle intersection
-nearest a reference point — solves the cutter arc's toe/heel ends), `_bottomEdgeMid`, `_perpToAxis`,
-`_distDim`, and `_pinionMeshPhase`. Pinion is built first; driving second (mesh offset
-`180° / drivingTeeth`); the pinion additionally gets `_pinionMeshPhase()` (0 unless a spiral pair
-needs it).
+Helpers used by the above come in two kinds.
+
+**Framework helpers (import; do NOT re-implement — behavior pinned in the PLAYBOOK "Shared geargen
+helper library"):** from `.solids`: `cut_conical_ends` / `apply_conical_cut` / `select_keeper` /
+`find_cone_faces_by_midpoint` / `surface_distance` (the conical-cut machinery — see "Conical
+cuts"), `slice_body_by_offset_planes` (§3a step E), `rotate_body_about_edge` (the meshing
+rotations), and the spiral-only `plane_by_angle`, `combine_point`, `circle_intersect_nearest`
+(§3a steps B–C), plus `hide_construction_geometry` (Cleanup); from `.utilities`:
+`find_profile_by_curve_counts` (tooth-profile selection, below); from `.spurproxy`:
+`VirtualSpurProxy` (see Dependencies).
+
+**Own helpers (names may vary; behaviour is pinned by the Instructions):** `_readInputs`,
+`_cutBore`, `_bottomEdgeMid`, `_perpToAxis`, `_distDim`, and `_pinionMeshPhase` (returns the
+pinion's extra mesh rotation in **radians**: `_PINION_MESH_PHASE_TEETH · 2π / pinionTeeth`).
+
+**Tooth-profile selection.** Select the tooth cross-section loop with
+`find_profile_by_curve_counts(toothSketch, nurbs=2, arcs=2, lines=wantLines)` — but the line count
+is **DETERMINED BY the `embedded` flag, NOT guessed/accepted-either**: `wantLines = 0 if embedded
+else 2`. ⚠️ Do **NOT** accept "0 **or** 2 lines" — for a given gear only ONE of those is the real
+tooth; an **unrelated** loop (e.g. an inter-tooth or annular region between the drawCircles
+circles) can also have 2 NURBS + 2 arcs but the *other* line count, and selecting it makes the
+apex→profile loft in "Create the Gear Bodies" fail with `RuntimeError ... ASM_RBI_INTERNAL /
+LOFT_NO_TOOLBODY` (the impostor loop can't form a loft tool body). The `embedded` flag is read from
+the borrowed spur generator — see Dependencies (`_lastToothEmbedded`); `embedded` ⇒ tip/root/flanks
+meet with no connecting lines (4 curves), non-embedded ⇒ 2 connecting lines (6 curves), mirroring
+spur's own selection.
+
+Pinion is built first; driving second (mesh offset `180° / drivingTeeth`); the pinion additionally
+gets `_pinionMeshPhase()` (0 unless a spiral pair needs it).
 
 ## Sketch Discipline (bevel-specific)
 
@@ -282,7 +305,7 @@ SpurGearInvoluteToothDesignGenerator`. It is used only inside `_buildVirtualSpur
 gear:
 
 ```python
-proxy  = _VirtualSpurProxy(module_mm=module, virtualTeeth=virtualTeeth)
+proxy  = VirtualSpurProxy(module_mm=module, virtualTeeth=virtualTeeth)
 drawer = SpurGearInvoluteToothDesignGenerator(sketch, proxy)
 drawer.draw(anchorPoint, angle=math.radians(180))   # the 180° tooth rotation IS the draw() angle
 ```
@@ -290,15 +313,14 @@ drawer.draw(anchorPoint, angle=math.radians(180))   # the 180° tooth rotation I
 The borrowed generator's surface (from `spec/spurgear/instructions.md`): constructor `(sketch, parent, angle=0)`;
 `draw(anchorPoint, angle=0)` runs `drawCircles()` → `drawTooth(angle)` → anchor-projection; it reads
 parameters via `parent.getParameter(name).value`. So bevel must supply a `parent` exposing
-`getParameter(name)` → an object with a `.value`. That is **`_VirtualSpurProxy`**: it precomputes,
-in internal cm, exactly the keys the spur drawer reads and returns each wrapped in `_Val`:
-`Module`, `ToothNumber`, `PressureAngle` (radians; bevel hardcodes 20° — pressure angle is not a
-bevel dialog input), `PitchCircleDiameter`, `PitchCircleRadius`, `BaseCircleDiameter`,
-`BaseCircleRadius`, `RootCircleDiameter`, `RootCircleRadius`, `TipCircleDiameter`, `TipCircleRadius`,
-`InvoluteSteps` (15). Standard spur formulas: pitch = teeth·module, base = pitch·cos α,
-root = pitch − 2.5·module, tip = pitch + 2·module.
+`getParameter(name)` → an object with a `.value`. That is the framework's **`VirtualSpurProxy`**
+(`lib/geargen/spurproxy.py` — import it; do NOT define a local copy): it precomputes, in internal
+cm, exactly the keys the spur drawer reads (its defaults match bevel: pressure angle 20° — not a
+bevel dialog input — and `InvoluteSteps` 15) and returns each wrapped in a `.value` carrier.
+Construct it as `VirtualSpurProxy(module_mm=module, virtualTeeth=virtualTeeth)` with the raw-mm
+module and the §3 virtual tooth number.
 
-**The proxy must also carry `_lastToothEmbedded` — it is an OUTPUT the spur generator writes, and bevel MUST read it back.** During `draw()` the spur generator decides whether the tooth is *embedded* (tip/root/flanks meet with no connecting lines) and records it with `self.parent._lastToothEmbedded = <bool>` (it has no ctx of its own). So `_VirtualSpurProxy.__init__` must define `self._lastToothEmbedded = False` up front to absorb that write. **After `drawer.draw(...)` returns, read `proxy._lastToothEmbedded` and thread it to `_findSpurToothProfile(toothSketch, embedded)`** (e.g. stash it alongside the tooth sketch/plane returned by `_buildVirtualSpurProfile`). This flag is **not optional bookkeeping** — it is the deterministic selector for the tooth loop's line count (`0 if embedded else 2`); skipping it and accepting either count makes `_findSpurToothProfile` grab an unrelated loop and the apex→tooth loft dies with `LOFT_NO_TOOLBODY` (see Method contract).
+**The proxy carries `_lastToothEmbedded` — an OUTPUT the spur generator writes, and bevel MUST read it back.** During `draw()` the spur generator decides whether the tooth is *embedded* (tip/root/flanks meet with no connecting lines) and records it with `self.parent._lastToothEmbedded = <bool>` (it has no ctx of its own); the framework proxy pre-initialises the slot to absorb that write. **After `drawer.draw(...)` returns, read `proxy._lastToothEmbedded` and thread it to the tooth-profile selection (see Method contract)** — e.g. stash it alongside the tooth sketch/plane returned by `_buildVirtualSpurProfile`. This flag is **not optional bookkeeping** — it is the deterministic selector for the tooth loop's line count (`0 if embedded else 2`); skipping it and accepting either count grabs an unrelated loop and the apex→tooth loft dies with `LOFT_NO_TOOLBODY` (see Method contract).
 
 The **180° rotation is delivered through the `draw()` angle argument** (the spur generator rotates
 the whole tooth by `angle`, per `spec/spurgear/instructions.md`), *not* a post-hoc Move/sketch rotation — this relies
@@ -310,23 +332,23 @@ still created as described in §3.)
 
 ### Create the Parent Component
 
-Create the Bevel Gear component as a child of the Parent Component.
+Create the Bevel Gear component as a child of the Parent Component. Name it `Bevel Gear`.
 
 ## Creating the Design Component
 
 The Design Component shall contain the necessary sketches and construction planes / axis / etc that will be used by the components creating the actual gears later.
 
-Create the Design component as a child of the Bevel Gear component.
+Create the Design component as a child of the Bevel Gear component. Name it `Design`.
 
 ### 1: Anchor Sketch
 
-Start the Anchor Sketch **directly on the user-selected target plane**, whether the selection is a `ConstructionPlane` or a `PlanarFace`; don't re-derive or offset it (`[PB-USE-SELECTED-PLANE]` — re-deriving collapses the gear onto XY). Mark the center point by projecting the user-specified center point onto the sketch.
+Start the Anchor Sketch (name the sketch `Anchor`) **directly on the user-selected target plane**, whether the selection is a `ConstructionPlane` or a `PlanarFace`; don't re-derive or offset it (`[PB-USE-SELECTED-PLANE]` — re-deriving collapses the gear onto XY). Mark the center point by projecting the user-specified center point onto the sketch.
 
 Create a line through the projected center point. Apply **BOTH** `addCoincident(projectedCenter, anchorLine)` (the "intersection" — pins the center onto the line) **and** `addMidPoint(projectedCenter, anchorLine)` (center bisects the line). Use both, not midpoint alone. Give it a ~10mm length dimension (the value is arbitrary; it's only a reference line). **Then pin its direction so the sketch ends FULLY CONSTRAINED:** add `addHorizontal(anchorLine)` (sketch-local, per `[PB-REFLINE-DIRECTION]` — works on any tilted target plane; a world-axis lock would mis-orient). The anchor line's absolute direction is arbitrary (nothing downstream depends on it — §2 derives all directions *relative* to the projected anchor line), but it must not be a free degree of freedom: with midpoint + length + Horizontal the line has zero DOF. **Stash the projected-center SketchPoint** (e.g. on `self`) so §2 re-projects *this* anchor-sketch point — not the raw user-selected center — into the Gear Profiles sketch. This line is the Anchor Line. After all constraints, the Anchor Sketch must report `isFullyConstrained` (see the full-constraint gate in Sketch Discipline).
 
 ### 2: Gear Profiles
 
-Using setByAngle, create a plane that includes the Anchor Line, set at 90° (by default it would lie flush to the anchor line's plane, but we want it perpendicular). **Build it off the original `targetPlane`** as the reference — don't re-derive/offset it (`[PB-USE-SELECTED-PLANE]`) — this is the other place the target-plane orientation reaches the bodies; substituting a different plane here also collapses the gear onto XY. Create a sketch on this plane.
+Using setByAngle, create a plane that includes the Anchor Line, set at 90° (by default it would lie flush to the anchor line's plane, but we want it perpendicular). **Build it off the original `targetPlane`** as the reference — don't re-derive/offset it (`[PB-USE-SELECTED-PLANE]`) — this is the other place the target-plane orientation reaches the bodies; substituting a different plane here also collapses the gear onto XY. Name the plane `Gear Profiles Plane`. Create a sketch on this plane, named `Gear Profiles`.
 
 In the sketch, project **the Anchor Sketch's center SketchPoint** (the one you stashed in §1) — NOT the raw user-selected center point. Both happen to be coincident, but projecting the anchor-sketch point keeps the chain within the Design component and faithful to the anchor geometry; projecting the raw external point is a cross-component reference and can resolve inconsistently.
 
@@ -334,11 +356,13 @@ From the projected center point, draw a construction line **perpendicular to the
 
 Create a construction line from the apex representing the Driving Gear Shaft Axis, pointing from the apex back toward the anchor line (seed its far end at `c - perp·(some length)`, i.e. the `-perp` direction). It must run **parallel to the center→apex construction line** — apply `addParallel(drivingShaftAxis, centerToApex)`. **Do NOT use `addVertical`**: `addVertical` forces the line to the sketch's world-vertical, which is wrong on a tilted target plane (the gear-profiles sketch is not world-aligned) and over-constrains/mis-orients the figure. The shaft axis must be parallel to the *in-plane* apex direction (`perp`), expressed via `addParallel` to the center→apex line — never an absolute Horizontal/Vertical constraint. Beginning of this line uses a coincidence constraint with the apex. The end of this line shall be called point B. Do **not** dimension the line's length — it is determined by the closing constraint at Apex 2 below.
 
-Create a construction line from the apex representing the Pinion Gear Shaft Axis. Apply an angular dimension between this line and the Driving Gear Shaft Axis equal to Shaft Angle (this is the traditional "angle between the two shaft axes" — Shaft Angle = 90° gives the classic perpendicular bevel pair). **Place the angular dimension so it measures Σ and not its supplement 180−Σ** (`[PB-ANGULAR-DIM]`). The pinion shaft is the Driving Gear Shaft Axis direction rotated about the apex by the Shaft Angle. Rotating by the Shaft Angle has two senses (one to each side of the driving shaft), and they place point A on opposite sides — choosing wrong mirrors the whole gear onto the wrong side of the target plane. **Select the sense this way: form both candidate point-A positions (the driving-shaft direction rotated about the apex by +Shaft Angle and by −Shaft Angle) and keep the candidate whose endpoint has the greater X coordinate in the Gear Profiles sketch.** Compare the two candidates' X and take the larger — do **not** rotate one fixed sense and only flip it when its X comes out negative; when *both* candidates have a positive X that shortcut keeps the wrong one (this is exactly the side-flip to avoid). The +X-most endpoint is the side away from the anchor sketch's leading direction and is consistent across all target planes. Beginning of this line should use coincidence constraint with apex. The end of this line shall be called point A. Do **not** dimension the line's length — it is determined by the closing constraint at Apex 2 below.
+Create a construction line from the apex representing the Pinion Gear Shaft Axis. The pinion shaft is the Driving Gear Shaft Axis direction rotated about the apex by the Shaft Angle. Rotating by the Shaft Angle has two senses (one to each side of the driving shaft), and they place point A on opposite sides — choosing wrong mirrors the whole gear onto the wrong side of the target plane. **Select the sense (seed) this way: form both candidate point-A positions (the driving-shaft direction rotated about the apex by +Shaft Angle and by −Shaft Angle) and keep the candidate whose endpoint has the greater X coordinate in the Gear Profiles sketch.** Compare the two candidates' X and take the larger — do **not** rotate one fixed sense and only flip it when its X comes out negative; when *both* candidates have a positive X that shortcut keeps the wrong one (this is exactly the side-flip to avoid). The +X-most endpoint is the side away from the anchor sketch's leading direction and is consistent across all target planes. Call the chosen seed direction `pinionDir` (the unit Apex→A direction).
 
-From A, create a construction line perpendicular to the Pinion Gear Shaft Axis, drawn toward the side where Apex 2 will lie (between the two shaft axes, in the direction of the anchor line). Apply a perpendicular constraint against the Pinion Gear Shaft Axis. Apply a dimensional constraint with length = Pinion Gear Pitch Diameter / 2 (this equals the pinion's pitch radius at the heel, which is the perpendicular distance from Apex 2 to the Pinion Gear Shaft Axis for any Shaft Angle). Beginning of this line should use coincidence constraint with A. **Naming convention used throughout this spec: this perpendicular drop line (A → its far end, which becomes Apex 2) is what "A->Apex2" / "line A->Apex2" always refers to — it is NOT the Apex->A shaft axis. The two share point A but are different lines (one is the PPD/2 perpendicular drop, the other the shaft axis). Whenever a later step says to pin something to or dimension against "A->Apex2", it means this drop line. The same holds for "B->Apex2" (the DPD/2 drop) vs the Apex->B shaft axis.**
+Apply an angular dimension between this line and the Driving Gear Shaft Axis equal to Shaft Angle (the traditional "angle between the two shaft axes" — 90° gives the classic perpendicular bevel pair). **Place its text point inside the Σ wedge so it measures Σ and not its supplement 180−Σ** (`[PB-ANGULAR-DIM]`) — e.g. on the interior bisector of the two shaft directions, `apex + normalize(pinionDir + drivingDir) · (PPD/4)`, where `drivingDir` is the unit Apex→B direction. (The angular dimension only fixes the angle *magnitude*; it does not by itself pin which side the pinion lies on, and the text point does not prevent a frame flip — the pinion side is held by the seed above together with the Apex 2 closure below. The real side-flip hazard lives in the perpendicular drops to Apex 2 — see the ⚠️ on the B→Apex 2 drop.) Beginning of this line should use coincidence constraint with apex. The end of this line shall be called point A. Do **not** dimension the line's length — it is determined by the closing constraint at Apex 2 below.
 
-From B, create a construction line perpendicular to the Driving Gear Shaft Axis, drawn toward the side where Apex 2 will lie. Apply a perpendicular constraint against the Driving Gear Shaft Axis. Apply a dimensional constraint with length = Driving Gear Pitch Diameter / 2 (the driving pitch radius at the heel, perpendicular distance from Apex 2 to the Driving Gear Shaft Axis for any Shaft Angle). Beginning of this line should use coincidence constraint with B.
+From A, create a construction line perpendicular to the Pinion Gear Shaft Axis, drawn toward the side where Apex 2 will lie. ⚠️ **Apex 2 sits in the interior wedge *between* the two shaft axes — so this drop must point toward the OTHER (Driving) shaft axis / point B, NOT "toward the anchor line".** Pick the perpendicular sense by the sign of its dot product with the A→B direction (toward the driving shaft), not against a generic "toward the anchor" reference. Apply a perpendicular constraint against the Pinion Gear Shaft Axis. Apply a dimensional constraint with length = Pinion Gear Pitch Diameter / 2 (this equals the pinion's pitch radius at the heel, which is the perpendicular distance from Apex 2 to the Pinion Gear Shaft Axis for any Shaft Angle). Beginning of this line should use coincidence constraint with A. **Naming convention used throughout this spec: this perpendicular drop line (A → its far end, which becomes Apex 2) is what "A->Apex2" / "line A->Apex2" always refers to — it is NOT the Apex->A shaft axis. The two share point A but are different lines (one is the PPD/2 perpendicular drop, the other the shaft axis). Whenever a later step says to pin something to or dimension against "A->Apex2", it means this drop line. The same holds for "B->Apex2" (the DPD/2 drop) vs the Apex->B shaft axis.**
+
+From B, create a construction line perpendicular to the Driving Gear Shaft Axis, drawn toward the side where Apex 2 will lie. ⚠️ **This drop must point toward the OTHER (Pinion) shaft axis / point A** — pick the perpendicular sense by the sign of its dot product with the B→A direction. **Do NOT choose this sense by a "toward the anchor line" reference (i.e. the −perp / center→apex grow direction): the Driving Gear Shaft Axis is itself parallel to that grow direction, so the perpendicular's dot with it is ≈ 0 — a degenerate test that silently selects an arbitrary (usually wrong) side.** This is the critical failure: if this B→Apex 2 drop seeds Apex 2 on the wrong side of the driving shaft while the Pinion's A→Apex 2 drop seeds it on the correct side, the coincidence that closes the two drops at Apex 2 (below) makes the solver **flip the entire frame to the mirror solution** — point A jumps to the opposite side, and the pinion dedendum C collapses onto the driving dedendum D, inverting the pinion (the toe ends up *outside* the heel, the revolved frustum is degenerate, and the conical end-cut finds no cone face at the toe midpoint → `face dist = inf`). Both Apex 2 drops must aim at the *same* interior-wedge point. Apply a perpendicular constraint against the Driving Gear Shaft Axis. Apply a dimensional constraint with length = Driving Gear Pitch Diameter / 2 (the driving pitch radius at the heel, perpendicular distance from Apex 2 to the Driving Gear Shaft Axis for any Shaft Angle). Beginning of this line should use coincidence constraint with B.
 
 Constrain the end points of the two perpendicular lines from the previous two paragraphs with a coincident constraint. Let this point be called Apex 2. (At Shaft Angle = 90° the four points Apex, A, Apex 2, B form a rectangle. For other shaft angles the figure is a non-rectangular parallelogram-like quadrilateral; the lengths of Apex→A and Apex→B adjust so the perpendicular drops of length PPD/2 and DPD/2 coincide at Apex 2.)
 
@@ -392,7 +416,7 @@ Create line M->N. **Seed it near its solved position** (`[PB-SEED-NEAR]`): seed 
 - `addCoincident(M, Pinion Root Axis)` — M lies on the Apex->C root axis;
 - `addCoincident(N, line A->Apex2)` — N lies on the A->Apex2 **perpendicular DROP** (per the naming convention — NOT the Apex->A shaft axis). This is the pin; do not merely place N numerically. Load-bearing: pinning N to the shaft axis puts N *on the axis of revolution*, and the later conical split fails with `ASM_API_FAILED` for asymmetric tooth counts even though the symmetric 45° case happens to survive;
 - `addParallel(M->N, C->H)` — the toe line is parallel to C->H;
-- `addOffsetDimension(C->H, M->N, textPoint).parameter.value = Face Width` — the parallel offset between C->H and M->N equals Face Width.
+- `addOffsetDimension(C->H, M->N, textPoint).parameter.value = Face Width` — the parallel offset between C->H and M->N equals Face Width. Place the `textPoint` in the gap between C->H and M->N on the Apex side (e.g. the midpoint of the M-seed and point C, `(M_seed + C)/2`) so the dimension reads cleanly (`[PB-OFFSET-DIM]`). The toe's side relative to the heel (`toe→Apex < heel→Apex`) follows from the §2 frame being built correctly — in particular from the Apex 2 drops aiming at the interior wedge (see the ⚠️ above); it is **not** controlled by this text point.
 
 (Because N is pinned to A->Apex2, the Maximum Face Width above is exactly the value at which N reaches A; the capped Face Width keeps N between Apex2 and A.)
 
@@ -406,7 +430,7 @@ Create line O->P, the mirror of M->N on the driving side. Seed it the same way (
 - `addCoincident(O, Driving Root Axis)` — O on the Apex->D root axis;
 - `addCoincident(P, line B->Apex2)` — P on the B->Apex2 perpendicular DROP, **NOT the Apex->B shaft axis** (same trap as N above);
 - `addParallel(O->P, D->J)`;
-- `addOffsetDimension(D->J, O->P, textPoint).parameter.value = Face Width`.
+- `addOffsetDimension(D->J, O->P, textPoint).parameter.value = Face Width` — as for the pinion, place the `textPoint` in the gap on the Apex side of D->J (e.g. `(O_seed + D)/2`) so it reads cleanly (`[PB-OFFSET-DIM]`).
 
 Let the beginning of this new line be point O, the end be point P. Draw a line from O to D. Draw a line from P to B. Draw line from B to I.
 
@@ -421,15 +445,15 @@ Do all four steps below **once per gear** — pinion first, then driving — wit
 
 1. Compute this gear's virtual (back-cone / Tredgold) tooth number from the closed form, **not** by measuring Apex2->K′/L′: virtual pitch radius = `(this gear's Pitch Diameter / 2) / cos(γ)`. Virtual tooth number = `floor(2 · virtualPitchRadius / Module)`, as an int. (Module here is the raw mm value; the radius is a length — keep the unit handling consistent, see the Units note.)
 
-2. Create a new plane that includes the tooth-center reference line. Use setByAngle to make this plane perpendicular to the Gear Profiles sketch plane.
+2. Create a new plane that includes the tooth-center reference line, named `{gearLabel} Plane`. Use setByAngle to make this plane perpendicular to the Gear Profiles sketch plane (`plane_by_angle` from `.solids`).
 
-3. Using the new plane and the tooth-center point as the center point, create a spur gear tooth profile with module and the virtual tooth number from step 1. Draw it **already rotated 180°** by passing `angle=math.radians(180)` to the spur tooth generator's `draw(anchorPoint, angle=…)` (see Dependencies) — the generator rotates the whole tooth by that angle; do not draw it flat and rotate the sketch afterward. **After `draw()` returns do NOT hard-gate this sketch: log if `not toothSketch.isFullyConstrained`, never raise** — the tooth-profile sketches are exempt from the full-constraint gate (see Sketch Discipline: the embedded low-tooth-count tooth is legitimately under-constrained, and the profile is consumed immediately by the loft).
+3. Using the new plane and the tooth-center point as the center point, create a spur gear tooth profile with module and the virtual tooth number from step 1, in a sketch named `{gearLabel} Tooth`. Draw it **already rotated 180°** by passing `angle=math.radians(180)` to the spur tooth generator's `draw(anchorPoint, angle=…)` (see Dependencies) — the generator rotates the whole tooth by that angle; do not draw it flat and rotate the sketch afterward. **After `draw()` returns do NOT hard-gate this sketch: log if `not toothSketch.isFullyConstrained`, never raise** — the tooth-profile sketches are exempt from the full-constraint gate (see Sketch Discipline: the embedded low-tooth-count tooth is legitimately under-constrained, and the profile is consumed immediately by the loft).
 
-4. Create a construction axis through the tooth-center point, normal to the plane the tooth profile was drawn on, via `setByTwoPlanes` (`[PB-CONSTRUCTION-AXES]`; `setByPerpendicularAtPoint` would need a `BRepFace`). The two planes are: the **Gear Profiles plane** and a **helper plane built `setByDistanceOnPath(<tooth-center reference line>, 1.0)`** (perpendicular to that line at its far end, the tooth-center point); their intersection is the line through the tooth center normal to the tooth plane.
+4. Create a construction axis (named `{gearLabel} Tooth Axis`) through the tooth-center point, normal to the plane the tooth profile was drawn on, via `setByTwoPlanes` (`[PB-CONSTRUCTION-AXES]`; `setByPerpendicularAtPoint` would need a `BRepFace`). The two planes are: the **Gear Profiles plane** and a **helper plane built `setByDistanceOnPath(<tooth-center reference line>, 1.0)`** (perpendicular to that line at its far end, the tooth-center point); their intersection is the line through the tooth center normal to the tooth plane. (Creating this axis in the never-activated Design component is proven to work — `constructionAxes.add` via `setByTwoPlanes` does not hit `[PB-CONSTRUCTION-NEEDS-ACTIVE]` here; keep the axis.)
 
 ### 3a: Spiral tooth body (ψ > 0)
 
-This is the ψ > 0 branch of the tooth-body hook `_transformToothBody` (Method contract) — it **replaces** the straight tooth's two conical trims with a curved tooth. When **ψ = 0 the hook returns immediately** with `_cutConicalEnds` (the straight tooth, trimmed to a flush band — byte-for-byte the prior behavior); everything below runs **only when ψ > 0**. It is invoked once per gear (pinion then driving), inside `_createGearBody`, on the freshly lofted uncut apex→heel `toothBody`, before pattern/combine/bore. The arc math it realizes is derived in `spiral-tooth-trace.md`; this section states **how** that construction is realized as Fusion sketches/features and the order it runs in. Use the existing `{gear}` sketch-naming (`gearLabel` is `Pinion` or `Driving`).
+This is the ψ > 0 branch of the tooth-body hook `_transformToothBody` (Method contract) — it **replaces** the straight tooth's two conical trims with a curved tooth. When **ψ = 0 the hook returns immediately** with the framework's `cut_conical_ends` (the straight tooth, trimmed to a flush band — byte-for-byte the prior behavior); everything below runs **only when ψ > 0**. It is invoked once per gear (pinion then driving), inside `_createGearBody`, on the freshly lofted uncut apex→heel `toothBody`, before pattern/combine/bore. The arc math it realizes is derived in `spiral-tooth-trace.md`; this section states **how** that construction is realized as Fusion sketches/features and the order it runs in. Use the existing `{gear}` sketch-naming (`gearLabel` is `Pinion` or `Driving`).
 
 **Caller hand-off — the four toe/heel world points `_createGearBody` builds and passes to the hook (PIN EXACTLY; mislabeling them silently inverts the spiral — this is the single biggest spiral-regen hazard).** The §2 lattice gives each gear a **toe edge** (the inner face-width edge, nearer the apex) and a **heel edge** (the outer edge, at the back cone). Per gear they are exactly:
 
@@ -469,18 +493,18 @@ Cy = handSign · r_c · cos ψ
 
 ⚠️ **Gotcha — the hand sign goes on the `cos`/`Cy` term, NOT the `sin`/`Cx` term** (this was a real bug). Opposite hand mirrors the cutter centre **across the cone element (y = 0)**, which flips `Cy`. Putting `handSign` on `Cx` mirrors about `x = R_mean` instead — a *different* curve that gives the two gears **unequal twist**; for equal teeth the driving and pinion traces must come out as exact mirror images.
 
-The trace's toe/heel arc endpoints are circle∩circle intersections taken a hair **past** the face so the kept arc reaches cleanly past the end-trims: `toe2d = _circleIntersectNearest(R_lo, …)` and `heel2d = _circleIntersectNearest(R_hi, …)` with `R_lo = R_toe − 0.06·span` and `R_hi = R_heel + 0.06·span`. `_circleIntersectNearest` intersects the apex circle of radius R with the cutter circle (centre `(Cx,Cy)`, radius `r_c`) and keeps the solution nearest `(R_mean, 0)` — the branch the mean point sits on. (See `spiral-tooth-trace.md` §6 for why the near branch, and §5 for the centre derivation.)
+The trace's toe/heel arc endpoints are circle∩circle intersections taken a hair **past** the face so the kept arc reaches cleanly past the end-trims: `toe2d = circle_intersect_nearest(R_lo, …)` and `heel2d = circle_intersect_nearest(R_hi, …)` (the framework helper from `.solids`) with `R_lo = R_toe − 0.06·span` and `R_hi = R_heel + 0.06·span`. `circle_intersect_nearest` intersects the apex circle of radius R with the cutter circle (centre `(Cx,Cy)`, radius `r_c`) and keeps the solution nearest `(R_mean, 0)` — the branch the mean point sits on. (See `spiral-tooth-trace.md` §6 for why the near branch, and §5 for the centre derivation.)
 
-**C. 2-D trace sketch (the genuine cutter arc).** Build the tangent plane with `_planeByAngle`: first draw a **cone-element construction line** Apex→(Apex + R_heel·coneVec) in a sketch on the **axial / Gear Profiles plane** (name it `{gear} Cone Element`), then make the tangent plane = that axial plane rotated **90°** about the cone-element line (`_planeByAngle(comp, coneElementLine, axialPlane, 90)`). Add a sketch on it named **`{gear} 2D Tooth Trace`**. In it draw, with `tanW(px,py) = _combine(apex, px, coneVec, py, v)` mapping 2-D coords to world:
+**C. 2-D trace sketch (the genuine cutter arc).** Build the tangent plane with the framework's `plane_by_angle`: first draw a **cone-element construction line** Apex→(Apex + R_heel·coneVec) in a sketch on the **axial / Gear Profiles plane** (name it `{gear} Cone Element`), then make the tangent plane = that axial plane rotated **90°** about the cone-element line (`plane_by_angle(comp, coneElementLine, axialPlane, 90)`; name it `{gear} Trace Plane`). Add a sketch on it named **`{gear} 2D Tooth Trace`**. In it draw, with `tanW(px,py) = combine_point(apex, px, coneVec, py, v)` (framework) mapping 2-D coords to world:
 
-- the **cutter circle** — centre at `tanW(Cx, Cy)`, radius `r_c` — `isConstruction`, with its centre constrained (coincident) and a diameter dimension = `2·r_c`;
+- the **cutter circle** — centre at `tanW(Cx, Cy)`, radius `r_c` — `isConstruction`, with its centre pinned via `centerSketchPoint.isFixed = True` (`[PB-CIRCLE-CENTER]`) and a diameter dimension = `2·r_c`;
 - the **trace arc** — a 3-point arc through `tanW(toe2d)`, `tanW(R_mean, 0)` (the mean point on the cone element), `tanW(heel2d)`, with its **centre coincident to the cutter circle's centre** and a **radius dimension = `r_c`**, so it is the genuine cutter circle and not a look-alike spline. ⚠️ Text points per `[PB-RADIAL-DIM]` (off-centre, on/near the curve): use the mean point `tanW(R_mean, 0)` for the trace arc's radius dimension, and a point on the cutter circle such as `tanW(Cx + r_c, Cy)` for its diameter dimension.
 
 This sketch is **deliberately left with free DOF** — the arc's endpoints are pinned by the 3-point construction, not by endpoint dimensions (dimensioning them over-constrains the solve against the cone-element plane). It is therefore **exempt from the full-constraint gate**, as already declared in Sketch Discipline ("The spiral build's auxiliary sketches are EXEMPT") — do not gate it.
 
 **D. (No 3-D projection.)** The 2-D cutter-arc sketch from step C is the only trace geometry needed — the spiral twist is computed **analytically** from it in step G, so there is **no `projectToSurface`, no root-cone-face search, and no 3-D trace sketch.** (Earlier versions projected the 2-D arc onto the root cone along `tpNormal` and measured the trace azimuth there. That projection is *fragile*: for unequal-ratio pairs the arc wraps around the cone and `projectToSurface` returns it as **multiple disjoint fragments**, so the measured azimuth collapses to a fraction of the true sweep — the pinion comes out grossly under-twisted and the pair interferes. The analytic crown-gear law in step G is exact, deterministic, and cannot wrap.)
 
-**E. Slice the straight tooth.** Split the uncut apex→heel `toothBody` into cross-section slabs by planes **perpendicular to the cone element**, spanning a touch past toe and heel, via a **fixed** slice scheme (≈8 planes — the count is not user-configurable). The first cut plane is the **parent transverse tooth plane** (`parentToothPlane`, the virtual-spur tooth-profile plane `{label} Plane` from §3, passed into the hook) offset toward the apex by `span/6`; the offset **sign is chosen per gear** so it moves toward the apex (the parent plane's normal points opposite ways for the two gears — pick `sign` so `sign·normal` points apex-ward, i.e. test `(apex − planeOrigin)·normal`). Then a sequence of ~8 planes stepped further toward the apex in `span/6` increments (`sign·(k+1)·span/6` for k = 0…7, k = 0 being the first cut plane). Split the body **piece-by-piece**: maintain a list of pieces, split each with each plane in turn, and **skip any plane that misses a piece** (the split throws — catch it and keep the piece whole). ⚠️ **The slice MUST actually split the tooth.** After the cut loop, if the body is still in **one piece** (no plane cut it), the offset sign was wrong or `parentToothPlane` sits outside the tooth's span — **retry the whole cut once with the opposite sign**. If it is *still* one piece, **`raise` a clear self-diagnosing error** naming the gear, the final piece count, `span`, and the sign tried. Do **NOT** return an unsliced (single-piece) result: step F then drops that one piece as the apex scrap, leaving `segments` **empty**, and the crown later crashes with `ValueError: max() iterable argument is empty` far from the cause. The result is the set of cross-section segments.
+**E. Slice the straight tooth.** Split the uncut apex→heel `toothBody` into cross-section slabs by planes **perpendicular to the cone element**, spanning a touch past toe and heel, via a **fixed** slice scheme (≈8 planes — the count is not user-configurable). The first cut plane is the **parent transverse tooth plane** (`parentToothPlane`, the virtual-spur tooth-profile plane `{label} Plane` from §3, passed into the hook) offset toward the apex by `span/6`; the offset **sign is chosen per gear** so it moves toward the apex (the parent plane's normal points opposite ways for the two gears — pick `sign` so `sign·normal` points apex-ward, i.e. test `(apex − planeOrigin)·normal`). Then a sequence of ~8 planes stepped further toward the apex in `span/6` increments (`sign·(k+1)·span/6` for k = 0…7, k = 0 being the first cut plane). Split the body with the framework's `slice_body_by_offset_planes(designComponent, toothBody, parentToothPlane, offsets)` where `offsets = [sign·(k+1)·span/6 for k in 0…7]` — it splits piece-by-piece and keeps a piece whole when a plane misses it. ⚠️ **The slice MUST actually split the tooth.** After the cut loop, if the body is still in **one piece** (no plane cut it), the offset sign was wrong or `parentToothPlane` sits outside the tooth's span — **retry the whole cut once with the opposite sign**. If it is *still* one piece, **`raise` a clear self-diagnosing error** naming the gear, the final piece count, `span`, and the sign tried. Do **NOT** return an unsliced (single-piece) result: step F then drops that one piece as the apex scrap, leaving `segments` **empty**, and the crown later crashes with `ValueError: max() iterable argument is empty` far from the cause. The result is the set of cross-section segments.
 
 **F. Order & drop scrap.** Sort the segments by `distAlong` of their centroid (`physicalProperties.centerOfMass`). The first (apex-most) is the long **apex-side scrap** below the toe — **remove it**; keep the rest as the working `segments`. (Drop the scrap by re-slicing the list, *then* delete it — `segments = segments[1:]` before `removeFeatures.add(scrap)`.) After dropping the scrap, **`segments` must be non-empty** (≥1 cross-section); if it is empty the slice failed in step E — `raise` a clear error rather than proceeding into the twist (G) and crown (H), which assume ≥1 segment.
 
@@ -505,7 +529,7 @@ ang = −handSign · total · (R_mean − R_heelFace(seg)) / span
 factor = 1 − _CROWN_PER_RAD · (|total| / 2) · u
 ```
 
-`total` is the full toe→heel twist from step G; `|total|/2` = the per-end peak twist magnitude (`max|ang|`), so the maximum relief — now at the **toe** — keeps the same magnitude the old per-end peak had, just relocated. This makes relief **grow monotonically from the (full) heel to the toe**, so slab heights stay **strictly ordered heel→toe** and the natural cone taper is never reversed. **`_CROWN_PER_RAD` is a tunable class constant, default `0.5`** (0 disables the crown) — set it to 0.5, do not leave it unset/0.
+`total` is the full toe→heel twist from step G; `|total|/2` = the per-end peak twist magnitude (`max|ang|`), so the maximum relief — now at the **toe** — keeps the same magnitude the old per-end peak had, just relocated. This makes relief **grow monotonically from the (full) heel to the toe**, so slab heights stay **strictly ordered heel→toe** and the natural cone taper is never reversed. If a computed `factor` comes out ≤ 0 (extreme twist), `raise` a self-diagnosing error naming the gear, the segment's `u`, and the factor — never scale by a non-positive factor. **`_CROWN_PER_RAD` is a tunable class constant, default `0.5`** (0 disables the crown) — set it to 0.5, do not leave it unset/0.
 
 ⚠️ **Do NOT key the relief on `|ang|` (the twist magnitude, i.e. |distance from mid-face|).** That is **symmetric** about mid-face — maximal at BOTH ends — so, because the heel slab is held full (gotcha 2), the slab *just inside* the heel becomes the **most**-relieved one and dips below both its neighbours (a notch), reversing the heel→toe taper. This was the observed bug: the heel-adjacent slab came out at factor `0.932` while the next slab inward was `0.972` (taller). Key the relief on the monotonic heel-distance `u`, never on `|ang|`. Three gotchas:
 
@@ -515,7 +539,7 @@ factor = 1 − _CROWN_PER_RAD · (|total| / 2) · u
 
 **I. Loft → curved tooth.** ⚠️ **Re-sort the segments by their heel-face cone distance HERE, AFTER the twist (G) and crown (H) — do NOT reuse the pre-twist slice/centroid order from step F.** The twist rotates each slab about the shaft axis, and for high-twist *unequal-ratio* pairs that rotation changes the slabs' along-cone (`distAlong`) order enough to **reorder adjacent slabs**; lofting in the stale pre-twist order then assembles the cross-sections out of sequence and the crowned tooth comes out distorted → the two gears interfere. (For equal/low-twist pairs the two orders coincide, which is why equal-teeth gears mesh even with the stale order but unequal ratios distort — this is the single thing that makes a ratio pair like 31/17 fail while 31/31 looks fine.) So: compute `order = sorted(segment indices, key = distAlong(slabHeelFace(seg).centroid))` **now**, and loft a NewBody through, in that order: first the **toe-most segment's apex-side (toe-facing) face** — the toe segment is `order[0]`, its toe face added first to push the loft past the toe cone so the toe trim bites — then the **heel-facing face of every segment, iterated in `order`** (each segment's farthest-along-the-element face by post-twist centroid; the last reaches past the heel cone). Name the resulting body **`{gear} Spiral Tooth`**. Then remove the segment scaffolding (the loft has captured their faces).
 
-**J. Flush trim + mesh phase.** Return `_cutConicalEnds(designComponent, curvedTooth, gearBody, toeMid, heelMid, apexWorld, gearLabel)` — the same toe-then-heel two-cone trim used for the straight tooth — so the curved tooth's ends sit **flush** on the gear base. The toe/heel **mesh phasing** is handled outside this hook by `_createGearBody`'s mesh-rotate step (driving by `180°/drivingTeeth`; the **pinion additionally** by `_pinionMeshPhase()`, which is 0 by default because the mid-face section is unrotated and already meshes — see Method contract).
+**J. Flush trim + mesh phase.** Return `cut_conical_ends(designComponent, curvedTooth, gearBody, toeMid, heelMid, apexWorld, gearLabel)` (framework) — the same toe-then-heel two-cone trim used for the straight tooth — so the curved tooth's ends sit **flush** on the gear base. The toe/heel **mesh phasing** is handled outside this hook by `_createGearBody`'s mesh-rotate step (driving by `180°/drivingTeeth`; the **pinion additionally** by `_pinionMeshPhase()`, which is 0 by default because the mid-face section is unrotated and already meshes — see Method contract).
 
 ## Create the Gear Bodies (once per gear — pinion first, then driving)
 
@@ -531,7 +555,7 @@ Run this whole section **once per gear** — pinion first, then driving — with
 | teeth / bore / pitch-diameter inputs | Pinion Gear … | Driving Gear … |
 | §2 shaft construction line (NOT usable as the axis) | Apex->A | Apex->B |
 
-Create a new component as a child of the **Bevel Gear** component (the same component that owns Design — *not* the user's Parent Component; this intentionally overrides the looser "child of Parent Component" phrasing so the pair nests cleanly inside Bevel Gear). The resulting bodies for this gear end up in this component. (Implementation note: Fusion rejects cross-sibling sketch and project calls even when the target is activated or the entities are wrapped in `createForAssemblyContext` proxies — `[PB-NO-CROSS-SIBLING]` — so the actual feature operations run in the Design component and the finished bodies are `moveToComponent`'d here at the end. The visible end state is identical.)
+Create a new component as a child of the **Bevel Gear** component (the same component that owns Design — *not* the user's Parent Component; this intentionally overrides the looser "child of Parent Component" phrasing so the pair nests cleanly inside Bevel Gear), named `{gearLabel} Gear` (`Pinion Gear` / `Driving Gear`). The resulting bodies for this gear end up in this component. (Implementation note: Fusion rejects cross-sibling sketch and project calls even when the target is activated or the entities are wrapped in `createForAssemblyContext` proxies — `[PB-NO-CROSS-SIBLING]` — so the actual feature operations run in the Design component and the finished bodies are `moveToComponent`'d here at the end. The visible end state is identical.)
 
 **Profile sketch.** Open a **fresh sketch on the axial (Gear Profiles) plane**, named per the table — **one profile sketch per gear**, so `sketch.profiles` holds exactly this one hexagon loop (do not draw both gears' hexagons in the shared Gear Profiles sketch — that would leave two identically-shaped loops to disambiguate). Build the hexagon on fixed vertices per the `[PB-PROJECT-NOT-FIXED]` recreate-share-fix recipe: recreate the six §2 vertices as new points at their exact (world-mapped) positions — valid because §2 is fully constrained by now — then draw the closed hexagon (in the table's draw order) as six `SketchLine`s **sharing** those points, then fix the lines and their endpoints **after** the lines exist (not before). The hexagon's **first edge is the gear's shaft axis** for the revolve, pattern, bore plane AND the meshing-rotation axis, so it must be fixed well enough to carry a trustworthy world position: fixed endpoints give that edge a well-defined `worldGeometry` (`[PB-WORLDGEO-CONSTRAINED]`); a free edge resolves against a default/world-XY frame and silently moves the body onto world XY (observed on the driving gear — the pinion looked fine only because it never read the edge's `worldGeometry`).
 
@@ -541,30 +565,46 @@ Create a new component as a child of the **Bevel Gear** component (the same comp
 
 **Tooth loft.** Loft the **§2 Apex sketch point** (the `centerToApex.endSketchPoint` from the Gear Profiles sketch — the degenerate point-section) to this gear's §3 Tooth profile; let the result be the Tooth Body. Use the §2 Apex SKETCH point directly — do NOT create a construction point for it (`[PB-CONSTRUCTION-NEEDS-ACTIVE]`; the Design component is never active).
 
-**Conical cuts.** Cut the Tooth Body twice, in order — **selecting the keeper piece between the two cuts so each cut splits exactly one body (exactly two split features for every gear ratio).** **Two distinct bodies are involved — do not conflate them:** the **cutting TOOL** each time is a `ConeSurfaceType` face of the **Gear Body (the revolved-hexagon frustum)** — the lofted Tooth Body has no cone faces, so searching *it* for the cone face finds none (`distances: []`). The **TARGET being split** is the **Tooth Body (the loft)**.
+**Conical cuts.** Trim the Tooth Body to a flush band with the framework helper — return
+`cut_conical_ends(designComponent, toothBody, gearBody, toeMid, heelMid, apexWorld, gearLabel)`
+(from `.solids`; do **NOT** re-implement the cut machinery). **Two distinct bodies are involved —
+do not conflate them:** the cutting TOOLS are `ConeSurfaceType` faces of the **Gear Body (the
+revolved-hexagon frustum)** — the lofted Tooth Body has no cone faces, so searching *it* for the
+cone face finds none — and the TARGET being split is the **Tooth Body (the loft)**.
 
-1. First the **toe cut**, using the conical face **on the frustum** generated from the toe edge — locate the existing face on the frustum (don't build a fresh revolved surface from the sketch line). **Identify the cone by the cut edge's world MIDPOINT, not its endpoints** (`[PB-FACE-BY-MIDPOINT]` — a toe endpoint sits near the cone's apex singularity where `getParameterAtPoint` returns `None`, while the midpoint is reliable and uniquely distinguishes the toe cone from the heel/neighbour cones): compute the toe edge's world midpoint (`(M_world + N_world)/2` / `(O_world + P_world)/2`), order the frustum's `ConeSurfaceType` faces by ascending `_surfaceDistance(face.geometry, edgeMidWorld)` (an unevaluable `None` → +inf, tried last), and **try each best-first as the `splitBodyFeatures` tool (`isSplittingToolExtended=True`) on the Tooth Body, keeping the first that actually splits it (>1 piece)**. Picking the wrong cone makes the toe cut split in the wrong place, after which the correct heel cone has nothing left to intersect (observed: "cut#2 heel: no cone face split any piece"). Do not use endpoint distance, a hard tolerance gate, or `body.faces` order. Only if *every* cone face fails to split is this cut non-intersecting (raise the self-diagnosing error below).
-2. **After the toe cut, immediately select the keeper** (rule below), **then run the heel cut on the keeper ALONE** — do NOT feed both cut-1 pieces into cut 2, and do NOT cut the apex tip — using the conical face on the frustum generated from the heel edge, located the same way by that edge's world midpoint (`(C_world + H_world)/2` / `(D_world + J_world)/2`). Removing the apex tip *before* the heel cut is essential: the heel cone is an **extended/infinite** surface, so a still-present apex tip would be sliced too — a **geometry-dependent spurious third cut** (observed in v33: **3** split features on the pinion but **2** on the driving, because the extended heel cone reaches the pinion's apex tip but not the driving's). Cutting only the keeper makes it deterministically **two** cuts for both gears. The heel cone may not intersect the keeper at all (the tooth profile sits on the heel/back cone, so there may be no overshoot — common on ratio pairs where the pinion's heel cone never overshoots its spiral tooth, e.g. module 1 / driving 31 / pinion 43) — wrap the heel split in `try/except RuntimeError` and, on `SPLIT_TARGET_TOOL_NOT_INTERSECT` (or localized `交差`) **anywhere in the exception text**, keep the keeper whole (it is already the tooth). **For this catch to fire, the non-intersection signal must REACH it as a `RuntimeError` carrying that message text.** The per-face split loop (next paragraph) catches each face's Fusion `RuntimeError` into a history list and then raises its own summary error when no face split the target — that summary raise MUST itself be a `RuntimeError` whose message **preserves the underlying `SPLIT_TARGET_TOOL_NOT_INTERSECT` / `交差` text verbatim** when that was the failure on every face. Do NOT relabel it as a bare `Exception`: `except RuntimeError` does not catch `Exception` (its parent), so a generic re-raise silently defeats this lenient path and the build crashes mid-spiral with `heel cut found no cone face that splits the tooth body` — the original symptom for that 31/43 pair. (Equivalently, the lenient catch may be `except Exception` and match the message, but the simplest contract is: face-loop raises `RuntimeError`, propagating the cause text.)
+The helper implements the pinned cut behavior (see the PLAYBOOK "Shared geargen helper library"):
+the **toe cut first**, its cone face identified by the toe edge's world **MIDPOINT** best-first
+across the frustum's cone faces (`[PB-FACE-BY-MIDPOINT]` — endpoints sit near the apex
+singularity), each candidate tried as the actual split tool and the first that splits (>1 piece)
+kept; **keeper selection after each cut** (remove apex-containing pieces, keep the largest —
+`[PB-REMOVE-PIECES]`); then the **heel cut on the keeper alone** (removing the apex tip first is
+what makes it deterministically two split features for every gear ratio). A heel cone that does
+not intersect the keeper at all (common on ratio pairs, e.g. module 1 / driving 31 / pinion 43,
+where the heel cone never overshoots the tooth) is raised by the helper as the **typed
+`solids.NonIntersectError`** and caught — the keeper is returned whole. Every failure is
+self-diagnosing with the per-face distance/error history (`[PB-SELF-DIAGNOSING]`), and each cut's
+outcome is logged with `force_console=True`.
 
-**The keeper/tooth selection rule — apply it AFTER EACH cut.** Both times the rule is identical: remove every piece that contains the Apex (by point-containment), then of the remaining pieces keep the single **largest** by volume and remove the rest (`[PB-REMOVE-PIECES]`). **After the toe cut** this drops the apex tip and yields the keeper (one piece; the toe cut must produce ≥2 pieces — apex tip + keeper — or it is the self-diagnosing failure below). **After the heel cut** it yields the tooth band (any thin heel stub is the removed smaller piece; no apex piece remains). Raise only if there is no non-apex piece at all. Because each cut acts on a single body, you get exactly **two** split features regardless of gear ratio.
-
-**Make every cut failure self-diagnosing** (`[PB-SELF-DIAGNOSING]` — these errors are how the build is debugged when run headless, so they must carry the measured numbers, not a bare count):
-- **The cut never silently no-ops.** If, after trying **every** `ConeSurfaceType` face of the frustum as the split tool, none actually splits the target, `raise RuntimeError` (NOT a bare `Exception`, so the heel's lenient `except RuntimeError` above can catch the non-intersection case) naming the cut (#1/#2, pinion/driving) and listing, for every frustum cone face, its distances (which may be `None` when the evaluator can't project the point) **and whether the split was attempted/failed** — so a genuinely-absent cone is distinguishable from an evaluator/selection problem. **Preserve the per-face Fusion error text** (the `SPLIT_TARGET_TOOL_NOT_INTERSECT` / `交差` strings collected in the history) in this message verbatim, so the heel's message-based leniency keeps the keeper whole when the heel cone simply does not overshoot, while a true face-selection/tolerance bug (which carries different per-face text, e.g. faces that split into ≤1 piece without a non-intersect error) still propagates and crashes the toe cut. Do **not** return the bodies unchanged on a miss.
-- **Log each cut's outcome** with `futil.log(..., force_console=True)`: how many bodies went in, which face was selected (with its distances), and how many pieces came out (or "tool did not intersect, kept intact").
-- **Errors must report the per-cut history**, e.g. `"<gear>: toe cut produced N pieces (faces found=…, selected dist=…); keeper selection found M non-apex pieces; heel cut …"`, so the message alone reveals which cut under- or over-split and whether it was a tolerance/face-selection problem. (Do not assert a fixed total piece count — with interleaved selection each cut acts on one body, so the counts are toe→2, heel→1-or-2.)
+**Caller obligations (these stay in the generator):** pass `toeMid` = the toe edge's world
+midpoint (`(M_world + N_world)/2` pinion / `(O_world + P_world)/2` driving) and `heelMid` = the
+heel edge's world midpoint (`(C_world + H_world)/2` / `(D_world + J_world)/2`) — the same
+edge-midpoint pairs as the §3a hand-off; `apexWorld` = the §2 Apex sketch point's world geometry;
+`gearBody` = the revolved frustum (the cone-face source). The toe cut must split (its failure
+propagates and crashes the build — correct, since an uncut tooth is unusable); only the heel cut
+is lenient, and only via the typed `NonIntersectError`.
 
 **Pattern.** Circular-pattern the remaining tooth piece around the **shaft-axis edge** (the same in-sketch profile edge used for the revolve, not the §2 construction line). The number of copies equals this gear's Teeth Number. (Although the pitch diameter shrinks from heel toward apex, the *angular* spacing around the shaft axis stays constant at `360° / N` for the entire face width — the radial taper is already produced by the loft from Apex to the heel-end tooth profile, so the pattern just rotates that single tapered tooth into N evenly spaced copies.)
 
 **Combine.** Join all patterned tooth pieces with the Gear Body in a single Combine-Join (the Gear Body as the target, the patterned tooth bodies as the tools).
 
-**Bore.** If Enable Bore is checked, cut a cylindrical through bore through the Gear Body along the shaft axis. The bore diameter is this gear's Bore Diameter if specified (non-zero); otherwise `this gear's Pitch Diameter / 4`. Build the bore plane normal to the shaft at its start (`setByDistanceOnPath(<shaft-axis edge>, 0.0)`; pass the in-sketch edge, not the §2 construction line). Sketch the bore circle centered at the sketch origin (the plane is rooted at the shaft start, so the origin is on the axis): **fix the bore circle's center and add a diameter dimension** set to the bore diameter (`[PB-CIRCLE-CENTER]`). Extrude-cut it as a symmetric through-cut restricted to `[this Gear Body]` (`[PB-THROUGH-CUT]`). Skip this step entirely if Enable Bore is unchecked.
+**Bore.** If Enable Bore is checked, cut a cylindrical through bore through the Gear Body along the shaft axis. The bore diameter is this gear's Bore Diameter if specified (non-zero); otherwise `this gear's Pitch Diameter / 4`. Build the bore plane normal to the shaft at its start (`setByDistanceOnPath(<shaft-axis edge>, 0.0)`; pass the in-sketch edge, not the §2 construction line). In a sketch named `{gearLabel} Bore`, sketch the bore circle centered at the sketch origin (the plane is rooted at the shaft start, so the origin is on the axis): **fix the bore circle's center and add a diameter dimension** set to the bore diameter (`[PB-CIRCLE-CENTER]`). Extrude-cut it as a symmetric through-cut restricted to `[this Gear Body]` (`[PB-THROUGH-CUT]`; use `2 × Cone Distance` as the per-side half-length — generously past any face width). Skip this step entirely if Enable Bore is unchecked.
 
-**Meshing rotation (driving gear only) — do this here, in the Design component, before the body is moved out.** Rotate the driving body by `180° / Driving Gear Teeth Number` (half a tooth pitch) about its shaft axis — the B->I profile edge, whose **world** endpoints give the rotation axis/origin (`[PB-MOVE-ROTATE]`) — so a driving valley sits where the pinion tooth crosses the axial plane, giving the interlocked meshing look. Rationale: both gears are patterned from a starting tooth in the axial plane, so without the offset a driving tooth and a pinion tooth would both sit at the axial-plane crossing and visually collide. This runs in Design before `moveToComponent` because a construction axis can't be added in the moved-out gear component (`[PB-CONSTRUCTION-NEEDS-ACTIVE]`), so the rotation must use the edge's world geometry while still in Design. (The pinion additionally gets `_pinionMeshPhase()` — 0 unless a spiral pair needs it; see Method contract.)
+**Meshing rotation (driving gear only) — do this here, in the Design component, before the body is moved out.** Rotate the driving body by `180° / Driving Gear Teeth Number` (half a tooth pitch) about its shaft axis — `rotate_body_about_edge(designComponent, gearBody, shaftAxisEdge, angle)` (framework, from `.solids`), which takes the rotation axis/origin from the B->I profile edge's **world** endpoints (`[PB-MOVE-ROTATE]`) — so a driving valley sits where the pinion tooth crosses the axial plane, giving the interlocked meshing look. Rationale: both gears are patterned from a starting tooth in the axial plane, so without the offset a driving tooth and a pinion tooth would both sit at the axial-plane crossing and visually collide. This runs in Design before `moveToComponent` because a construction axis can't be added in the moved-out gear component (`[PB-CONSTRUCTION-NEEDS-ACTIVE]`), so the rotation must use the edge's world geometry while still in Design. (The pinion additionally gets `_pinionMeshPhase()` — 0 unless a spiral pair needs it; see Method contract.)
 
 
 
 ## Cleanup
 
-Recursively walk the Bevel Gear component tree (dedupe by `entityToken`) and hide every sketch, construction plane, and construction axis with `isLightBulbOn = False` (construction planes/axes are **not** hidden by `isVisible`; sketches use `isVisible = False` or the same light-bulb). Leave only the two finished gear bodies visible.
+Call the framework's `hide_construction_geometry(bevelComponent)` (from `.solids`) — it recursively walks the Bevel Gear component tree (dedupe by `entityToken`) and hides every sketch, construction plane, and construction axis with `isLightBulbOn = False` (construction planes/axes are **not** hidden by `isVisible` — `[PB-HIDE-AFTER-USE]`). Leave only the two finished gear bodies visible.
 
 (The driving gear's half-tooth-pitch **meshing rotation** is performed earlier, at the end of "Create the Gear Bodies", in the Design component before the body is moved out — not a cleanup step; see that section for the rationale.)

--- a/spec/spurgear/instructions.md
+++ b/spec/spurgear/instructions.md
@@ -18,7 +18,12 @@ Target Plane: user-specified plane. The gear's front face is sketched on this pl
 
 Anchor Point: user-specified point. The gear center is aligned with this point. May be a `ConstructionPoint` or a `SketchPoint`. The anchor point is projected into the Tools sketch on the target plane; the Gear Profile sketch then constrains its own local origin (0,0,0) to that projected point, so changing the anchor point downstream moves the gear.
 
-Module: user-supplied number. Specifies the module of the gear.
+Module: user-supplied number. Specifies the module of the gear. The dialog input is unitless
+(`''`) with default `1`, and the `Module` user parameter is registered with units **`''`
+(unitless) — NOT `'mm'`** — so `generateName` renders `M=1` (no unit suffix) and the derived
+`mm`-registered expressions (`PitchCircleDiameter = Module * ToothNumber`, `RootCircleDiameter =
+PitchCircleDiameter - 2.5 * Module`, …) read the unitless `Module` factor exactly as the proven
+implementation does (Fusion accepts the unitless term inside those `mm` expressions).
 
 Tooth Number: user-specified integer. Default 17.
 
@@ -224,7 +229,13 @@ Specific boundaries subclasses depend on (do not move the work elsewhere):
 - Methods `drawCircles`, `drawTooth`, `drawBore`, and `calculateInvolutePoint(baseRadius,
   intersectionRadius)` must all exist. The tooth generator also exposes parameter accessors
   `getParameter(name)` and `getParameterValue(name)` (these names are part of the reproduced
-  surface).
+  surface). `drawBore(anchorPoint, diameter)` takes the anchor entity and the bore diameter (cm),
+  projects the anchor into the sketch, draws the bore circle of that diameter centered on the
+  projection with a driving diameter dimension, and returns the circle.
+- When a drawing step needs one of the four circles drawn by `drawCircles` (the tip circle for
+  the tooth-top point, the root circle for the flank-to-root lines), either keep direct references
+  from `drawCircles` or locate it with the framework's `find_circle_by_radius(sketch, radius)`
+  (from `.utilities`) — never fall back to an arbitrary circle on a failed radius match.
 - **`calculateInvolutePoint(baseRadius, intersectionRadius)` — exact math** (this fully pins the
   flank shape; do not infer it). Returns the point on the involute of `baseRadius` at the radius
   where the unrolled string reaches `intersectionRadius`; returns `None` when `intersectionRadius
@@ -318,13 +329,13 @@ If the Generate-Sketches-Only input is `true`, make the Gear Profile sketch visi
 
 ### 7: Extrude the Tooth
 
-Find the single tooth cross-section profile in the Gear Profile sketch. The profile has 2 NURBS (the two flanks), 2 arcs (the tooth top and the root arc between them), and — unless `toothProfileIsEmbedded` — 2 short line segments (the flank-to-root lines). Reject loops whose curve counts don't match.
+Find the single tooth cross-section profile in the Gear Profile sketch. The profile has 2 NURBS (the two flanks), 2 arcs (the tooth top and the root arc between them), and — unless `toothProfileIsEmbedded` — 2 short line segments (the flank-to-root lines). Find it with the framework helper — `find_profile_by_curve_counts(sketch, nurbs=2, arcs=2, lines=0 if ctx.toothProfileIsEmbedded else 2)` (from `.utilities`) — do not re-implement the loop search; the helper rejects loops whose curve counts don't match and raises when nothing matches.
 
 Extrude this profile from the target plane to the Extrusion End Plane (`ToEntityExtentDefinition`, PositiveExtentDirection) as a **New Body**. Name the feature `Extrude tooth`. Store the resulting body as `ctx.toothBody`.
 
 ### 8: Chamfer Tooth (optional)
 
-If Apply-Chamfer-To-Teeth > 0, round off every edge of the tooth's front face *except* the arc shared with the root valley. The target face is identified by its edge count matching the loop we drew in step 4 — 6 for a spur tooth, different for subclasses. Skipping the root arc is the critical part: chamfering it would eat into the neighbouring tooth.
+If Apply-Chamfer-To-Teeth > 0, round off every edge of the tooth's front face *except* the arc shared with the root valley. The target face is identified by its edge count matching the loop we drew in step 4 — 6 for a spur tooth, different for subclasses. When both end caps of the tooth body match the edge count, take the **front** one: the face that is coplanar with the gear's sketch plane (`sketchPlane.isCoPlanarTo(face.geometry)` with `sketchPlane = ctx.gearProfileSketch.referencePlane.geometry` — the same test step 9 uses, inverted). Skipping the root arc is the critical part: chamfering it would eat into the neighbouring tooth. (Known, accepted limitation: an **embedded** profile yields a 4-edge front face while `chamferWantEdges()` stays 6 for spur, so chamfering an embedded spur tooth raises the front-face-not-found error — users disable chamfer for such gears.)
 
 **Identify the root arc by radius, not by relative size.** Walk the front face's edges and add each to the chamfer edge set, *except* skip any edge that is an `Arc3DCurveType` whose `edge.geometry.radius` equals `Root Circle Radius` (compare against the registered parameter's `.value`, tolerance `0.001` cm). That radius match is exact — the root arc is the only edge lying on the root circle — so it is more robust than "the smallest-radius arc." (This is the same radius-matching technique step 11 uses to find the root cylinders.) Everything else on the face — the two flanks, the tooth-top arc, and the two flank-to-root lines — gets chamfered. Apply with `chamferFeatures.createInput2()` → `chamferEdgeSets.addEqualDistanceChamferEdgeSet(edges, <ChamferTooth value>, False)`.
 
@@ -332,7 +343,7 @@ Helical and herringbone subclasses override the expected edge count (a lofted em
 
 ### 9: Extrude the Body
 
-Find the gear body profile — the annular loop bounded by **exactly 2 arcs** (the root circle and the tip circle): a `profileLoop` whose `profileCurves.count == 2` and every curve's `geometry.curveType` is `Arc3DCurveType`. Extrude it from the target plane to the Extrusion End Plane (`ToEntityExtentDefinition.create(ctx.extrusionEndPlane, False)`, `PositiveExtentDirection`) as a **New Body**. Name the feature `Extrude body` and the resulting body `Gear Body`.
+Find the gear body profile — the annular loop bounded by **exactly 2 arcs** (the root circle and the tip circle): `find_profile_by_curve_counts(sketch, arcs=2)` (from `.utilities`). Extrude it from the target plane to the Extrusion End Plane (`ToEntityExtentDefinition.create(ctx.extrusionEndPlane, False)`, `PositiveExtentDirection`) as a **New Body**. Name the feature `Extrude body` and the resulting body `Gear Body`.
 
 While iterating the new body's faces (`extrude.bodies.item(0).faces`), capture two references needed later. Classify each face by `face.geometry.surfaceType`:
 


### PR DESCRIPTION
- shared `commands/_gear_command.py`: 4 per-gear command entries collapse to ~5-line declarations (supersedes #15)
- extract proven Fusion plumbing to `lib/geargen/solids.py` + `spurproxy.py` and `utilities` profile/circle finders; `base.get_value` now returns a `ValueInput` or raises
- regenerate spur/bevel from specs against the shrunk surface; fix bevel §2 Apex2-drop side-flip that inverted straight-cut pinions (drops now aim at the interior wedge, not the degenerate "toward anchor" reference)
