### PR TITLE
add mechanical anchor and contract gates

### DIFF
--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -106,15 +106,30 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
    - **Contract self-check:** every class name, hook method, tooth/profile-generator entry point,
      `ctx` field, Fusion user-parameter name, and dialog input id the spec's Contract sections
      declare is present in the generated file. If the spec declares dependent gears, confirm the
-     surface those dependents bind to (by name) exists unchanged.
+     surface those dependents bind to (by name) exists unchanged. Where the gear carries a
+     machine-readable manifest `spec/<gear>/contract.json`, run
+     `python3 .claude/skills/generate-gear/check_contract.py spec/<gear>/contract.json
+     .tmp/<gear>.generated.py` — it mechanically gates (exit 1 = BLOCKING) the manifest's classes,
+     bases, pinned methods, `ctx` fields, and module-level constants (the Python identifiers
+     dependents import AND their exact string values — the breakage class no other gate sees). The
+     spec **prose** stays authoritative; the manifest mirrors its Contract sections, and a
+     spec/manifest mismatch is a spec bug — fix both together. Prose-check whatever the manifest
+     doesn't carry. (`spec/spurgear/contract.json` is the worked example; gears without a manifest
+     get the full prose check.)
+   - **Anchor check:** run `python3 .claude/skills/generate-gear/check_anchors.py` (repo root).
+     Every `[PB-…]`/`[<GEAR>-F-…]` anchor cited anywhere in `spec/` or the playbook must resolve to
+     a defined anchor, defined in exactly one file, with no truncated cites. Exit 1 gates: an
+     unresolved cite silently unbinds the rule at that point of use.
    - **Dependency resolution:** every name the generated file imports from another gear or
-     framework module actually exists in that module.
+     framework module actually exists in that module. (`check_contract.py` verifies this
+     mechanically for `lib/geargen/` imports, plus the no-`import *` module-layout rule.)
    - **Helper-shadowing check:** the generated file must not re-define (via `def` or `class`) any
      name the framework helper library provides (PLAYBOOK "Shared geargen helper library":
      `find_profile_by_curve_counts`, `find_circle_by_radius`, the `solids.*` functions,
      `VirtualSpurProxy`/`Val`), nor carry a private re-implementation of one. A shadow or
      re-implementation means the spec/playbook failed to direct the generator to the helper — fix
-     there and regenerate.
+     there and regenerate. (`check_contract.py` catches the literal re-definition case
+     mechanically; private re-implementations under a different name still need the prose check.)
    - **Input-read consistency check:** run
      `python3 .claude/skills/generate-gear/check_input_read.py .tmp/<gear>.generated.py`. It pairs
      each `add*Input(id, …)` declaration in `configure()` with the `get_*(inputs, id, …)` read by

--- a/.claude/skills/generate-gear/check_anchors.py
+++ b/.claude/skills/generate-gear/check_anchors.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Anchor-citation linter for the spec/playbook rule-anchor convention.
+
+The playbook and the per-gear spec sidecars declare rules under stable IDs
+(`[PB-…]`, `[SPUR-F-…]`, `[CYCLOIDAL-F-…]`, …); specs cite an ID instead of
+restating the rule. A citation that resolves to nothing — a typo, a renamed
+anchor, or a truncated cite like "([SPUR-F parity)" — silently unbinds the
+rule at that point of use, and no other gate notices. This script makes the
+link mechanical:
+
+  * every cited ID must have a definition somewhere in the scanned set
+    (definition = the ID at the start of a bold span `**[ID]…`, or anywhere
+    on a markdown heading line);
+  * an ID must not be *defined* in more than one file (drift);
+  * no malformed/truncated anchor-like cites (`[ABC-DEF` with no closing
+    bracket).
+
+Cross-directory citations (one gear citing another gear's `*-F-*` anchor) are
+listed as information only — legitimate for declared dependencies, worth
+eyeballing otherwise.
+
+Usage:  python3 check_anchors.py [repo-root]
+Scans <root>/.claude/skills/generate-gear/*.md and <root>/spec/**/*.md.
+Exit 0 = clean; exit 1 = at least one unresolved / multiply-defined /
+malformed anchor.
+"""
+import glob
+import os
+import re
+import sys
+
+ANCHOR = r"[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+"
+CITE_RE = re.compile(r"\[(%s)\]" % ANCHOR)
+BOLD_DEF_RE = re.compile(r"\*\*\[(%s)\]" % ANCHOR)
+# an anchor-looking token whose bracket never closes: "[SPUR-F parity" etc.
+# The ellipsis forms "[PB-…]" / "[SPUR-F…]" are legitimate family-placeholder
+# prose (a reference to the whole anchor family), not truncation — allow them.
+MALFORMED_RE = re.compile(r"\[(%s)(?![\]A-Z0-9…-])" % ANCHOR)
+
+
+def scan_files(root):
+    paths = sorted(
+        glob.glob(os.path.join(root, ".claude/skills/generate-gear/*.md"))
+        + glob.glob(os.path.join(root, "spec/**/*.md"), recursive=True)
+    )
+    return [p for p in paths if os.path.isfile(p)]
+
+
+def main(root):
+    defs = {}       # id -> set of defining files
+    cites = {}      # id -> list of (file, lineno)
+    malformed = []  # (file, lineno, token)
+
+    files = scan_files(root)
+    if not files:
+        print("anchor check: no .md files found under %s" % root, file=sys.stderr)
+        return 2
+
+    for path in files:
+        rel = os.path.relpath(path, root)
+        with open(path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, 1):
+                for m in CITE_RE.finditer(line):
+                    cites.setdefault(m.group(1), []).append((rel, lineno))
+                is_heading = line.lstrip().startswith("#")
+                for m in BOLD_DEF_RE.finditer(line):
+                    defs.setdefault(m.group(1), set()).add(rel)
+                if is_heading:
+                    for m in CITE_RE.finditer(line):
+                        defs.setdefault(m.group(1), set()).add(rel)
+                for m in MALFORMED_RE.finditer(line):
+                    # ignore tokens that are also a well-formed cite on the
+                    # same position (CITE_RE requires the closing bracket the
+                    # malformed pattern forbids, so no overlap in practice)
+                    malformed.append((rel, lineno, m.group(1)))
+
+    problems = []
+    for aid, sites in sorted(cites.items()):
+        if aid not in defs:
+            where = ", ".join("%s:%d" % s for s in sites[:5])
+            problems.append("  [%s] cited but defined nowhere (%s)" % (aid, where))
+    for aid, dfiles in sorted(defs.items()):
+        if len(dfiles) > 1:
+            problems.append(
+                "  [%s] defined in %d files: %s" % (aid, len(dfiles), ", ".join(sorted(dfiles))))
+    for rel, lineno, token in malformed:
+        problems.append("  %s:%d: malformed/truncated anchor cite '[%s'" % (rel, lineno, token))
+
+    # informational: cross-directory citations of per-gear (*-F-*) anchors
+    cross = []
+    for aid, sites in sorted(cites.items()):
+        dfiles = defs.get(aid, set())
+        gear_dirs = {os.path.dirname(f) for f in dfiles if f.startswith("spec" + os.sep)}
+        if not gear_dirs:
+            continue
+        for rel, lineno in sites:
+            if rel.startswith("spec" + os.sep) and os.path.dirname(rel) not in gear_dirs:
+                cross.append("  [%s] cited from %s:%d, defined in %s" % (
+                    aid, rel, lineno, ", ".join(sorted(gear_dirs))))
+
+    if problems:
+        print("anchor check: %d problem(s):" % len(problems))
+        for p in problems:
+            print(p)
+        if cross:
+            print("cross-directory citations (informational):")
+            for c in cross:
+                print(c)
+        return 1
+
+    print("anchor check: OK (%d anchors defined, %d cited, %d files)"
+          % (len(defs), len(cites), len(files)))
+    if cross:
+        print("cross-directory citations (informational — fine for declared dependencies):")
+        for c in cross:
+            print(c)
+    return 0
+
+
+if __name__ == "__main__":
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    sys.exit(main(root))

--- a/.claude/skills/generate-gear/check_contract.py
+++ b/.claude/skills/generate-gear/check_contract.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Mechanical contract check for a generated gear module.
+
+The generate-gear skill's validation step requires a "contract self-check":
+every class, hook method, ctx field, module constant, input id, and parameter
+string the spec's Contract sections declare must exist in the generated file.
+Until now that check was prose-matching by an agent — which is exactly how a
+renamed `PARAM_*` export (imported by a dependent gear) can slip through every
+other gate. This script makes it mechanical against a machine-readable
+manifest `spec/<gear>/contract.json` that mirrors the spec's contract
+sections. The spec PROSE stays authoritative: a manifest/spec mismatch is a
+spec bug — fix both together.
+
+Manifest shape (all sections optional):
+  {
+    "module": "lib/geargen/spurgear.py",
+    "module_constants": {"PARAM_MODULE": "Module", ...},   // name -> exact string value
+    "classes": {
+      "SpurGearGenerator": {
+        "bases": ["Generator"],          // base names, matched by unqualified name
+        "methods": ["generate", ...],    // must be defined in the class body
+        "ctx_fields": ["plane", ...]     // self.<field> assigned in __init__
+      }, ...
+    }
+  }
+
+Also checked, manifest-free (they need only the repo):
+  * helper shadowing — the generated module must not re-define (def/class) a
+    name provided by the framework helper library (top-level names of
+    lib/geargen/{utilities,solids,spurproxy}.py);
+  * import resolution — every `from .mod import name` against lib/geargen/
+    must name something that exists top-level in that module;
+  * no `import *` in a gear module (playbook module-layout rule).
+
+Usage:  python3 check_contract.py <contract.json> <generated.py> [repo-root]
+Exit 0 = clean; exit 1 = at least one BLOCKING contract violation.
+"""
+import ast
+import json
+import os
+import sys
+
+HELPER_MODULES = ("utilities", "solids", "spurproxy")
+
+
+def _top_level_names(tree):
+    names = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    names.add(t.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def _base_name(node):
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ast.unparse(node)
+
+
+def _ctx_fields(classnode):
+    fields = []
+    for node in classnode.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__":
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Assign):
+                    for t in sub.targets:
+                        if isinstance(t, ast.Attribute) and \
+                                isinstance(t.value, ast.Name) and t.value.id == "self":
+                            fields.append(t.attr)
+    return fields
+
+
+def main(manifest_path, gen_path, root="."):
+    manifest = json.load(open(manifest_path, encoding="utf-8"))
+    tree = ast.parse(open(gen_path, encoding="utf-8").read())
+    problems = []
+
+    # --- module-level constants: identifier AND exact string value ---
+    consts = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                and isinstance(node.targets[0], ast.Name) \
+                and isinstance(node.value, ast.Constant):
+            consts[node.targets[0].id] = node.value.value
+    for name, want in manifest.get("module_constants", {}).items():
+        if name not in consts:
+            problems.append("  constant %s missing (dependents may import it)" % name)
+        elif consts[name] != want:
+            problems.append("  constant %s = %r, manifest says %r" % (name, consts[name], want))
+
+    # --- classes: existence, bases, methods, ctx fields ---
+    classes = {n.name: n for n in tree.body if isinstance(n, ast.ClassDef)}
+    for cname, decl in manifest.get("classes", {}).items():
+        cls = classes.get(cname)
+        if cls is None:
+            problems.append("  class %s missing" % cname)
+            continue
+        have_bases = [_base_name(b) for b in cls.bases]
+        for base in decl.get("bases", []):
+            if base not in have_bases:
+                problems.append("  class %s: base %s missing (has %s)" % (cname, base, have_bases))
+        have_methods = {m.name for m in cls.body
+                        if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        for meth in decl.get("methods", []):
+            if meth not in have_methods:
+                problems.append("  class %s: method %s missing" % (cname, meth))
+        want_fields = decl.get("ctx_fields", [])
+        if want_fields:
+            have_fields = set(_ctx_fields(cls))
+            for f in want_fields:
+                if f not in have_fields:
+                    problems.append("  class %s: ctx field self.%s not assigned in __init__" % (cname, f))
+
+    # --- helper shadowing (manifest-free) ---
+    helper_names = {}
+    for mod in HELPER_MODULES:
+        path = os.path.join(root, "lib", "geargen", mod + ".py")
+        if os.path.isfile(path):
+            for n in _top_level_names(ast.parse(open(path, encoding="utf-8").read())):
+                if not n.startswith("_"):
+                    helper_names.setdefault(n, mod)
+    own_defs = {n.name: n.lineno for n in tree.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))}
+    for name, lineno in sorted(own_defs.items(), key=lambda kv: kv[1]):
+        if name in helper_names:
+            problems.append(
+                "  L%d: re-defines framework helper %s (lives in lib/geargen/%s.py — call it instead)"
+                % (lineno, name, helper_names[name]))
+
+    # --- import resolution + star-import ban (manifest-free) ---
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            if any(a.name == "*" for a in node.names):
+                problems.append("  L%d: `from %s import *` — gear modules never star-import"
+                                % (node.lineno, node.module or ""))
+                continue
+            if node.level >= 1 and node.module:
+                path = os.path.join(root, "lib", "geargen", node.module.split(".")[0] + ".py")
+                if os.path.isfile(path):
+                    avail = _top_level_names(ast.parse(open(path, encoding="utf-8").read()))
+                    for a in node.names:
+                        if a.name not in avail:
+                            problems.append("  L%d: `from .%s import %s` — name not defined there"
+                                            % (node.lineno, node.module, a.name))
+
+    if problems:
+        print("contract check: %d BLOCKING violation(s) vs %s:"
+              % (len(problems), os.path.relpath(manifest_path, root)))
+        for p in problems:
+            print(p)
+        return 1
+    print("contract check: OK (%d constants, %d classes declared; shadowing/imports clean)"
+          % (len(manifest.get("module_constants", {})), len(manifest.get("classes", {}))))
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (3, 4):
+        print("usage: check_contract.py <contract.json> <generated.py> [repo-root]", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(*sys.argv[1:]))

--- a/spec/spurgear/contract.json
+++ b/spec/spurgear/contract.json
@@ -1,0 +1,95 @@
+{
+  "_comment": "Machine-readable mirror of the spec's contract sections, checked by .claude/skills/generate-gear/check_contract.py. The spec prose (instructions.md/fusion.md) is authoritative — a mismatch between this file and the spec is a spec bug; fix both together. Methods listed are the pinned public/hook surface (underscore-private decomposition stays free). module_constants pins the Python identifiers dependents import (helicalgear/herringbonegear) AND their exact string values.",
+  "module": "lib/geargen/spurgear.py",
+  "module_constants": {
+    "INPUT_ID_PARENT": "parentComponent",
+    "INPUT_ID_PLANE": "plane",
+    "INPUT_ID_ANCHOR_POINT": "anchorPoint",
+    "INPUT_ID_MODULE": "module",
+    "INPUT_ID_TOOTH_NUMBER": "toothNumber",
+    "INPUT_ID_PRESSURE_ANGLE": "pressureAngle",
+    "INPUT_ID_BORE_DIAMETER": "boreDiameter",
+    "INPUT_ID_THICKNESS": "thickness",
+    "INPUT_ID_CHAMFER_TOOTH": "chamferTooth",
+    "INPUT_ID_SKETCH_ONLY": "sketchOnly",
+    "PARAM_MODULE": "Module",
+    "PARAM_TOOTH_NUMBER": "ToothNumber",
+    "PARAM_PRESSURE_ANGLE": "PressureAngle",
+    "PARAM_BORE_DIAMETER": "BoreDiameter",
+    "PARAM_THICKNESS": "Thickness",
+    "PARAM_CHAMFER_TOOTH": "ChamferTooth",
+    "PARAM_SKETCH_ONLY": "SketchOnly",
+    "PARAM_PITCH_DIAMETER": "PitchCircleDiameter",
+    "PARAM_PITCH_RADIUS": "PitchCircleRadius",
+    "PARAM_BASE_DIAMETER": "BaseCircleDiameter",
+    "PARAM_BASE_RADIUS": "BaseCircleRadius",
+    "PARAM_ROOT_DIAMETER": "RootCircleDiameter",
+    "PARAM_ROOT_RADIUS": "RootCircleRadius",
+    "PARAM_TIP_DIAMETER": "TipCircleDiameter",
+    "PARAM_TIP_RADIUS": "TipCircleRadius",
+    "PARAM_INVOLUTE_STEPS": "InvoluteSteps",
+    "PARAM_TOOTH_SPACE_ANGLE": "ToothSpaceAngleAtRoot",
+    "PARAM_TOOTH_SPACE_ARC": "ToothSpaceArcAtRoot",
+    "PARAM_FILLET_CLEARANCE": "FilletClearance",
+    "PARAM_FILLET_RADIUS": "FilletRadius"
+  },
+  "classes": {
+    "SpurGearCommandInputsConfigurator": {
+      "bases": [],
+      "methods": ["configure"]
+    },
+    "SpurGearGenerationContext": {
+      "bases": ["GenerationContext"],
+      "methods": ["__init__"],
+      "ctx_fields": [
+        "plane",
+        "anchorPoint",
+        "extrusionEndPlane",
+        "gearProfileSketch",
+        "toothBody",
+        "gearBody",
+        "centerAxis",
+        "extrusionExtent",
+        "toothProfileIsEmbedded"
+      ]
+    },
+    "SpurGearInvoluteToothDesignGenerator": {
+      "bases": [],
+      "methods": [
+        "__init__",
+        "getParameter",
+        "getParameterValue",
+        "calculateInvolutePoint",
+        "draw",
+        "drawCircles",
+        "drawTooth",
+        "drawBore"
+      ]
+    },
+    "SpurGearGenerator": {
+      "bases": ["Generator"],
+      "methods": [
+        "__init__",
+        "prefixBase",
+        "newContext",
+        "addExtraPrimaryParameters",
+        "chamferWantEdges",
+        "filletHelixFactorExpression",
+        "generateName",
+        "processInputs",
+        "registerDerivedParameters",
+        "generate",
+        "prepareTools",
+        "buildMainGearBody",
+        "buildSketches",
+        "buildTooth",
+        "chamferTooth",
+        "buildBody",
+        "patternTeeth",
+        "createFillets",
+        "buildBore",
+        "cleanup"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- `check_anchors.py`: every cited `[PB-…]`/`[*-F-…]` anchor must resolve; flags truncated cites
- `check_contract.py` + spurgear manifest: gates classes, ctx fields, exported constants, imports
- SKILL validation step runs both; spec prose stays authoritative over the manifest

## Decisions for reviewer

- anchor gate fails on two known defects fixed by the companion spec-review PRs
- manifests for the other four gears are a follow-up after those PRs land
