### PR TITLE
spec-generate helical and herringbone gears

### DIFF
--- a/lib/geargen/helicalgear.py
+++ b/lib/geargen/helicalgear.py
@@ -1,39 +1,47 @@
 import math
 import adsk.core, adsk.fusion
-from .base import GenerationContext, get_value
-from .utilities import find_profile_by_curve_counts
 from .spurgear import (
     PARAM_MODULE, PARAM_TOOTH_NUMBER, PARAM_THICKNESS,
     SpurGearCommandInputsConfigurator, SpurGearGenerationContext,
     SpurGearGenerator, SpurGearInvoluteToothDesignGenerator,
 )
+from .base import GenerationContext, get_value
+from .utilities import find_profile_by_curve_counts
 
+
+# --- Helical-specific parameter name / dialog input id (verbatim surface) ---
 PARAM_HELIX_ANGLE = 'HelixAngle'
 INPUT_ID_HELIX_ANGLE = 'helixAngle'
+
 
 class HelicalGearCommandConfigurator(SpurGearCommandInputsConfigurator):
     @classmethod
     def configure(cls, cmd):
+        # Spur adds every base input first (Parent Component last); the Helix
+        # Angle value input is appended after, so it necessarily lands LAST in
+        # the dialog, after Parent Component ([SPUR-SUBCLASS-INPUT] consequence).
         super().configure(cmd)
         cmd.commandInputs.addValueInput(
-            INPUT_ID_HELIX_ANGLE,
-            'Helix Angle',
-            'deg',
-            adsk.core.ValueInput.createByReal(math.radians(14.5)),
-        )
+            INPUT_ID_HELIX_ANGLE, 'Helix Angle', 'deg',
+            adsk.core.ValueInput.createByReal(math.radians(14.5)))
+
 
 class HelicalGearGenerationContext(SpurGearGenerationContext):
     def __init__(self):
         super().__init__()
+        # The offset plane the twisted top profile is drawn on (also the mirror
+        # plane herringbone reflects across).
         self.helixPlane = adsk.fusion.ConstructionPlane.cast(None)
+        # The second, "Twisted Gear Profile" sketch: the top loft section.
         self.twistedGearProfileSketch = adsk.fusion.Sketch.cast(None)
 
+
 class HelicalGearGenerator(SpurGearGenerator):
+    def prefixBase(self):
+        return 'HelicalGear'
+
     def newContext(self):
         return HelicalGearGenerationContext()
-
-    def prefixBase(self) -> str:
-        return 'HelicalGear'
 
     def generateName(self):
         module = self.getParameter(PARAM_MODULE)
@@ -41,56 +49,63 @@ class HelicalGearGenerator(SpurGearGenerator):
         thickness = self.getParameter(PARAM_THICKNESS)
         helixAngle = self.getParameter(PARAM_HELIX_ANGLE)
         return 'Helical Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(
-            module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
+            module.expression, toothNumber.expression,
+            thickness.expression, helixAngle.expression)
 
-    def addExtraPrimaryParameters(self, inputs: adsk.core.CommandInputs):
+    def addExtraPrimaryParameters(self, inputs):
+        # Register HelixAngle from the degree dialog input, stored in radians.
         helixAngle = get_value(inputs, INPUT_ID_HELIX_ANGLE, 'rad')
-        self.addParameter(PARAM_HELIX_ANGLE, helixAngle, 'rad', 'Helix angle for the helical gear')
+        self.addParameter(PARAM_HELIX_ANGLE, helixAngle, 'rad',
+                          'Helix angle for the helical gear')
 
-    def filletHelixFactorExpression(self) -> str:
+    def filletHelixFactorExpression(self):
+        # Multiplies the root-fillet radius by cos(HelixAngle) so it reads
+        # correctly on the tilted tooth's transverse plane (spur base: '1').
         return f'cos({self.parameterName(PARAM_HELIX_ANGLE)})'
 
-    # Offset of the construction plane used for the twisted top profile,
-    # relative to the base plane. Herringbone halves this so the mirror plane
-    # sits in the middle of the gear body.
-    def helicalPlaneOffset(self) -> adsk.core.ValueInput:
-        return self.getParameterAsValueInput(PARAM_THICKNESS)
-
     def chamferWantEdges(self):
+        # [HELI-F-CHAMFER-COUNT] Reproduced verbatim (spur base returns 6).
         return 4
 
+    def helicalPlaneOffset(self):
+        # Distinct overridable hook (herringbone re-points it to half-thickness);
+        # helical returns the full Thickness.
+        return self.getParameterAsValueInput(PARAM_THICKNESS)
+
     def buildSketches(self, ctx: GenerationContext):
+        # Draw the bottom Gear Profile + spur tooth at angle 0 (spur steps 3-5).
         super().buildSketches(ctx)
 
-        # The bottom profile has already been drawn by the base class.
-        # Now draw a twisted profile on a plane offset from the base plane
-        # so the tooth can be built with a loft.
+        # [HELI-F-TWIST-PLANE] Offset construction plane for the twisted top
+        # profile, on the gear's own component.
         constructionPlaneInput = self.getComponent().constructionPlanes.createInput()
         constructionPlaneInput.setByOffset(self.plane, self.helicalPlaneOffset())
         plane = self.getComponent().constructionPlanes.add(constructionPlaneInput)
         ctx.helixPlane = plane
 
         loftSketch = self.createSketchObject('Twisted Gear Profile', plane=plane)
-        helixAngle = self.getParameter(PARAM_HELIX_ANGLE).value
-        SpurGearInvoluteToothDesignGenerator(loftSketch, self).draw(ctx.anchorPoint, angle=helixAngle)
+        # The twist is delivered as the draw() angle: the spur tooth generator
+        # rotates the whole tooth by angle ([SPUR-F-ROTATE-CONFIRM]).
+        SpurGearInvoluteToothDesignGenerator(loftSketch, self).draw(
+            ctx.anchorPoint, angle=self.getParameter(PARAM_HELIX_ANGLE).value)
         ctx.twistedGearProfileSketch = loftSketch
 
     def buildTooth(self, ctx: GenerationContext):
+        # Loft (not extrude); must end by calling chamferTooth (spur's boundary).
         self.loftTooth(ctx)
         self.chamferTooth(ctx)
 
     def loftTooth(self, ctx: GenerationContext):
-        bottomSketch = ctx.gearProfileSketch
-        topSketch = ctx.twistedGearProfileSketch
-
+        # [HELI-F-LOFT] Loft the bottom tooth loop to the top twisted tooth loop.
+        # Non-embedded only: both sections use a fixed nurbs=2, arcs=2, lines=2.
         lofts = self.getComponent().features.loftFeatures
-
         bottomToothProfile = find_profile_by_curve_counts(
-            bottomSketch, nurbs=2, arcs=2, lines=2)
+            ctx.gearProfileSketch, nurbs=2, arcs=2, lines=2)
         topToothProfile = find_profile_by_curve_counts(
-            topSketch, nurbs=2, arcs=2, lines=2)
-
-        loftInput = lofts.createInput(adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+            ctx.twistedGearProfileSketch, nurbs=2, arcs=2, lines=2)
+        loftInput = lofts.createInput(
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        # Add the bottom section first, then the top.
         loftInput.loftSections.add(bottomToothProfile)
         loftInput.loftSections.add(topToothProfile)
         loftResult = lofts.add(loftInput)

--- a/lib/geargen/herringbonegear.py
+++ b/lib/geargen/herringbonegear.py
@@ -2,13 +2,24 @@ import adsk.core, adsk.fusion
 from .base import GenerationContext
 from .spurgear import PARAM_MODULE, PARAM_TOOTH_NUMBER, PARAM_THICKNESS
 from .helicalgear import (
-    PARAM_HELIX_ANGLE, HelicalGearCommandConfigurator,
-    HelicalGearGenerationContext, HelicalGearGenerator,
+    PARAM_HELIX_ANGLE,
+    HelicalGearCommandConfigurator,
+    HelicalGearGenerationContext,
+    HelicalGearGenerator,
 )
 
-class HerringboneGearCommandConfigurator(HelicalGearCommandConfigurator): pass
 
-class HerringboneGearGenerationContext(HelicalGearGenerationContext): pass
+class HerringboneGearCommandConfigurator(HelicalGearCommandConfigurator):
+    # Herringbone's dialog is exactly helical's (Helix Angle + inherited spur
+    # inputs); no new input is added.
+    pass
+
+
+class HerringboneGearGenerationContext(HelicalGearGenerationContext):
+    # Same context fields as helical; ctx.helixPlane is now the mid-body mirror
+    # plane (a consequence of the half-thickness helicalPlaneOffset override).
+    pass
+
 
 class HerringboneGearGenerator(HelicalGearGenerator):
     def newContext(self):
@@ -25,8 +36,10 @@ class HerringboneGearGenerator(HelicalGearGenerator):
         return 'Herringbone Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(
             module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)
 
-    # The mirror plane sits in the middle of the body, so the loft only covers
-    # half the thickness.
+    # Place the twisted-profile plane at mid-body (half thickness) instead of
+    # the far face, so ctx.helixPlane becomes the mirror plane and the loft
+    # spans the bottom half while the mirror completes the top half. This is a
+    # raw computed offset, not a parameter reference.
     def helicalPlaneOffset(self) -> adsk.core.ValueInput:
         thickness = self.getParameter(PARAM_THICKNESS).value
         return adsk.core.ValueInput.createByReal(thickness / 2)
@@ -34,15 +47,15 @@ class HerringboneGearGenerator(HelicalGearGenerator):
     def buildTooth(self, ctx: GenerationContext):
         self.loftTooth(ctx)
 
-        # Mirror the lofted tooth across the helix plane to form the other half.
+        # Mirror the lofted half across the mid-body helix plane to form the other half.
         entities = adsk.core.ObjectCollection.create()
         entities.add(ctx.toothBody)
         mirrorInput = self.getComponent().features.mirrorFeatures.createInput(entities, ctx.helixPlane)
         mirrorResult = self.getComponent().features.mirrorFeatures.add(mirrorInput)
         mirrorResult.bodies.item(0).name = 'Tooth Body (Mirrored)'
 
-        # Combine the mirrored half into the original tooth body so the pattern
-        # and combine steps in the base class operate on a single body.
+        # Combine the mirrored half into the original so the pattern/combine steps in the
+        # inherited spur pipeline operate on a single body.
         entities = adsk.core.ObjectCollection.create()
         entities.add(mirrorResult.bodies.item(0))
         combineInput = self.getComponent().features.combineFeatures.createInput(

--- a/spec/helicalgear/fusion.md
+++ b/spec/helicalgear/fusion.md
@@ -1,0 +1,64 @@
+# Helical Gear — Fusion realization notes
+
+Helical reuses spur's Fusion mechanics for everything except the twisted-profile plane, the loft, and
+the chamfer edge count. These are the only helical-specific anchors; the tooth itself is spur's
+(`[SPUR-F-…]`). `instructions.md` cites these instead of restating them.
+
+## Twisted top profile
+
+- **[HELI-F-TWIST-PLANE] The twisted profile's plane and sketch (`buildSketches`, after
+  `super().buildSketches`).** Create the plane on the gear's own component:
+  ```python
+  constructionPlaneInput = self.getComponent().constructionPlanes.createInput()
+  constructionPlaneInput.setByOffset(self.plane, self.helicalPlaneOffset())
+  plane = self.getComponent().constructionPlanes.add(constructionPlaneInput)
+  ctx.helixPlane = plane
+  loftSketch = self.createSketchObject('Twisted Gear Profile', plane=plane)
+  SpurGearInvoluteToothDesignGenerator(loftSketch, self).draw(
+      ctx.anchorPoint, angle=self.getParameter(PARAM_HELIX_ANGLE).value)
+  ctx.twistedGearProfileSketch = loftSketch
+  ```
+  The offset is taken from **`self.helicalPlaneOffset()`** (a hook — helical: full `Thickness`;
+  herringbone: `Thickness/2`), so herringbone's mirror plane lands mid-body. The twist angle is read as
+  a raw `.value` (radians) and passed to the spur tooth generator's `draw(anchorPoint, angle=…)`; the
+  generator draws the whole tooth already rotated by it (`[SPUR-F-ROTATE-CONFIRM]` / `[SPUR-F-SPINE]`).
+  `createSketchObject` returns a hidden sketch; the inherited spur pipeline handles visibility/cleanup.
+
+## Loft the tooth
+
+- **[HELI-F-LOFT] Loft between the two profiles (`buildTooth` → `loftTooth`).** Find the tooth loop in
+  each sketch and loft bottom→top into a new body:
+  ```python
+  lofts = self.getComponent().features.loftFeatures
+  bottomToothProfile = find_profile_by_curve_counts(ctx.gearProfileSketch, nurbs=2, arcs=2, lines=2)
+  topToothProfile    = find_profile_by_curve_counts(ctx.twistedGearProfileSketch, nurbs=2, arcs=2, lines=2)
+  loftInput = lofts.createInput(adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+  loftInput.loftSections.add(bottomToothProfile)
+  loftInput.loftSections.add(topToothProfile)
+  loftResult = lofts.add(loftInput)
+  ctx.toothBody = loftResult.bodies.item(0)
+  ctx.toothBody.name = 'Tooth Body'
+  ```
+  Add the bottom section **first**, then the top. Use the framework helper `find_profile_by_curve_counts`
+  (do not re-implement the loop search — PLAYBOOK "Shared geargen helper library").
+  **⚠️ Non-embedded only.** Both sections pass a fixed `nurbs=2, arcs=2, lines=2` (the non-embedded
+  6-curve tooth). This implementation does **not** read `ctx.toothProfileIsEmbedded` and has **no
+  embedded branch**: an embedded low-tooth-count helical gear (flank starts inside the root circle,
+  `lines=0`) would fail to find the profile. This is faithful to the current code — a documented
+  limitation, not a bug to fix in the spec.
+
+## Chamfer edge count
+
+- **[HELI-F-CHAMFER-COUNT] `chamferWantEdges()` returns `4`.** The inherited `chamferTooth`
+  (`[SPUR-F]` step 8 / spur `chamferTooth`) selects the tooth's front face by
+  `face.edges.count == chamferWantEdges()` plus the sketch-plane coplanarity test, and helical bumps
+  the expected count from spur's 6 to **4** — it does **not** override `chamferTooth` itself and adds
+  no "must contain two NURBS flanks" content filter (that phrasing in the spur spec is speculative and
+  unimplemented).
+  **⚠️ Asserted / unverified — reproduce verbatim, do not "fix".** The lofted tooth here is the
+  non-embedded **6-curve** profile, so its front cap face would be expected to have **6** edges, not 4.
+  A `chamferWantEdges()` of 4 would then make `chamferTooth` fail to find the front face, so helical
+  chamfer is likely **fragile/broken for the default non-embedded tooth** and is effectively exercised
+  only at the default **chamfer 0** (no chamfer). This value (`4`) is copied straight from
+  `lib/geargen/helicalgear.py`; it is flagged here for a future, deliberate correction once the front
+  face edge count is confirmed in Fusion — changing it now would be an un-verified behavior change.

--- a/spec/helicalgear/instructions.md
+++ b/spec/helicalgear/instructions.md
@@ -1,0 +1,186 @@
+# Helical Gear Creation Instructions
+
+Helical is a **thin specialization of the spur gear.** It **subclasses `SpurGearGenerator`** and
+reuses the entire spur build pipeline verbatim (tools sketch, gear profile, body extrude, pattern,
+fillets, bore, cleanup, and the whole tooth generator). It changes exactly three things: it adds one
+**Helix Angle** input, draws a **second "Twisted Gear Profile" sketch** (the spur tooth generator run
+at `angle=helixAngle`), and **lofts** the bottom profile to that twisted top profile instead of
+extruding.
+
+**Read `spec/spurgear/instructions.md` + `spec/spurgear/fusion.md` first.** This spec states only
+helical's *deltas* and cites spur's contract by anchor (`[SPUR-F-…]`) and section name; it does not
+restate spur's geometry. The Fusion-API mechanics unique to helical (the offset plane, the loft, the
+chamfer edge count) live in `fusion.md` (`[HELI-F-…]`). The twisted profile's constraint scheme — the
+spur tooth at a non-zero angle, i.e. the `[SPUR-F-SPINE]` angle≠0 path — is proven to fully constrain
+in `spec/helicalgear/sketch/` (the sketch-first gate, `[PB-SKETCH-FIRST]`).
+
+## Component Setup
+
+Identical to spur (inherited). The gear occurrence, the Tools sketch and anchor chain, the Gear
+Profile sketch, the body, the circular pattern, the root fillets, the optional bore, and cleanup are
+all produced by the inherited `SpurGearGenerator` pipeline unchanged.
+
+## Variables
+
+**All spur inputs and derived parameters, inherited verbatim** (same input ids, same
+`SpurGear<N>_`-style names, same formulas — see `spec/spurgear/instructions.md` Variables). Helical
+adds **one** input and **one** derived parameter:
+
+Helix Angle: user-specified angle. Default **14.5°**. The angle by which the top gear profile is
+twisted relative to the bottom; the tooth is formed by lofting between them. Stored in the user
+parameter **`HelixAngle`**, registered in **radians** (from a **degree** dialog input). It also drives
+the root-fillet transverse correction via `filletHelixFactorExpression()` = `cos(HelixAngle)` (spur's
+`* 1` fillet-factor hook — see spur Variables "Fillet Radius").
+
+### Exact input ids and parameter-name strings
+
+Inherits every spur input id and user-parameter name unchanged, and adds exactly one of each:
+
+| Dialog label | input id       | user-parameter name |
+|--------------|----------------|---------------------|
+| Helix Angle  | `helixAngle`   | `HelixAngle`        |
+
+- **Dialog input** — `addValueInput('helixAngle', 'Helix Angle', 'deg', adsk.core.ValueInput.createByReal(math.radians(14.5)))`:
+  a **degree** value input defaulting to 14.5°. Added by `HelicalGearCommandConfigurator.configure`
+  **after** `super().configure(cmd)` (spur `[SPUR-SUBCLASS-INPUT]`). Because spur's `configure` already
+  added Parent Component **last**, the Helix Angle input necessarily appears **last in the dialog,
+  after Parent Component.** ⚠️ This is the actual/current behavior — reproduce it exactly; do not
+  attempt to insert Helix Angle earlier in the list.
+- **User parameter** — registered by the overridden `addExtraPrimaryParameters` hook (spur
+  `[SPUR-EXTRA-PARAMS]`): `helixAngle = get_value(inputs, 'helixAngle', 'rad')` then
+  `self.addParameter('HelixAngle', helixAngle, 'rad', 'Helix angle for the helical gear')`. Registered
+  in **`'rad'`** (the dialog is degrees; the parameter is radians).
+
+Module-level constants: `PARAM_HELIX_ANGLE = 'HelixAngle'`, `INPUT_ID_HELIX_ANGLE = 'helixAngle'`.
+
+## Architecture
+
+Helical **subclasses the spur family** — three classes, each extending its spur counterpart. There is
+no standalone generator; the spur pipeline is inherited. These names are the reproduced surface
+(herringbone subclasses all three, and `commands/helicalgear/entry.py` binds two by name):
+
+1. **`HelicalGearCommandConfigurator(SpurGearCommandInputsConfigurator)`** — `@classmethod def
+   configure(cls, cmd)` that calls `super().configure(cmd)` then appends the Helix Angle value input.
+2. **`HelicalGearGenerationContext(SpurGearGenerationContext)`** — `__init__(self)` calls
+   `super().__init__()` then initializes the two new fields to a cast-None:
+   `self.helixPlane = adsk.fusion.ConstructionPlane.cast(None)`,
+   `self.twistedGearProfileSketch = adsk.fusion.Sketch.cast(None)`.
+3. **`HelicalGearGenerator(SpurGearGenerator)`** — overrides the methods in Method contract below.
+
+Imports (explicit, no `import *`, per the PLAYBOOK Module-layout rule): from `.spurgear` —
+`PARAM_MODULE, PARAM_TOOTH_NUMBER, PARAM_THICKNESS, SpurGearCommandInputsConfigurator,
+SpurGearGenerationContext, SpurGearGenerator, SpurGearInvoluteToothDesignGenerator`; from `.base` —
+`GenerationContext, get_value`; from `.utilities` — `find_profile_by_curve_counts`; plus `math`,
+`adsk.core`, `adsk.fusion`.
+
+## Generation Context — spur's, plus two fields
+
+Cite spur's `SpurGearGenerationContext` field list (inherited unchanged — `ctx.plane`,
+`ctx.anchorPoint`, `ctx.extrusionEndPlane`, `ctx.gearProfileSketch`, `ctx.toothBody`, `ctx.gearBody`,
+`ctx.centerAxis`, `ctx.extrusionExtent`, `ctx.toothProfileIsEmbedded`). Helical adds two:
+
+- **`ctx.helixPlane`** — the offset `ConstructionPlane` the twisted top profile is drawn on. (Also the
+  mirror plane herringbone reflects across.)
+- **`ctx.twistedGearProfileSketch`** — the second, "Twisted Gear Profile" sketch: the top loft section.
+
+## Method contract — overrides only (spur's call graph is inherited)
+
+Helical keeps spur's entire call graph and override boundaries (`spec/spurgear/instructions.md` Method
+contract): `generate → processInputs → prepareTools → buildMainGearBody(buildSketches → buildTooth →
+buildBody → patternTeeth[→createFillets]) → buildBore → cleanup`. **Do not move work across those
+boundaries.** Helical overrides exactly these methods:
+
+- **`newContext()`** → `HelicalGearGenerationContext()`.
+- **`prefixBase()`** → `'HelicalGear'`.
+- **`generateName()`** → `'Helical Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)`
+  — the four parameters' **`.expression`** strings (spur's rule, extended with `HelixAngle`).
+- **`addExtraPrimaryParameters(self, inputs)`** → registers `HelixAngle` (see Exact input ids). Overrides
+  spur's no-op (`[SPUR-EXTRA-PARAMS]`).
+- **`filletHelixFactorExpression(self)`** → `f'cos({self.parameterName(PARAM_HELIX_ANGLE)})'` (spur base
+  returns `'1'`). Multiplies the root-fillet radius by `cos(HelixAngle)` so it reads correctly on the
+  tilted tooth's transverse plane.
+- **`chamferWantEdges(self)`** → `4` (spur base returns 6). See `fusion.md` `[HELI-F-CHAMFER-COUNT]`
+  (reproduce verbatim; it is flagged there).
+- **`helicalPlaneOffset(self)`** → the offset of the twisted-profile plane from the base plane, as a
+  `ValueInput`. Helical returns the full thickness: `self.getParameterAsValueInput(PARAM_THICKNESS)`.
+  **This is a distinct overridable hook** (herringbone re-points it to half-thickness); keep it its own
+  method — do not inline the offset into `buildSketches`.
+- **`buildSketches(self, ctx)`** → calls `super().buildSketches(ctx)` (which draws the bottom Gear
+  Profile and runs the spur tooth generator at angle 0), then draws the twisted top profile
+  (`[HELI-F-TWIST-PLANE]`; see Generation Order).
+- **`buildTooth(self, ctx)`** → `self.loftTooth(ctx)` then `self.chamferTooth(ctx)`. **Must end by
+  calling `chamferTooth`** (spur's boundary — `buildMainGearBody` does not chamfer separately). Does
+  **not** extrude.
+- **`loftTooth(self, ctx)`** → lofts the two profiles into `ctx.toothBody` (`[HELI-F-LOFT]`).
+
+**Inherited unchanged — do NOT re-implement:** `processInputs`, `prepareTools`, `buildMainGearBody`,
+`buildBody`, `patternTeeth`, `createFillets`, `chamferTooth`, `buildBore`, `cleanup`, and the entire
+`SpurGearInvoluteToothDesignGenerator`.
+
+The three `ctx`-taking overrides — `buildSketches`, `buildTooth`, `loftTooth` — **annotate the
+parameter as `ctx: GenerationContext`** (the base type imported from `.base`), matching the inherited
+signatures. This is why `GenerationContext` is in the import list; keep the annotation so the import
+is used.
+
+## Generation Order — spur's 12 steps, with two deltas
+
+Cite `spec/spurgear/instructions.md` Generation Order. Helical changes exactly two steps; everything
+else (body extrude step 9, pattern+combine step 10, fillets step 11, bore step 12, cleanup) runs
+spur's code untouched.
+
+**Delta 1 — `buildSketches` (extends spur steps 3–5).** After `super().buildSketches(ctx)` has drawn
+the bottom Gear Profile and run the tooth generator (at angle 0):
+1. create an offset construction plane at `self.helicalPlaneOffset()` from `self.plane`, store it as
+   `ctx.helixPlane`;
+2. create a sketch named `'Twisted Gear Profile'` on that plane;
+3. draw the tooth into it with `SpurGearInvoluteToothDesignGenerator(loftSketch, self).draw(ctx.anchorPoint, angle=self.getParameter(PARAM_HELIX_ANGLE).value)`
+   — the **twist is delivered as the `draw()` `angle`** (spur's tooth generator rotates the whole
+   tooth by `angle`; do not draw flat and rotate afterward — `[SPUR-F-ROTATE-CONFIRM]`);
+4. store the sketch as `ctx.twistedGearProfileSketch`.
+See `[HELI-F-TWIST-PLANE]`.
+
+**Delta 2 — `buildTooth` (replaces spur step 7's extrude).** Loft the bottom Gear Profile tooth loop
+to the top twisted tooth loop → `ctx.toothBody` named `'Tooth Body'`, then `self.chamferTooth(ctx)`.
+See `[HELI-F-LOFT]`.
+
+## Sketch-discipline deltas
+
+- **The twisted profile is drawn at `angle=helixAngle`** — the spur tooth generator's **angle≠0**
+  path applies verbatim (`[SPUR-F-SPINE]`: pre-rotated geometry + a +X horizontal reference line whose
+  far end is pinned on the tip circle + a confirming angular dimension; `[SPUR-F-ROTATE-CONFIRM]`).
+  Helical does nothing special here — it just passes `angle=helixAngle` to `draw()`; the generator
+  builds the fully-constrained rotated tooth. This angle≠0 path is proven in `spec/helicalgear/sketch/`.
+- **Both profiles are the non-embedded 6-curve tooth** (2 splines + 2 arcs + 2 lines). Helical
+  **requires non-embedded** — see `[HELI-F-LOFT]` and its limitation note.
+- **No runtime full-constraint gate.** Spur registers none, and helical adds none; the twisted
+  sketch's full-constraint is a design-time property, proven by the sketch bench, not asserted in code.
+
+## Dependencies
+
+Helical **subclasses `SpurGearGenerator`, `SpurGearCommandInputsConfigurator`, and
+`SpurGearGenerationContext`** (from `.spurgear`), and additionally constructs
+`SpurGearInvoluteToothDesignGenerator` directly for the twisted profile. Generation reads
+`spec/spurgear/instructions.md` + `spec/spurgear/fusion.md` and the current `lib/geargen/spurgear.py`
+surface. The borrowed surface that must exist unchanged on spur:
+
+- **The three base classes and their method boundaries** (spur Method contract): the full call graph
+  and the overridable hooks `addExtraPrimaryParameters` (`[SPUR-EXTRA-PARAMS]`), `chamferWantEdges`,
+  `filletHelixFactorExpression`, and the configurator extension seam `[SPUR-SUBCLASS-INPUT]`.
+- **The tooth generator** `SpurGearInvoluteToothDesignGenerator(sketch, parent)` with
+  `draw(anchorPoint, angle=0)` — the `angle` rotates the whole tooth (`[SPUR-F-ROTATE-CONFIRM]`).
+- **Context fields** `ctx.anchorPoint`, `ctx.gearProfileSketch`, `ctx.toothBody`,
+  `ctx.toothProfileIsEmbedded`, and `self.plane`.
+- **Inherited framework helpers**: `getComponent()`, `createSketchObject(name, plane=…)`,
+  `getParameter(name)`, `getParameterAsValueInput(name)`, `parameterName(name)`.
+
+## Honesty note — faithful-but-flagged behaviors
+
+Reproduced verbatim from `lib/geargen/helicalgear.py`; **do not "fix" them in the spec** (fixing
+changes behavior and belongs in a separate, deliberate change once verified in Fusion):
+
+- **Helix Angle sits last in the dialog**, after Parent Component (`[SPUR-SUBCLASS-INPUT]` consequence).
+- **`chamferWantEdges()` returns 4** for a non-embedded 6-curve lofted tooth — see
+  `[HELI-F-CHAMFER-COUNT]`; helical chamfer is likely fragile for the default tooth and effectively
+  exercised only at chamfer 0.
+- **Embedded (low-tooth-count) helical is unsupported** — `loftTooth` hardcodes `lines=2` and never
+  reads `ctx.toothProfileIsEmbedded` (`[HELI-F-LOFT]`).

--- a/spec/helicalgear/sketch/README.md
+++ b/spec/helicalgear/sketch/README.md
@@ -1,0 +1,55 @@
+# Helical twisted Gear Profile — sketch-first constraint proof
+
+The **sketch-first gate** ([PB-SKETCH-FIRST]) for the helical gear. Helical reuses the whole spur
+build pipeline but draws a **second, twisted** "Twisted Gear Profile" sketch — the spur tooth
+generator run at `angle=helixAngle` — and lofts the bottom (untwisted) profile to this top one. This
+bench reproduces that twisted profile in the [lestrrat-3d/sketch](https://github.com/lestrrat-3d/sketch)
+engine and proves its constraint scheme **fully constrains** before any Fusion code is generated.
+
+## Run it
+
+```sh
+./run.sh
+```
+
+Resolves the engine from `$SKETCH_DIR` or a sibling `../sketch` (via `git --git-common-dir`), same as
+the spur bench. Expected tail:
+
+```
+ALL PASS — the helical twisted Gear Profile fully constrains across sizes and helix angles.
+```
+
+## What this proves that the spur bench did not
+
+The tooth geometry and its constraint scheme are spur's (see `spec/spurgear/sketch/README.md` for the
+circles / involute flanks / ribs / flank-to-root construction). The **one new thing** is the spine's
+rotation lock. The spur bench only runs the seed tooth at `angle == 0`, where `[SPUR-F-SPINE]` reduces
+to a single `NewHorizontal(spine)`. Helical draws the tooth pre-rotated by `helixAngle`, which takes
+the **`[SPUR-F-SPINE]` angle ≠ 0 path** — untested until now:
+
+- a **+X horizontal reference** construction line from the origin, whose **far end is pinned on the
+  tip circle** (`NewPointOnCircle`). Without this end-pin the reference line's length floats and the
+  whole sketch is under-constrained even though the geometry looks right — the exact failure
+  `[SPUR-F-SPINE]` warns about;
+- an **angular dimension** from the reference to the spine (`NewAngle`, in degrees) fixing the twist.
+
+This bench runs the twisted profile across **sizes** (M/N) at the default 14.5° **and** a **helix-angle
+sweep** (0°, 10°, 25°, 35°) at N=17, confirming the angle ≠ 0 path reaches `DOF == 0`, no
+redundant/conflicting constraints, well-conditioned, for every combination. (angle 0° is included as
+the spur-equivalent baseline.)
+
+## The gate
+
+Identical to the spur bench: **primary gate** = `Status == FullyConstrained` and healthy
+`Conditioning` (⇒ `DOF == 0`, no redundant/conflicting constraints). `ProfilesValid` is **true** (needs
+the engine's #12 corner-join fix, now in sketch `main`); probe ambiguity is expected for a seeded
+draw-then-constrain sketch. See `spec/spurgear/sketch/README.md` for the full rationale.
+
+## Scope
+
+Models the **non-embedded** twisted profile, which is all helical supports: `helicalgear.py`'s
+`loftTooth` finds both loft sections with a fixed `nurbs=2, arcs=2, lines=2` (6-curve) count and never
+reads `ctx.toothProfileIsEmbedded`, so an embedded low-tooth-count helical gear is unsupported by the
+implementation. The bench matches that and skips embedded sizes. Herringbone reuses this exact twisted
+profile (same tooth at the helix angle); its extra work — mirror + combine — is a solid-body
+operation, not a sketch, so it needs no separate proof.

--- a/spec/helicalgear/sketch/go.mod
+++ b/spec/helicalgear/sketch/go.mod
@@ -1,0 +1,5 @@
+module helicalgearsketch
+
+go 1.24
+
+require github.com/lestrrat-3d/sketch v0.0.0

--- a/spec/helicalgear/sketch/main.go
+++ b/spec/helicalgear/sketch/main.go
@@ -1,0 +1,220 @@
+// Sketch-first proof for the helical gear's TWISTED Gear Profile — the second
+// (top) loft profile that helical draws with the spur tooth generator at
+// angle=helixAngle. It reproduces the SPUR-F constraint scheme (from
+// spec/spurgear/fusion.md) with the [SPUR-F-SPINE] *angle != 0* path — the
+// horizontal reference line + far-end pin + angular dimension — which the spur
+// bench (angle == 0) never exercised, and proves it FULLY CONSTRAINS (DOF==0, no
+// redundant/conflicting constraints, well-conditioned) BEFORE any Fusion code is
+// generated ([PB-SKETCH-FIRST]). It runs across sizes AND helix angles.
+//
+//	go run .
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/lestrrat-3d/sketch"
+)
+
+// calculateInvolutePoint mirrors the spec's exact math. ok=false when
+// intersectionRadius < baseRadius (sample inside the base circle — dropped).
+func calculateInvolutePoint(baseRadius, intersectionRadius float64) (x, y float64, ok bool) {
+	if intersectionRadius < baseRadius {
+		return 0, 0, false
+	}
+	alpha := math.Acos(baseRadius / intersectionRadius)
+	t := math.Tan(alpha)
+	x = baseRadius * (math.Cos(t) + t*math.Sin(t))
+	y = baseRadius * (math.Sin(t) - t*math.Cos(t))
+	return x, y, true
+}
+
+func rot(x, y, a float64) (float64, float64) {
+	return x*math.Cos(a) - y*math.Sin(a), x*math.Sin(a) + y*math.Cos(a)
+}
+
+type pt struct{ x, y float64 }
+
+func dist(a, b pt) float64 { return math.Hypot(a.x-b.x, a.y-b.y) }
+
+// checkTwistedProfile builds the helical twisted Gear Profile sketch (the tooth
+// drawn at `helixAngle`) and returns whether it PASSES the primary
+// full-constraint gate. helixAngle is in radians; helixAngle==0 reduces to the
+// spur (untwisted) profile.
+func checkTwistedProfile(module, toothNumber, pressureAng, helixAngle float64, involSteps int) bool {
+	angle := helixAngle // the whole tooth is drawn pre-rotated by this (spur step 4)
+	pitchR := module * toothNumber / 2
+	baseR := pitchR * math.Cos(pressureAng)
+	rootR := (module*toothNumber - 2.5*module) / 2
+	tipR := (module*toothNumber + 2*module) / 2
+	embedded := baseR < rootR
+	fmt.Printf("\n=== M=%.2f N=%.0f PA=%.1f° helix=%.1f°  base=%.3f root=%.3f tip=%.3f embedded=%v ===\n",
+		module, toothNumber, pressureAng*180/math.Pi, helixAngle*180/math.Pi, baseR, rootR, tipR, embedded)
+	if embedded {
+		fmt.Println("(embedded 4-curve variant not modelled — helical requires non-embedded; see README)")
+		return true
+	}
+
+	// sample the involute flank, mirror across +X, rotate the pitch crossing to
+	// +pi/(2N), then apply the requested `angle` (the helix twist).
+	var mirrored []pt
+	for i := 0; i < involSteps; i++ {
+		r := baseR + (tipR-baseR)*float64(i)/float64(involSteps-1)
+		x, y, ok := calculateInvolutePoint(baseR, r)
+		if !ok {
+			continue
+		}
+		mirrored = append(mirrored, pt{x, -y})
+	}
+	px, py, _ := calculateInvolutePoint(baseR, pitchR)
+	rotateAngle := math.Pi/(2*toothNumber) - math.Atan2(-py, px)
+	var left, right []pt
+	for _, p := range mirrored {
+		lx, ly := rot(p.x, p.y, rotateAngle)
+		lx, ly = rot(lx, ly, angle)
+		left = append(left, pt{lx, ly})
+		right = append(right, pt{lx, -ly})
+	}
+
+	w := sketch.NewWorld()
+	s, _ := w.CreateSketch(w.XY())
+
+	origin := s.CreatePoint(0, 0)
+	origin.MoveTo(0, 0)
+	s.Fix(origin) // anchor coincidence (spec step 5)
+
+	mkCircle := func(r float64) *sketch.Circle {
+		c := s.CreateCircle(origin, r)
+		c.SetConstruction(true)
+		s.AddConstraint(sketch.NewDiameter(c, 2*r))
+		return c
+	}
+	rootCircle := mkCircle(rootR)
+	tipCircle := mkCircle(tipR)
+	mkCircle(baseR)
+	mkCircle(pitchR)
+
+	leftPts := make([]*sketch.Point, len(left))
+	rightPts := make([]*sketch.Point, len(right))
+	for i := range left {
+		leftPts[i] = s.CreatePoint(left[i].x, left[i].y)
+		rightPts[i] = s.CreatePoint(right[i].x, right[i].y)
+	}
+	if _, err := s.CreateSpline(leftPts...); err != nil {
+		fmt.Println("left spline:", err)
+		return false
+	}
+	if _, err := s.CreateSpline(rightPts...); err != nil {
+		fmt.Println("right spline:", err)
+		return false
+	}
+
+	// spine: origin -> tooth-top (pre-rotated to `angle`). [SPUR-F-SPINE].
+	ttx, tty := rot(tipR, 0, angle)
+	toothTop := s.CreatePoint(ttx, tty)
+	s.AddConstraint(sketch.NewPointOnCircle(toothTop, tipCircle))
+	spine := s.CreateLine(origin, toothTop)
+	spine.SetConstruction(true)
+	if angle == 0 {
+		// angle==0 (spur) path: the spine's only extra constraint is horizontal.
+		s.AddConstraint(sketch.NewHorizontal(spine))
+	} else {
+		// angle!=0 (helical/herringbone/bevel) path: a +X horizontal REFERENCE line
+		// whose far end is PINNED on the tip circle (else its length floats and the
+		// sketch is under-constrained — the [SPUR-F-SPINE] end-pin), then an angular
+		// dimension from the reference to the spine fixes the twist.
+		refEnd := s.CreatePoint(tipR, 0)
+		refLine := s.CreateLine(origin, refEnd)
+		refLine.SetConstruction(true)
+		s.AddConstraint(sketch.NewHorizontal(refLine))
+		s.AddConstraint(sketch.NewPointOnCircle(refEnd, tipCircle)) // the end-pin
+		// CCW from the +X reference to the spine == helixAngle (NewAngle is in degrees).
+		s.AddConstraint(sketch.NewAngle(refLine, spine, helixAngle*180/math.Pi))
+	}
+
+	// tooth-top arc (free center + diameter dim, faithful to Fusion's 3-point arc).
+	topArc := s.CreateArc(s.CreatePoint(rot(0, tipR*0.1, angle)), rightPts[len(rightPts)-1], leftPts[len(leftPts)-1])
+	s.AddConstraint(sketch.NewDiameter(topArc, 2*tipR)) // [SPUR-F-TOOTHTOP-ARC]
+
+	// ribs: lock each flank pair to the spine. Exact [SPUR-F-RIBS] order.
+	prevMid := origin
+	prevMidPt := pt{0, 0}
+	for i := range left {
+		rib := s.CreateLine(leftPts[i], rightPts[i])
+		rib.SetConstruction(true)
+		s.AddConstraint(sketch.NewDistance(leftPts[i], rightPts[i], dist(left[i], right[i])))
+		t := left[i].x*math.Cos(angle) + left[i].y*math.Sin(angle) // foot on the spine
+		mx, my := t*math.Cos(angle), t*math.Sin(angle)
+		mid := s.CreatePoint(mx, my)
+		s.AddConstraint(sketch.NewPointOnLine(mid, spine))
+		s.AddConstraint(sketch.NewMidpoint(mid, rib))
+		s.AddConstraint(sketch.NewPerpendicular(spine, rib))
+		s.AddConstraint(sketch.NewDistance(prevMid, mid, dist(prevMidPt, pt{mx, my})))
+		prevMid, prevMidPt = mid, pt{mx, my}
+	}
+
+	// flank-to-root lines ([SPUR-F-FLANK-ROOT], non-embedded).
+	addFlankRoot := func(flankStart *sketch.Point, seed pt) *sketch.Point {
+		n := math.Hypot(seed.x, seed.y)
+		re := s.CreatePoint(rootR*seed.x/n, rootR*seed.y/n)
+		line := s.CreateLine(re, flankStart)
+		s.AddConstraint(sketch.NewPointOnCircle(re, rootCircle))
+		s.AddConstraint(sketch.NewPointOnLine(origin, line))
+		return re
+	}
+	leftFoot := addFlankRoot(leftPts[0], left[0])
+	rightFoot := addFlankRoot(rightPts[0], right[0])
+
+	// explicit root arc completing the 6-curve loop.
+	rootArc := s.CreateArc(s.CreatePoint(rot(0, -rootR*0.1, angle)), rightFoot, leftFoot)
+	s.AddConstraint(sketch.NewDiameter(rootArc, 2*rootR))
+
+	res, err := s.Solve()
+	if err != nil {
+		fmt.Println("solve error:", err)
+	}
+	rep := s.Verify(sketch.WithProbe())
+	fmt.Printf("Solve: converged=%v DOF=%d redundant=%d residual=%.1e | Verify: status=%s conditioning=%.2e\n",
+		res.Converged, res.DOF, res.Redundant, res.Residual, rep.Status, rep.Conditioning)
+
+	condGate := math.Max(1e-6, 4*math.Sqrt(1e-10))
+	primary := rep.Status == sketch.FullyConstrained && rep.Conditioning >= condGate
+	fmt.Printf("  PRIMARY GATE (full constraint) = %v\n", primary)
+	fmt.Printf("  advisory: profilesValid=%v (true with the engine's #12 corner-join fix) probeAmbiguous=%v (expected — seeded)\n",
+		rep.ProfilesValid, rep.Probe != nil && rep.Probe.Ambiguous())
+	return primary
+}
+
+func main() {
+	const pa = 20.0 * math.Pi / 180.0
+	deg := func(d float64) float64 { return d * math.Pi / 180.0 }
+
+	allPass := true
+	check := func(m, n, helix float64) {
+		if !checkTwistedProfile(m, n, pa, helix, 15) {
+			allPass = false
+		}
+	}
+
+	// The helical default helix angle (14.5°) across non-embedded sizes, to show
+	// the angle!=0 twisted profile fully constrains parametrically.
+	for _, c := range []struct{ m, n float64 }{{1, 12}, {1, 17}, {2, 20}, {3, 15}} {
+		check(c.m, c.n, deg(14.5))
+	}
+	// A sweep of helix angles at N=17 to show the angle!=0 path is robust to the
+	// twist magnitude; plus angle==0 as the spur-equivalent sanity baseline.
+	for _, h := range []float64{0, 10, 25, 35} {
+		check(1, 17, deg(h))
+	}
+
+	fmt.Println()
+	if allPass {
+		fmt.Println("ALL PASS — the helical twisted Gear Profile fully constrains across sizes and helix angles.")
+		fmt.Println("Cleared to generate Fusion add-in code.")
+	} else {
+		fmt.Println("FAIL — scheme does not fully constrain; fix the scheme before generating Fusion code.")
+		os.Exit(1)
+	}
+}

--- a/spec/helicalgear/sketch/run.sh
+++ b/spec/helicalgear/sketch/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run the spur Gear Profile sketch-first proof (main.go) against a local checkout
+# of github.com/lestrrat-3d/sketch, without committing a machine-specific replace
+# path. The sketch engine is source-available (not go-gettable from the public
+# proxy), so it must be resolved from a local checkout.
+#
+# Resolution order for the sketch repo:
+#   1. $SKETCH_DIR if set;
+#   2. otherwise a sibling checkout of the MAIN gear repo: <repo>/../sketch,
+#      located via `git --git-common-dir` so it works from a worktree too.
+#
+# The replace is injected through a throwaway GOWORK file, so the committed
+# go.mod stays portable.
+set -euo pipefail
+
+here=$(cd "$(dirname "$0")" && pwd)
+
+if [[ -n "${SKETCH_DIR:-}" ]]; then
+  sketch_dir=$SKETCH_DIR
+else
+  common=$(cd "$here" && git rev-parse --git-common-dir)
+  main_repo=$(cd "$(dirname "$common")" && pwd)
+  sketch_dir="$(cd "$main_repo/.." && pwd)/sketch"
+fi
+
+if [[ ! -f "$sketch_dir/go.mod" ]]; then
+  echo "sketch repo not found at: $sketch_dir" >&2
+  echo "set SKETCH_DIR=/path/to/lestrrat-3d/sketch and re-run" >&2
+  exit 2
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+cat > "$work/go.work" <<WORK
+go 1.24
+
+use $here
+
+replace github.com/lestrrat-3d/sketch => $sketch_dir
+WORK
+
+echo "using sketch engine at: $sketch_dir"
+cd "$here"
+GOWORK="$work/go.work" go run .

--- a/spec/herringbonegear/fusion.md
+++ b/spec/herringbonegear/fusion.md
@@ -1,0 +1,46 @@
+# Herringbone Gear — Fusion realization notes
+
+Herringbone's only Fusion-specific delta over helical is its `buildTooth`: loft one half, then mirror
+and combine into a single tooth body before the pattern. Everything else is helical's
+(`[HELI-F-…]`) / spur's (`[SPUR-F-…]`).
+
+## Mirror + combine the lofted half
+
+- **[HERR-F-MIRROR-COMBINE] `buildTooth(ctx)` — loft half, mirror across the mid-plane, combine, then
+  chamfer.** With `helicalPlaneOffset()` overridden to `Thickness/2`, the inherited `buildSketches`
+  has placed `ctx.helixPlane` at mid-body and `loftTooth` builds the bottom-half tooth into
+  `ctx.toothBody` named `'Tooth Body'`. `buildTooth` then:
+  ```python
+  self.loftTooth(ctx)
+
+  # Mirror the lofted half across the mid-body helix plane to form the other half.
+  entities = adsk.core.ObjectCollection.create()
+  entities.add(ctx.toothBody)
+  mirrorInput = self.getComponent().features.mirrorFeatures.createInput(entities, ctx.helixPlane)
+  mirrorResult = self.getComponent().features.mirrorFeatures.add(mirrorInput)
+  mirrorResult.bodies.item(0).name = 'Tooth Body (Mirrored)'
+
+  # Combine the mirrored half into the original so the pattern/combine steps in the
+  # inherited spur pipeline operate on a single body.
+  entities = adsk.core.ObjectCollection.create()
+  entities.add(mirrorResult.bodies.item(0))
+  combineInput = self.getComponent().features.combineFeatures.createInput(
+      self.getComponent().bRepBodies.itemByName('Tooth Body'),
+      entities,
+  )
+  self.getComponent().features.combineFeatures.add(combineInput)
+
+  self.chamferTooth(ctx)
+  ```
+  Key points, exactly as the current code does them:
+  - The mirror **target plane is `ctx.helixPlane`** (the mid-body plane), not a fresh plane.
+  - The mirrored body is renamed `'Tooth Body (Mirrored)'`; the combine's **target is looked up by
+    name** — `self.getComponent().bRepBodies.itemByName('Tooth Body')` — and the mirrored half is the
+    tool. After the combine there is a single `'Tooth Body'` spanning the full thickness, which the
+    inherited `patternTeeth` then circular-patterns and joins into the gear body.
+  - **`chamferTooth(ctx)` is still the last action** (spur's `buildTooth` boundary). Herringbone
+    inherits helical's `chamferWantEdges()` of 4 — see `[HELI-F-CHAMFER-COUNT]` for the same flagged
+    caveat (chamfer is fragile for the default non-embedded tooth; effectively exercised only at
+    chamfer 0).
+  - The gear **body** is still extruded across the **full** thickness by the inherited `buildBody`;
+    only the tooth is built half-then-mirrored.

--- a/spec/herringbonegear/instructions.md
+++ b/spec/herringbonegear/instructions.md
@@ -1,0 +1,89 @@
+# Herringbone Gear Creation Instructions
+
+Herringbone is a **thin specialization of the helical gear** — a double-helical (chevron) tooth. It
+**subclasses `HelicalGearGenerator`** and reuses everything helical does, changing exactly two things:
+it puts the twisted-profile plane at **mid-body** (half thickness) instead of the far face, and its
+`buildTooth` **lofts one half, then mirrors and combines** to form the symmetric chevron.
+
+**Read `spec/helicalgear/instructions.md` (and, through it, `spec/spurgear/`) first.** This spec states
+only herringbone's deltas over helical and cites those specs by anchor/section. Herringbone adds **no
+new dialog input and no new user parameter** — its dialog and parameters are exactly helical's (Helix
+Angle and all inherited spur parameters). The tooth profile is helical's twisted profile at the same
+`angle=helixAngle`, already proven fully-constrained in `spec/helicalgear/sketch/`; herringbone's only
+extra work — a mirror and a combine — is a **solid-body** operation, not a sketch, so it needs no
+separate sketch-first proof.
+
+## Component Setup / Variables
+
+Identical to helical (inherited). Same inputs (including Helix Angle, default 14.5°), same derived
+parameters, same input ids and parameter names. No additions.
+
+## Architecture
+
+Three classes extending their helical counterparts (names are the reproduced surface;
+`commands/herringbonegear/entry.py` binds two by name):
+
+1. **`HerringboneGearCommandConfigurator(HelicalGearCommandConfigurator)`** — trivial `pass`
+   subclass (herringbone's dialog is helical's).
+2. **`HerringboneGearGenerationContext(HelicalGearGenerationContext)`** — trivial `pass` subclass
+   (same context fields; `ctx.helixPlane` is now the mid-body mirror plane).
+3. **`HerringboneGearGenerator(HelicalGearGenerator)`** — overrides the methods in Method contract.
+
+Imports (explicit, no `import *`): from `.base` — `GenerationContext`; from `.spurgear` —
+`PARAM_MODULE, PARAM_TOOTH_NUMBER, PARAM_THICKNESS`; from `.helicalgear` — `PARAM_HELIX_ANGLE,
+HelicalGearCommandConfigurator, HelicalGearGenerationContext, HelicalGearGenerator`; plus `adsk.core`,
+`adsk.fusion`.
+
+## Generation Context
+
+Helical's context unchanged (`HerringboneGearGenerationContext` is a `pass` subclass). `ctx.helixPlane`
+is repurposed as the **mid-body mirror plane** (a consequence of the `helicalPlaneOffset` override
+below); `ctx.twistedGearProfileSketch` is the (half-height) top loft section.
+
+## Method contract — overrides only (helical's/spur's call graph is inherited)
+
+Herringbone keeps the full inherited call graph (`spec/helicalgear/instructions.md` +
+`spec/spurgear/instructions.md`). It overrides exactly:
+
+- **`newContext()`** → `HerringboneGearGenerationContext()`.
+- **`prefixBase()`** → `'HerringboneGear'`.
+- **`generateName()`** → `'Herringbone Gear (M={}, Tooth={}, Thickness={}, Angle={})'.format(module.expression, toothNumber.expression, thickness.expression, helixAngle.expression)`
+  — the four parameters' `.expression` strings (helical's form with the herringbone label).
+- **`helicalPlaneOffset(self)`** → **half** the thickness, as a fresh `ValueInput`:
+  ```python
+  thickness = self.getParameter(PARAM_THICKNESS).value
+  return adsk.core.ValueInput.createByReal(thickness / 2)
+  ```
+  (Helical returned the full thickness.) This places `ctx.helixPlane` at mid-body so the loft spans the
+  bottom half and the mirror completes the top half. Note the value is a **raw computed offset**
+  (`createByReal(thickness/2)`), not a parameter reference.
+- **`buildTooth(self, ctx)`** → loft one half, mirror it across `ctx.helixPlane`, combine, then chamfer
+  (`[HERR-F-MIRROR-COMBINE]`).
+
+**Inherited unchanged — do NOT re-implement:** `addExtraPrimaryParameters`, `chamferWantEdges` (→4),
+`filletHelixFactorExpression`, `buildSketches` (draws the twisted profile using the overridden
+half-thickness `helicalPlaneOffset`), `loftTooth`, and the entire spur pipeline
+(`prepareTools`/`buildBody`/`patternTeeth`/`createFillets`/`buildBore`/`cleanup`) and tooth generator.
+
+## Generation Order — helical's, with one delta
+
+Cite `spec/helicalgear/instructions.md` Generation Order. The `buildSketches` twisted-profile step is
+unchanged in code but its plane now lands at **half thickness** (via the overridden
+`helicalPlaneOffset`). The only code delta is **`buildTooth`**: instead of helical's `loftTooth` +
+`chamferTooth`, herringbone does loft → mirror → combine → chamfer (`[HERR-F-MIRROR-COMBINE]`). Body
+extrude, pattern+combine, fillets, bore, and cleanup remain spur's, unchanged. (The gear body is still
+extruded across the **full** thickness by the inherited `buildBody`; only the lofted tooth is built
+half-then-mirrored.)
+
+## Dependencies
+
+Herringbone **subclasses `HelicalGearGenerator`, `HelicalGearCommandConfigurator`, and
+`HelicalGearGenerationContext`** (from `.helicalgear`), and transitively depends on spur. Generation
+reads `spec/helicalgear/instructions.md` + `spec/helicalgear/fusion.md`, `spec/spurgear/*`, and the
+current `lib/geargen/helicalgear.py` surface. Borrowed surface that must exist unchanged:
+
+- **`HelicalGearGenerator`** and its overridable methods — `loftTooth(ctx)` (called first in
+  `buildTooth`), `helicalPlaneOffset()` (overridden here), `chamferTooth(ctx)` (called last),
+  `buildSketches` (inherited; consumes the overridden offset), and `PARAM_HELIX_ANGLE`.
+- **Context fields** `ctx.helixPlane` and `ctx.toothBody` (produced by `loftTooth`).
+- **Inherited framework helpers** `getComponent()`, `getParameter(name)`.

--- a/spec/spurgear/instructions.md
+++ b/spec/spurgear/instructions.md
@@ -112,6 +112,15 @@ real-valued user parameter (1 = true, 0 = false), since the framework only reads
 parameters as booleans (`getParameterAsBoolean`). The derived parameters in the list above
 (Pitch/Base/Root/Tip circles, InvoluteSteps, ToothSpace…, Fillet…) keep exactly those names.
 
+**[SPUR-SUBCLASS-INPUT] Configurator extension seam (for subclasses).** `configure()` is a
+`@classmethod` on `SpurGearCommandInputsConfigurator`. A subclass gear (helical/herringbone) adds its
+own extra dialog input by **subclassing the configurator and appending after `super().configure(cmd)`**
+— e.g. `HelicalGearCommandConfigurator.configure` calls `super().configure(cmd)` then
+`cmd.commandInputs.addValueInput(...)` for its Helix Angle. Because `super().configure()` already
+added Parent Component **last**, a subclass's extra input necessarily lands **after** Parent Component
+in the dialog. (This is the actual behavior; the "Parent Component last" rule above is a spur-base
+statement that a subclass's appended inputs sit below.)
+
 ## Sketch Discipline
 
 A few rules apply across every sketch created below. They're not obvious from the step list, and
@@ -210,6 +219,14 @@ Specific boundaries subclasses depend on (do not move the work elsewhere):
   separately.
 - **`chamferTooth` / `createFillets`** read `chamferWantEdges()` and the fillet helix factor
   (`filletHelixFactorExpression()`); these hooks must exist on the generator.
+- **[SPUR-EXTRA-PARAMS] `addExtraPrimaryParameters(self, inputs)`** is an overridable hook, a **no-op
+  on the spur base**, that `processInputs` calls **between** registering the input-sourced parameters
+  and the derived ones. Subclasses override it to register their own primary user parameters from the
+  extra dialog inputs they added (e.g. helical registers `HelixAngle` from the `helixAngle` input).
+  It must exist (as a no-op) on the spur base so the call site in `processInputs` is present for
+  subclasses to hook. Together with `[SPUR-SUBCLASS-INPUT]`, these are the two seams by which a
+  subclass adds a parameter: the configurator adds the dialog *input*, this hook registers the
+  *parameter*.
 - **`generateName()`** returns the component name. For the spur base it is
   `'Spur Gear (M={}, Tooth={}, Thickness={})'.format(module.expression, toothNumber.expression, thickness.expression)`
   — i.e. the `Module`, `ToothNumber`, and `Thickness` parameters' **`.expression`** strings (not


### PR DESCRIPTION
Brings helical and herringbone up to par with spur/bevel/cycloidal — generated from a spec instead of hand-coded.

- add `spec/helicalgear/` (instructions + fusion + a sketch-first bench proving the twisted profile's `[SPUR-F-SPINE]` angle≠0 path fully constrains across sizes and helix angles) and `spec/herringbonegear/` (delta over helical)
- pin the two spur subclass-extension hooks the helical spec exposes (`[SPUR-EXTRA-PARAMS]`, `[SPUR-SUBCLASS-INPUT]`)
- regenerate `lib/geargen/helicalgear.py` + `herringbonegear.py` reference-free (0 BLOCKING, identical class/method surface, validated in Fusion); keeps the spur inheritance (helical is a true specialization)

Faithful-but-flagged behaviors preserved as-is (not fixed): `chamferWantEdges==4` (fragile for the non-embedded tooth), helix-angle input last in the dialog, embedded low-tooth-count helical unsupported.

Stacked on #18 (base `feat-sketch-first-gate`); retarget to `main` once #18 merges.
