### PR TITLE
align cycloidal spec docs with deployed code

### DIFF
--- a/spec/cycloidal/epitrochoid-trace.md
+++ b/spec/cycloidal/epitrochoid-trace.md
@@ -1,13 +1,13 @@
-# Cycloidal rotor profile — geometry oracle (minimal: one lobe)
+# Cycloidal rotor profile — geometry oracle
 
 This is the geometry oracle for the cycloidal-rotor generator (cited from `instructions.md`). Reproduce
 the point function and formulas **exactly** — no mechanical gate verifies geometry, so these are the
 asserted facts. The generator works in Fusion-internal **cm**; convert mm inputs with `to_cm`. Profile
 points computed here are **already cm** — add them to sketches as-is (never re-wrap in `to_cm`).
 
-> Scope note: the full archived drive is at `.tmp/cycloidal-spec-full-archive/`. This spec is being grown
-> back incrementally; it currently produces the **rotor disk** (lobe section → extrude → pattern → join)
-> with its **center bore**, the **output holes**, the **ring pins + Housing Ring base**, the **eccentric
+> Scope note: this spec produces the **rotor disk(s)** (lobe section → extrude → pattern → join)
+> with **center bore**, the **output holes**, the **pinless `Housing`** (base annulus + swept-contour
+> ring casing — see "Pinless ring casing"; no discrete ring pins), the **eccentric
 > input cam**, the **output plate + `M` output pins**, edge **chamfers**, and an optional **second disc**
 > (`Disc Count = 2`, 180° opposed — see "Two discs" below). **Output pins** are `M` cylinders (`D_pin =
 > Output Pin Diameter`, resolved) on the

--- a/spec/cycloidal/epitrochoid-trace.md
+++ b/spec/cycloidal/epitrochoid-trace.md
@@ -174,8 +174,8 @@ pattern steps by exactly `2π/N`, so adjacent sectors share a spoke face **only 
 at `±π/N`. Bin **centres** (inset by half a bin) leave a `2π/(N·nbins)` angular **gap** between every pair of
 patterned sectors → the sectors don't touch, the Join can't merge them, and you get `N` disjoint "several
 unnamed bodies" that never combine into one casing (the reported bug). The casing **sector** is the pie wedge
-bounded by the outer arc (`R + Rr + Wall`), the contour spline (`env+c` over the pin-pitch), and two **radial
-spokes** at `φ = ±π/N` (the section ends fall on the mid-gap **peaks**, where the contour is tangential by
+bounded by the outer arc (`R − Rr + 2·E + Wall`, the pinless outer wall = contour peak + `Wall`), the contour
+spline (`env+c` over the pin-pitch), and two **radial spokes** at `φ = ±π/N` (the section ends fall on the mid-gap **peaks**, where the contour is tangential by
 symmetry, so the seamlessly-tiled patterned sectors join into one smooth wall).
 Extrude the sector by the stack height, **circular-pattern ×`N`** about the drive axis, **Join** into one
 `'Ring Casing'`. The `Housing Ring` base stays below it; the discrete pins are gone. (Moderate sweep

--- a/spec/cycloidal/epitrochoid-trace.md
+++ b/spec/cycloidal/epitrochoid-trace.md
@@ -65,7 +65,7 @@ the base trochoid offset by `Rr_eff`, and that offset **self-intersects (undercu
 when `Rr_eff` exceeds the smallest radius of curvature of the base trochoid at the points whose centre of
 curvature lies **toward `O`** (the convex flanks an inward offset can overrun). Below that limit the
 profile is clean; above it the spline self-intersects and Fusion fails. **Reject when `Rr_eff ≥ ρ_min^O`**,
-computed numerically (sample `t` at ~2000 points over `[0, 2π)`):
+computed numerically (sample `t` at exactly **2000** points over `[0, 2π)`):
 
 ```
 bx  =  R·cos t − E·cos(Nt) ;            by  = −R·sin t + E·sin(Nt)        # base trochoid point
@@ -121,11 +121,11 @@ from the root circle + pattern). ⚠️ Do **NOT** sample `t` uniformly: an inte
 **overshoots** ("rabbit-ear" loops) where the lobe turns sharply. The per-step direction change is only
 ~6° for the gentle default but reaches **~25° near the undercut limit** at 60 uniform points — far past
 where the spline overshoots. A uniform sample dense enough to be smooth there needs ~480 points; instead
-sample so consecutive fit points subtend a **bounded turn angle** (≤ ~5°), which stays smooth at **any**
-valid `E` with only ~30–55 points:
-1. Evaluate `disk_point` at fine resolution (e.g. ~2000 `t` over `[0, 2π/L]`).
+sample so consecutive fit points subtend a **bounded turn angle** (threshold exactly **5.0°**), which stays
+smooth at **any** valid `E` with only ~30–55 points:
+1. Evaluate `disk_point` at fine resolution: exactly **2000** uniform steps (2001 points) over `[0, 2π/L]`.
 2. Greedily keep points: keep the first; accumulate the turn angle between consecutive fine points; each
-   time the accumulator reaches the threshold (~5°), keep that point and reset; always keep the last.
+   time the accumulator reaches the threshold (**5.0°**), keep that point and reset; always keep the last.
 3. Build the fitted spline through the kept points.
 This concentrates points on the sharp flanks/tip and thins them on the gentle parts — fewer points than a
 smooth uniform sample, and no overshoot. Valid (non-self-intersecting) for `E < min(Rr, R/N)` and the
@@ -162,13 +162,18 @@ disc rotates by `β(θ) = −θ/L`. Sample the world disc `disk_point(t, E·cos 
 `env(φ)`. The result is **`N`-fold symmetric** (period `2π/N`).
 
 **Build one section, pattern ×`N`** (like the disc's lobe-sector → pattern → join). Compute the contour over
-**one pin-pitch** `φ ∈ [−π/N, π/N]` (a pin centred at `φ = 0`) — bin only that sector while sweeping; ~60–90
-points (dense enough that the fitted spline doesn't overshoot at the pin bump — same risk as the lobe spline).
+**one pin-pitch** `φ ∈ [−π/N, π/N]` (a pin centred at `φ = 0`) — bin only that sector while sweeping;
+**`nbins = 80`** (81 emitted edge points — dense enough that the fitted spline doesn't overshoot at the pin
+bump, same risk as the lobe spline).
 
 ⚠️ **The contour's first and last points MUST land EXACTLY on `φ = −π/N` and `φ = +π/N`** (the pin-pitch
 boundaries), NOT at the centres of the first/last bins. Emit the `nbins+1` points at the bin **EDGES**
 `φ_i = −π/N + (2π/N)·i/nbins` for `i = 0 … nbins` (radius at edge `i` = `c + max(binMax[i−1], binMax[i])`,
-using the single existing neighbour at the two ends), so `φ_0 = −π/N` and `φ_nbins = +π/N` exactly. This is
+using the single existing neighbour at the two ends), so `φ_0 = −π/N` and `φ_nbins = +π/N` exactly.
+**Empty (unhit) bins:** track a per-bin hit flag while sweeping; an edge's radius considers only its **hit**
+neighbour bins, and when **both** neighbours are unhit the max is taken as `0`, so the edge radius falls
+back to `c`. (At the pinned `Nθ = Nt = 240` / `nbins = 80` resolution unhit bins are not expected; the
+guard just keeps a sparse sweep from crashing or emitting garbage radii.) This is
 **load-bearing for the join**: the two radial spokes are placed at the spline endpoints' angles, and the ×`N`
 pattern steps by exactly `2π/N`, so adjacent sectors share a spoke face **only if** the endpoints are exactly
 at `±π/N`. Bin **centres** (inset by half a bin) leave a `2π/(N·nbins)` angular **gap** between every pair of
@@ -178,6 +183,6 @@ bounded by the outer arc (`R − Rr + 2·E + Wall`, the pinless outer wall = con
 spline (`env+c` over the pin-pitch), and two **radial spokes** at `φ = ±π/N` (the section ends fall on the mid-gap **peaks**, where the contour is tangential by
 symmetry, so the seamlessly-tiled patterned sectors join into one smooth wall).
 Extrude the sector by the stack height, **circular-pattern ×`N`** about the drive axis, **Join** into one
-`'Ring Casing'`. The `Housing Ring` base stays below it; the discrete pins are gone. (Moderate sweep
-resolution, e.g. `Nθ = Nt ≈ 240`, keeps generation fast; the disc clears the contour so small sampling error
-is absorbed by `c`.)
+`'Ring Casing'`. The `Housing Ring` base stays below it; the discrete pins are gone. (Sweep resolution
+exactly **`Nθ = Nt = 240`** — moderate, keeps generation fast; the disc clears the contour so small sampling
+error is absorbed by `c`.)

--- a/spec/cycloidal/fusion.md
+++ b/spec/cycloidal/fusion.md
@@ -1,17 +1,16 @@
-# Cycloidal rotor — Fusion-API realization (minimal: one lobe)
+# Cycloidal drive — Fusion-API realization
 
 The gear-specific *how*: binding Fusion-API recipes cited by anchor from `instructions.md`. Shared
 conventions are in `PLAYBOOK.md` (`[PB-…]`); reuse `lib/geargen/spurgear.py`'s idioms where noted. The
-generator works in internal **cm** — convert mm inputs with `misc.to_cm`. (Full-drive recipes are
-archived at `.tmp/cycloidal-spec-full-archive/fusion.md`; this minimal file covers only the one-lobe
-sketch.)
+generator works in internal **cm** — convert mm inputs with `misc.to_cm`. This file covers the full
+drive: rotor disc(s), pinless housing, eccentric cam, output plate + pins, chamfers, sub-components.
 
 ## [CYCLOIDAL-F-ANCHOR-CHAIN] Anchor projection
 
-Same shape as `[SPUR-F-ANCHOR-CHAIN]`. The sketch projects the user's Anchor
+The same anchor-projection recipe the spur generator uses. The sketch projects the user's Anchor
 (`sketch.project(anchorEntity).item(0)`) and constrains its own **local origin** to the result with
 `geometricConstraints.addCoincident(localOrigin, projected)`. The local origin is a fresh
-`sketchPoints.add(Point3D.create(0,0,0))` (`[SPUR-F-LOCAL-ORIGIN]`), **not** `sketch.originPoint`. All
+`sketchPoints.add(Point3D.create(0,0,0))` (spur's local-origin idiom), **not** `sketch.originPoint`. All
 geometry is drawn relative to that local origin, so anchoring it drags the drawing onto the user's
 Anchor. Keep the sketch visible.
 
@@ -100,16 +99,16 @@ output hole is a **separate** sketch so its profile never shares this one.
 
 ## [CYCLOIDAL-F-DISK-AXIS] Construction axis ⟂ the sketch at the disk centre — from a BODY FACE
 
-The construction axis is **perpendicular to the sketch plane through the Root-circle centre `Od`** (the
-disk's rotation axis, the pattern axis). The generator keeps the Rotor-Lobe sketch's `diskCentre` sketch
-point as `self.lobeDiskCentre`.
+The construction axis is **perpendicular to the sketch plane through the Root-circle centre `Od_d`** (the
+disc's rotation axis, the pattern axis). The generator keeps each Rotor-Lobe sketch's `diskCentre` sketch
+point as `self.lobeDiskCentres[d]`.
 
 ⚠️ **`setByLine` does NOT work — confirmed.** A face-less axis (`setByLine` with an `InfiniteLine3D`)
 raises `RuntimeError: 3 : Environment is not supported` in the parametric design environment, and
 `occurrence.activate()` does **not** fix it (tested — it still raised on `constructionAxes.add`). The axis
 **must be anchored to a BRep face**, so it is created **AFTER the lobe sector is extruded**
 (`[CYCLOIDAL-F-DISK-BODY]` step 1) — never before any body. Do **not** call `activate()`. Recipe
-(`buildDiskAxis(capFace)`, called from `buildDisk` after the extrude):
+(`buildDiskAxis(capFace, d)`, called from `buildDisk(d)` after the extrude):
 1. `capFace` = **a planar cap of the extrude — selected by NORMAL direction**, i.e. a face whose surface
    is `PlaneSurfaceType` **and whose normal is parallel to the sketch-plane normal** (the cap is ⟂ the
    extrude direction). Use **`extrude.startFaces.item(0)`** unconditionally (the cap in the sketch plane;
@@ -125,10 +124,11 @@ raises `RuntimeError: 3 : Environment is not supported` in the parametric design
    evaluate `getParameterAtPoint(Od)` to score faces: `Od` is a degenerate boundary vertex on every
    candidate, so that test is unreliable.
 2. `axInput = component.constructionAxes.createInput()`;
-   `axInput.setByPerpendicularAtPoint(capFace, self.lobeDiskCentre)` — direction = the cap's (vertical)
-   normal, location = the disk-centre point `Od`. (The cap need not *contain* `Od`; the face supplies only
-   the direction.)
-3. `axis = component.constructionAxes.add(axInput)`; `axis.name = 'Disk Axis'`; **`self.diskAxis = axis`**.
+   `axInput.setByPerpendicularAtPoint(capFace, self.lobeDiskCentres[d])` — direction = the cap's (vertical)
+   normal, location = the disc-centre point `Od_d`. (The cap need not *contain* `Od_d`; the face supplies
+   only the direction.)
+3. `axis = component.constructionAxes.add(axInput)`; `axis.name = 'Disk Axis {d+1}'`;
+   **`self.diskAxes[d] = axis`**.
 
 Face-anchored axis methods (`setByPerpendicularAtPoint`, `setByCircularFace`) work on a **non-active**
 component — only the line/point methods need a body face. Pass the stashed disk-centre sketch point
@@ -158,14 +158,14 @@ in **separate loops**. Therefore **circle-bounded profiles (annulus, plain disc,
    adsk.fusion.FeatureOperations.NewBodyFeatureOperation)`; `ext.setOneSideExtent(
    adsk.fusion.DistanceExtentDefinition.create(ValueInput.createByString(discThicknessParam.name)),
    adsk.fusion.ExtentDirections.PositiveExtentDirection)`; `extrude = extrudeFeatures.add(ext)`. Name the
-   body `'Cycloidal Disk'`. (Use the `DiscThickness` param **by name** for the extent; the value is already
-   cm. Features build fine non-active.)
-2. **Disk Axis (now that a body face exists).** Call `self.buildDiskAxis(...)` with a planar cap face of
-   this extrude → the construction axis ⟂ the sketch at `Od`, stashed on `self.diskAxis`
+   body `'Cycloidal Disk {d+1}'`. (Use the `DiscThickness` param **by name** for the extent; the value is
+   already cm. Features build fine non-active.)
+2. **Disk Axis (now that a body face exists).** Call `self.buildDiskAxis(capFace, d)` with a planar cap face
+   of this extrude → the construction axis ⟂ the sketch at `Od_d`, stashed on `self.diskAxes[d]`
    (`[CYCLOIDAL-F-DISK-AXIS]`). This MUST come after step 1 — `setByLine` (pre-body) is unsupported.
 3. **Circular-pattern the EXTRUDE FEATURE ×`L` about the Disk Axis.** Pattern the **extrude feature**, not
    its body: `coll = adsk.core.ObjectCollection.create(); coll.add(extrude)` (the `ExtrudeFeature` from
-   step 1); `pat = circularPatternFeatures.createInput(coll, self.diskAxis)`;
+   step 1); `pat = circularPatternFeatures.createInput(coll, self.diskAxes[d])`;
    **`pat.patternComputeOption = adsk.fusion.PatternComputeOptions.AdjustPatternCompute`**
    (`[CYCLOIDAL-F-OUTPUT-HOLES]` ⚠️); `pat.quantity = ValueInput.createByReal(L)` (`= N − 1`);
    `pat.totalAngle = ValueInput.createByString('360 deg')`; `pat.isSymmetric = False`;
@@ -183,9 +183,10 @@ in **separate loops**. Therefore **circle-bounded profiles (annulus, plain disc,
 
 ## [CYCLOIDAL-F-OUTPUT-HOLE] Separate output-hole sketch
 
-A **new** sketch (`Output Hole`), independent of the lobe sketch so the lobe and hole profiles never
-interfere. Anchor it (`[CYCLOIDAL-F-ANCHOR-CHAIN]`) and rebuild the disk centre
-(`[CYCLOIDAL-F-DISK-CENTER]`) — output holes belong to the **disk**, so they are centred on `Od = (E,0)`:
+A **new** sketch (`Output Hole {d+1}`, per disc, on `plane(d)`), independent of the lobe sketch so the lobe
+and hole profiles never interfere. Anchor it (`[CYCLOIDAL-F-ANCHOR-CHAIN]`) and rebuild the disc centre
+(`[CYCLOIDAL-F-DISK-CENTER]`) — output holes belong to the **disc**, so they are centred on
+`Od_d = (s_d·E, 0)` (signed `E` per `[CYCLOIDAL-F-TWO-DISC]`; the text below shows the `d = 0` case):
 
 1. **Output-hole circle (construction, on the disk centre).** `addByCenterRadius(Point3D.create(E,0,0),
    Rop)` (`Rop = Output Pin Circle Radius`), `isConstruction = True`, centre coincident to `diskCentre`,
@@ -198,32 +199,33 @@ interfere. Anchor it (`[CYCLOIDAL-F-ANCHOR-CHAIN]`) and rebuild the disk centre
    hole.centerSketchPoint, outputHoleCircle)` (on the `Rop` circle) **and** a horizontal construction line
    `addByTwoPoints(diskCentre, hole.centerSketchPoint)` + `addHorizontal(...)` (hole on the `+X̂` ray from
    `Od`). → hole fully constrained. (One of `M`; the pattern comes later.) Stash the solid hole circle on
-   **`self.outputHole`** — the cut step selects its profile by identity.
+   **`self.outputHoles[d]`** — the cut step selects its profile by identity.
 
 Leave the sketch **visible**. The solid hole is cut through the disk next (`[CYCLOIDAL-F-OUTPUT-HOLES]`).
 
 ## [CYCLOIDAL-F-OUTPUT-HOLES] Cut the output hole through the disk + pattern ×M
 
-After `buildOutputHoleSketch` has drawn the hole (`self.outputHole`, the solid circle on the `Rop` circle
-about `Od`) and `buildDisk` has produced the combined `self.diskBody`, cut one hole and pattern it ×`M`:
+After `buildOutputHoleSketch(d)` has drawn the hole (`self.outputHoles[d]`, the solid circle on the `Rop`
+circle about `Od_d`) and `buildDisk(d)` has produced the combined `self.diskBodies[d]`, cut one hole and
+pattern it ×`M`:
 
 1. **Select the hole profile by identity.** ⚠️ **Not** `profiles.item(0)` — the construction circle and the
    `'Output Hole Circle'` text label add other (non-cut / letter) profiles. Pick the profile whose loop
-   contains `self.outputHole` (the solid hole circle), the same identity trick the lobe sector uses.
+   contains `self.outputHoles[d]` (the solid hole circle), the same identity trick the lobe sector uses.
 2. **Extrude-cut through the disk.** `ci = extrudeFeatures.createInput(holeProfile,
    adsk.fusion.FeatureOperations.CutFeatureOperation)`; same extent idiom as the lobe extrude
    (`[CYCLOIDAL-F-DISK-BODY]` step 1): `ci.setOneSideExtent(adsk.fusion.DistanceExtentDefinition.create(
    ValueInput.createByString(discThicknessParam.name)), adsk.fusion.ExtentDirections.PositiveExtentDirection)`
    (the `Output Hole` sketch is on the target plane `z=0`, the disk spans `[0, DiscThickness]`, so the cut
    passes through it). ⚠️ `setDistanceExtent` is a **`HoleFeatureInput`** method — do **not** use it on an
-   extrude. Set **`ci.participantBodies = [self.diskBody]`** (restrict the cut to the disk); `cut =
-   extrudeFeatures.add(ci)`. Stash `self.outputHoleCut = cut`.
+   extrude. Set **`ci.participantBodies = [self.diskBodies[d]]`** (restrict the cut to the disc); `cut =
+   extrudeFeatures.add(ci)` (kept local — nothing else needs the feature after the pattern).
 3. **Pattern the CUT FEATURE ×`M` about the Disk Axis.** `coll = ObjectCollection.create(); coll.add(cut)`
    (the **`ExtrudeFeature`**, not a body — same as the lobe pattern); `pat = circularPatternFeatures.
-   createInput(coll, self.diskAxis)`; **`pat.patternComputeOption = adsk.fusion.PatternComputeOptions.
+   createInput(coll, self.diskAxes[d])`; **`pat.patternComputeOption = adsk.fusion.PatternComputeOptions.
    AdjustPatternCompute`** (see ⚠️ below); `pat.quantity = ValueInput.createByReal(M)` (`M = Output Pin
    Count`); `pat.totalAngle = ValueInput.createByString('360 deg')`; `pat.isSymmetric = False`;
-   `circularPatternFeatures.add(pat)`. The `M` holes orbit `Od` (the Disk Axis is at `Od`).
+   `circularPatternFeatures.add(pat)`. The `M` holes orbit `Od_d` (the Disk Axis is at `Od_d`).
 
 ⚠️ **`AdjustPatternCompute` is mandatory on EVERY circular pattern here.** This is a **lone CUT** pattern
 (no body-creating feature to anchor it). With the default optimized/identical "paste" compute, Fusion
@@ -324,16 +326,19 @@ running gap, both on `Od`) so the cam turns freely. Use **two sketches** so the 
 stay simple. `buildCam()` runs after the per-disc loop and **before** `buildRingPins()` (the call-graph
 order; `buildDiskBore(d)` runs inside the per-disc loop):
 
-1. **Disk center bore — sketch `Disk Bore`** on `self.plane`; anchor a local origin to `O`
-   (`[CYCLOIDAL-F-ANCHOR-CHAIN]`), rebuild `Od` (`[CYCLOIDAL-F-DISK-CENTER]`). One **solid** circle
-   `addByCenterRadius(Od, (CenterBearingDiameter + BearingClearance)/2)`, centre coincident to `Od`, diameter
+1. **Disc center bore — `buildDiskBore(d)`, sketch `Disc Bore {d+1}`** on `plane(d)` (runs per disc, inside
+   the §0 loop); anchor a local origin to `O`
+   (`[CYCLOIDAL-F-ANCHOR-CHAIN]`), rebuild `Od_d` (`[CYCLOIDAL-F-DISK-CENTER]`). One **solid** circle
+   `addByCenterRadius(Od_d, (CenterBearingDiameter + BearingClearance)/2)`, centre coincident to `Od_d`,
+   diameter
    dim `.parameter.expression = '{} + {}'.format(centerBearingParam.name, bearingClearanceParam.name)`. Cut
-   it through the disk: `coll = ObjectCollection.create()`; add **every** profile in this sketch (just the
+   it through the disc: `coll = ObjectCollection.create()`; add **every** profile in this sketch (just the
    disc); `ci = extrudeFeatures.createInput(coll, CutFeatureOperation)`;
    `ci.setOneSideExtent(DistanceExtentDefinition.create(ValueInput.createByString(discThicknessParam.name)),
-   PositiveExtentDirection)`; `ci.participantBodies = [self.diskBody]`; `extrudeFeatures.add(ci)`. → a clean
-   round center bore `Bearing Clearance` wider than the cam.
-2. **Eccentric Cam — sketch `Eccentric Cam`** on `self.plane`; anchor a local origin to `O`, rebuild `Od`.
+   PositiveExtentDirection)`; `ci.participantBodies = [self.diskBodies[d]]`; `extrudeFeatures.add(ci)`. → a
+   clean round center bore `Bearing Clearance` wider than the cam.
+2. **Eccentric Cam — per-disc section sketch `Eccentric Cam {d+1}`** on `plane(d)` (in `buildCam()`'s own
+   loop over `d`); anchor a local origin to `O`, rebuild `Od_d`.
    Add:
    - **cam-outer circle** `addByCenterRadius(Od, CenterBearingDiameter/2)`, **solid**, centre coincident to
      `Od`, diameter dim `.parameter.expression = CenterBearingDiameter`. Keep `camOuter`.
@@ -341,17 +346,19 @@ order; `buildDiskBore(d)` runs inside the per-disc loop):
      InputShaftDiameter/2)`, **solid**, centre coincident to the local origin `O`, diameter dim →
      `InputShaftDiameter`. Keep `inputBore`. (It lies inside `camOuter`, offset `E` from `Od`, so it splits
      the cam disc into a small **bore disc** + the **cam annulus**.)
-   Extrude the **cam cross-section** by `Disc Thickness` as a New Body, name it `'Eccentric Cam'`
-   (`PositiveExtentDirection` → `[0, DiscThickness]`, co-level with the disk). The cross-section is the **cam
+   Extrude the **cam cross-section** as a New Body named `'Eccentric Cam {d+1}'`
+   (`PositiveExtentDirection`; extent `T + g` for `d < D−1`, `T` for the last — the `[CYCLOIDAL-F-TWO-DISC]`
+   "Cam" paragraph owns the extent expressions). The cross-section is the **cam
    annulus** when `Input Shaft Diameter > 0` — the **2-loop** profile (outer loop `camOuter`, inner hole-loop
    `inputBore`); select it by **`profileLoops.count == 2`**. ⚠️ **Do NOT use `find_profile_by_curve_counts`
    for the cam annulus** — a full circle is a single `Circle3DCurveType` curve (that helper counts it as
    "other", not an arc) and the annulus's two circles are in **separate loops**, so `find_profile_by_curve_counts(arcs=2)`
    raises `Could not find profile`. Same gotcha as the housing annulus (`[CYCLOIDAL-F-RING-PINS]`). When
    `Input Shaft Diameter == 0` there is no bore, so the cross-section is the **1-loop** cam disc — select the
-   only profile (`profiles.item(0)`). Stash **`self.cam`**. The cam
-   outer is on `Od`; the disk's bore (on `Od`, larger by `Bearing Clearance`) rides on it with the running
-   gap; the input bore runs through the full cam height on `O`.
+   only profile (`profiles.item(0)`). After all `D` sections: **Join** them into one body named
+   `'Eccentric Cam'` and stash **`self.cam`** (per `[CYCLOIDAL-F-TWO-DISC]`). The cam
+   outer is on `Od_d`; the disc's bore (on `Od_d`, larger by `Bearing Clearance`) rides on it with the
+   running gap; the input bore runs through the full cam height on `O`.
 
 ## [CYCLOIDAL-F-OUTPUT-PINS] Output pins + plate (on `O`, the output member)
 

--- a/spec/cycloidal/fusion.md
+++ b/spec/cycloidal/fusion.md
@@ -112,8 +112,8 @@ raises `RuntimeError: 3 : Environment is not supported` in the parametric design
 (`buildDiskAxis(capFace)`, called from `buildDisk` after the extrude):
 1. `capFace` = **a planar cap of the extrude — selected by NORMAL direction**, i.e. a face whose surface
    is `PlaneSurfaceType` **and whose normal is parallel to the sketch-plane normal** (the cap is ⟂ the
-   extrude direction). Use **`extrude.startFaces.item(0)`** (the cap in the sketch plane); only if that is
-   somehow not such a face, fall back to `extrude.endFaces.item(0)`. The axis direction comes from the
+   extrude direction). Use **`extrude.startFaces.item(0)`** unconditionally (the cap in the sketch plane;
+   no `endFaces` fallback). The axis direction comes from the
    cap's normal, so **either cap yields the same vertical axis** — you only need *a cap*; its location
    through `Od` is set by the point arg in step 2.
    ⚠️ **Do NOT pick the cap by "nearest planar face to `Od`" or "the planar face whose plane contains
@@ -131,8 +131,8 @@ raises `RuntimeError: 3 : Environment is not supported` in the parametric design
 3. `axis = component.constructionAxes.add(axInput)`; `axis.name = 'Disk Axis'`; **`self.diskAxis = axis`**.
 
 Face-anchored axis methods (`setByPerpendicularAtPoint`, `setByCircularFace`) work on a **non-active**
-component — only the line/point methods need a body face. If `setByPerpendicularAtPoint` rejects the
-sketch point, pass the body **vertex** at `Od` instead (search `body.vertices` for the one nearest `Od`).
+component — only the line/point methods need a body face. Pass the stashed disk-centre sketch point
+directly (no nearest-vertex fallback).
 
 ## [CYCLOIDAL-F-DISK-BODY] Extrude the lobe sector + circular-pattern into the disk
 
@@ -171,11 +171,15 @@ in **separate loops**. Therefore **circle-bounded profiles (annulus, plain disc,
    `pat.totalAngle = ValueInput.createByString('360 deg')`; `pat.isSymmetric = False`;
    `circularPatternFeatures.add(pat)`. (`createInput` accepts features **or** bodies; pass the **feature** —
    `[PB-PATTERN-BODIES]`.) The `L` sectors tile the full rotor disk.
-4. **Combine ×`L` → one disk body.** The component now holds exactly the `L` lobe-sector bodies. Join them:
-   `target = component.bRepBodies.item(0)`; `tools = ObjectCollection` of `component.bRepBodies.item(i)` for
-   `i in 1..count−1`; `ci = combineFeatures.createInput(target, tools)`;
+4. **Combine ×`L` → one disk body.** ⚠️ Join ONLY disc `d`'s **own** `L` sectors — with two discs, earlier
+   bodies already exist, so `bRepBodies.item(0)` is the WRONG target. Record `base =
+   component.bRepBodies.count` **BEFORE** step 1's extrude; disc `d`'s sectors are then
+   `bRepBodies.item(base) … item(base + L − 1)`. Join them: `target = component.bRepBodies.item(base)`;
+   `tools = ObjectCollection` of `component.bRepBodies.item(i)` for `i in base+1 .. base+L−1`;
+   `ci = combineFeatures.createInput(target, tools)`;
    `ci.operation = adsk.fusion.FeatureOperations.JoinFeatureOperation`; `combineFeatures.add(ci)`. Name the
-   resulting body `'Cycloidal Disk'` and stash **`self.diskBody`** (the output-hole cut needs it).
+   resulting body `'Cycloidal Disk {d+1}'` and stash **`self.diskBodies[d]`** (the output-hole cut needs it).
+   (`[CYCLOIDAL-F-TWO-DISC]` restates the baseline rule.)
 
 ## [CYCLOIDAL-F-OUTPUT-HOLE] Separate output-hole sketch
 
@@ -316,7 +320,8 @@ The cam is the **input** — an eccentric cylinder the disk rides on (a plain jo
 on the disk centre `Od`, input-shaft bore centred on the drive axis `O`; the `E` offset between them is the
 eccentricity. The disk's center bore is **enlarged** over the cam by `Bearing Clearance` (a concentric
 running gap, both on `Od`) so the cam turns freely. Use **two sketches** so the bore-cut and cam profiles
-stay simple. Build `buildCam()` after the ring pins:
+stay simple. `buildCam()` runs after the per-disc loop and **before** `buildRingPins()` (the call-graph
+order; `buildDiskBore(d)` runs inside the per-disc loop):
 
 1. **Disk center bore — sketch `Disk Bore`** on `self.plane`; anchor a local origin to `O`
    (`[CYCLOIDAL-F-ANCHOR-CHAIN]`), rebuild `Od` (`[CYCLOIDAL-F-DISK-CENTER]`). One **solid** circle
@@ -451,8 +456,8 @@ pins are integral bumps** — no separate chamfer; `buildChamfers` chamfers the 
 `D = Disc Count` (`1`|`2`, from the dropdown). The per-disc steps run in a `for d in range(D)` loop; the
 stack-spanning steps (cam, ring pins, output pins, chamfers) run once. Per-disc stashes are **lists** indexed
 by `d` (`self.diskBodies`, `self.diskAxes`, `self.lobeSplines`, `self.outputHoles`, `self.lobeDiskCentres`,
-`self.discPlanes`); `self.lobePinCircle` stays scalar (disc 0). For `D = 1` the loop runs once and everything
-is identical to the single-disc build.
+`self.discPlanes`); `self.lobePinCircle` stays scalar (disc 0; stashed but unused — legacy). For `D = 1` the loop runs once and
+everything is identical to the single-disc build.
 
 ⚠️ **Prefix EVERY parameter in EVERY `createByString` expression** (offsets AND extents) with
 `self.parameterName(PARAM_…)` — the params register under `CycloidalDrive<N>_`, so a bare `'DiscThickness'`

--- a/spec/cycloidal/fusion.md
+++ b/spec/cycloidal/fusion.md
@@ -260,10 +260,11 @@ gap) and Joined. **No discrete pins.** Build `buildRingPins()` after the discs +
 4. **Ring casing — one section, patterned ×`N`** (mirrors the disc's lobe-sector → pattern → join). The inner
    wall is the disc's **swept envelope** `contour(φ) = env(φ) + c` (`epitrochoid-trace.md` "Pinless ring
    casing") — a smooth conjugate curve, NOT a constant circle.
-   - **Compute one pin-pitch of the contour (Python).** `env = {}`; for `θ` in `linspace(0, 2π, Nθ≈240)`:
-     `cx, cy = E*cos θ, E*sin θ`; `phi = -θ/L`; for `t` in `linspace(0, 2π, Nt≈240)`:
-     `x, y = disk_point(t, cx, cy, phi)`; `a = atan2(y, x)`; **if `a ∈ [−π/N, π/N]`**: bin `a` into `nbins`
-     bins, keep `max(r=hypot(x,y))` per bin (`binMax`). ⚠️ **Emit the contour points at bin EDGES so the FIRST
+   - **Compute one pin-pitch of the contour (Python).** `env = {}`; for `θ` in `linspace(0, 2π, Nθ = 240)`:
+     `cx, cy = E*cos θ, E*sin θ`; `phi = -θ/L`; for `t` in `linspace(0, 2π, Nt = 240)`:
+     `x, y = disk_point(t, cx, cy, phi)`; `a = atan2(y, x)`; **if `a ∈ [−π/N, π/N]`**: bin `a` into
+     **`nbins = 80`** bins, keep `max(r=hypot(x,y))` per bin (`binMax`). (Empty bins: per
+     `epitrochoid-trace.md` — an edge uses only its hit neighbours; both-unhit edges fall back to radius `c`.) ⚠️ **Emit the contour points at bin EDGES so the FIRST
      lands exactly on `−π/N` and the LAST exactly on `+π/N`** — `nbins+1` points at `φ_i = −π/N + (2π/N)·i/nbins`
      (`i = 0 … nbins`), radius `(c + max(binMax[i−1], binMax[i]))` (single neighbour at the two ends), as
      `[(r_i·cos φ_i, r_i·sin φ_i)]` ordered by angle (all cm; `disk_point` returns cm, use as-is). **Do NOT use

--- a/spec/cycloidal/instructions.md
+++ b/spec/cycloidal/instructions.md
@@ -39,11 +39,12 @@ name='Cycloidal Drive Generator', …)`, binding the two classes above by name.
 ## Component Setup
 
 One command invocation creates a new child component (named per `generateName`) of the user-selected
-Parent Component. It draws six sketches — `Rotor Lobe` (one fully-constrained open lobe section + its
+Parent Component. It draws seven sketches — `Rotor Lobe` (one fully-constrained open lobe section + its
 reference frame), `Output Hole` (one output hole), `Housing Ring` (the base annulus, on a construction plane
-`1 mm` below the disk) + `Ring Casing` (one swept-contour section), `Disk Bore` (the enlarged center bore),
+`1 mm` below the disk), `Ring Casing` (one swept-contour section), `Disc Bore` (the enlarged center bore),
 `Eccentric Cam` (cam outer + input bore), and `Output Plate` (the output disc + one output pin, on a plane
-`1 mm` above the disk) — and builds the **rotor disk** (with its **center bore**), **`M` output holes**, the
+`1 mm` above the disk); the per-disc ones (`Rotor Lobe`, `Output Hole`, `Disc Bore`, `Eccentric Cam`) carry
+`{d+1}` name suffixes and repeat for the second disc — and builds the **rotor disk** (with its **center bore**), **`M` output holes**, the
 **`Housing` body** (base annulus + pinless swept-contour ring casing, Combined into one part), the
 **eccentric input cam**, and the **output plate + `M` output pins**. The **Anchor is the drive axis** `O`; the
 **cycloidal disk is eccentric**, its centre
@@ -136,29 +137,26 @@ lobe-tip envelope `env_max + c`, the `c` cancels — verified]; the outer wall c
 **minimum wall thickness is exactly `Wall`** at the peaks, a bit more at the valleys. The inner floor lip sits
 `Wall` inside the contour valley `R − PinRadius`); and the **output-plate**
 diameter **`OutputPlateDiameter = OutputPinCircleDiameter + D_pin + 2·Wall`** (= `2·Rop + D_pin + 2·Wall`,
-the plate covers the output pins by `Wall`). The resolved **output-pin diameter** is `D_pin = OutputHoleDiameter − 2E`. Validity (reject with a clear message, on the
-**resolved** values): `E < PinRadius < R·sin(π/N)`; `D_pin > 0`; `D_hole < 2·Rop·sin(π/M)`; `E < R/N`;
-`Rop < Rv`; **and the no-undercut guard `Rr_eff < ρ_min^O`** (`epitrochoid-trace.md` "No-undercut guard"
-— the *binding* eccentricity limit, ≈ 2.5 mm for defaults; computed numerically from the base-trochoid
-curvature, far tighter than `R/N`). This is the check that stops the "sketch breaks at high E" failure.
-Also (cam/bore): `Input Shaft Diameter < Center Bearing Diameter`; the input bore must sit inside the cam
-(`E + InputShaftDiameter/2 < CenterBearingDiameter/2`); and the **enlarged** disk center bore must clear the
-output holes (`(CenterBearingDiameter + BearingClearance)/2 < Rop − D_hole/2`). Reject with a clear message
-otherwise.
-Also (two-disc): when **`Disc Count == 2`**, require **`N` even AND `M` even** — the 180° disc-2
-construction maps pins→pins only for even `N` and output-holes→output-pins only for even `M`. Reject with a
-clear message (e.g. "Two discs require an even Pin Count and even Output Pin Count").
+the plate covers the output pins by `Wall`). The resolved **output-pin diameter** is
+`D_pin = OutputHoleDiameter − 2E`.
+**Validity — the table under "Live input validation" is the single authoritative list of enforced checks**
+(run on the **resolved** values; it includes the two-disc evenness gate and the cam/bore fit checks). The
+**no-undercut guard `Rr_eff < ρ_min^O`** in that table is the *binding* eccentricity limit
+(`epitrochoid-trace.md` "No-undercut guard" — ≈ 2.5 mm for defaults, computed numerically from the
+base-trochoid curvature, far tighter than `R/N`); it is the check that stops the "sketch breaks at high E"
+failure.
 
-⚠️ **All of the above validity checks are implemented exactly once**, in the shared
+⚠️ **All validity checks are implemented exactly once**, in the shared
 `evaluate_problems(vals)` helper, and surfaced **both** live (OK greys out while editing, via
 `validate_inputs`) **and** at execute time (`_resolveDimensions` raises the joined messages) — see
 "Live input validation" for the routine, the actionable message wording, and the numeric `E*` bound.
 
 ### Exact input ids and parameter-name strings (verbatim)
 
+Rows are in dialog display order (the authoritative order — see the display-order paragraph below):
+
 | Dialog input | input id | registered user-parameter |
 |---|---|---|
-| Parent Component (selection) | `parentComponent` | — |
 | Target Plane (selection) | `plane` | — |
 | Anchor Point (selection) | `anchorPoint` | — |
 | Disc Count (dropdown 1/2) | `discCount` | — |
@@ -169,16 +167,17 @@ clear message (e.g. "Two discs require an even Pin Count and even Output Pin Cou
 | Disk Clearance | `diskClearance` | `DiskClearance` |
 | Disc Thickness | `discThickness` | `DiscThickness` |
 | Disc Gap | `discGap` | `DiscGap` |
-| Output Pin Circle Diameter | `outputPinCircleDiameter` | `OutputPinCircleDiameter` |
-| Output Pin Count | `outputPinCount` | `OutputPinCount` |
-| Output Pin Diameter | `outputPinDiameter` | `OutputPinDiameter` |
 | Center Bearing Diameter | `centerBearingDiameter` | `CenterBearingDiameter` |
 | Input Shaft Diameter | `inputShaftDiameter` | `InputShaftDiameter` |
 | Bearing Clearance | `bearingClearance` | `BearingClearance` |
+| Output Pin Circle Diameter | `outputPinCircleDiameter` | `OutputPinCircleDiameter` |
+| Output Pin Count | `outputPinCount` | `OutputPinCount` |
+| Output Pin Diameter | `outputPinDiameter` | `OutputPinDiameter` |
 | Housing Wall | `wall` | `Wall` |
 | Base Thickness | `baseThickness` | `BaseThickness` |
 | Output Plate Thickness | `outputPlateThickness` | `OutputPlateThickness` |
 | Chamfer Size | `chamferSize` | `ChamferSize` |
+| Parent Component (selection) | `parentComponent` | — |
 | Per-field message slot after each value/dropdown input | `<inputId>__status` (e.g. `pinCircleDiameter__status`) | — (not read, not a parameter) |
 
 `Pin Diameter` and `Output Pin Diameter` are `addValueInput` defaulting to **`0`** (`0` = auto-derive).
@@ -201,14 +200,15 @@ expressions (they compose cleanly from the registered inputs, including the snap
 **derived** parameters — required because the `PinRadius` / `OutputHoleDiameter` snapshots read the resolved
 `self.Rr` / `self.D_hole` that `_resolveDimensions` stashes.
 
-**Dialog display order (`configure()` adds inputs in exactly this sequence):** Target Plane, Anchor
+**Dialog display order — AUTHORITATIVE (`configure()` adds inputs in exactly this sequence; the ids table
+above lists the same order):** Target Plane, Anchor
 Point, Disc Count, Pin Count, Pin Circle Diameter, Pin Diameter, Eccentricity, Disk Clearance, Disc
 Thickness, Disc Gap, Center Bearing Diameter, Input Shaft Diameter, Bearing Clearance, Output Pin Circle
 Diameter, Output Pin Count, Output Pin Diameter, Housing Wall, Base Thickness, Output Plate Thickness,
-Chamfer Size, Parent Component. Selections first two; Parent last. **Immediately after each
-value/dropdown input** in that sequence (i.e. after Disc Count, Pin Count, …, Chamfer Size — but NOT
-after the selections), add that input's hidden `<id>__status` message slot, so each editable field is
-directly followed by its own slot. All numerics are `addValueInput` (read with `get_value`); selections
+Chamfer Size, Parent Component. Selections first two; Parent last. Each value/dropdown input is
+immediately followed by its hidden `<id>__status` slot (the "Per-field message slots" bullet under
+Variables owns the exact creation signature; selections get no slot). All numerics are `addValueInput`
+(read with `get_value`); selections
 via `get_selection`; the `__status` slots are `addTextBoxCommandInput` and are never read.
 `Pin Count` (`N`) and `Output Pin Count` (`M`) are integer counts —
 their `addValueInput` **unit string is `''`** (unitless) and they are **registered as unitless parameters**
@@ -218,11 +218,8 @@ value rounded to int** for the Python formulas (`sin(π/N)`, `sin(π/M)`; Fusion
 ## Live input validation
 
 The dialog validates geometry **live** so the user is never silently kicked out at OK time. The shared
-`GearCommand.command_validate_input` (`[PB-VALIDATE-INPUTS]`) consults two members this generator
-declares, and on any problem **disables OK** (the dialog stays open and editable) while showing the
-problem list in the **per-field message slot next to the field the user last edited** (the handler
-tracks the last-changed input and writes into `<that-input-id>__status`, hiding the previously shown
-slot; for selection changes or the initial open it uses `DEFAULT_STATUS_INPUT_ID`):
+handler's mechanics (OK-disable, last-edited-slot tracking, fallback slot) are `[PB-VALIDATE-INPUTS]` —
+the PLAYBOOK owns them; this gear's delta is only the two members the handler consults:
 
 - **`DEFAULT_STATUS_INPUT_ID = INPUT_ID_PIN_CIRCLE_DIAMETER + '__status'`** (class attribute on
   `CycloidalDriveGenerator`) — the fallback slot, used when the last-edited input has no slot of its own.
@@ -423,7 +420,8 @@ reduces to today's single-disc build.
 
 ### 1: Normalize the Target Plane
 If the selected plane is not a `ConstructionPlane`, make a coplanar one via
-`ConstructionPlaneInput.setByOffset(selectedPlane, 0)` and use it (`[SPUR-F` parity).
+`ConstructionPlaneInput.setByOffset(selectedPlane, 0)` and use it (the same normalization the spur
+generator does).
 
 ### 2: Fully-constrained lobe, on the eccentric disk centre — `buildLobeSketch(d)`
 (Takes the disc index `d` per **§0**; the text below is the `d=0` case — for general `d` substitute

--- a/spec/cycloidal/instructions.md
+++ b/spec/cycloidal/instructions.md
@@ -33,6 +33,9 @@ per-disc handles are **lists** indexed by the disc index `d` (`self.diskBodies`,
 `fusion360utils`). ⚠️ Use **`solids.hide_construction_geometry(component)`** for the final cleanup — do NOT
 re-implement it (helper-shadowing is rejected).
 
+**Entry wiring:** `commands/cycloidaldrive/entry.py` constructs `GearCommand(gear_type='CycloidalDrive',
+name='Cycloidal Drive Generator', …)`, binding the two classes above by name.
+
 ## Component Setup
 
 One command invocation creates a new child component (named per `generateName`) of the user-selected
@@ -56,10 +59,17 @@ profile lives in its own sketch so they never interfere.
 User inputs in dialog order; all linear inputs are mm. Derived parameters are registered as Fusion user
 parameters under the `CycloidalDrive<N>_` prefix.
 
+⚠️ **The bullet bounds below are authoring constraints, NOT live-validated.** The "integer ≥ 4" /
+"integer ≥ 3" count floors and the "mm > 0" / "mm ≥ 0" notes are documentation of sensible ranges;
+`evaluate_problems` does **not** enforce them. The validity table under "Live input validation" is the
+authoritative, complete list of checks `validate_inputs` / `_resolveDimensions` actually run.
+
 - **Target Plane** — user-specified plane; the lobe sketch sits here. Any non-`ConstructionPlane`
   selection (e.g. a planar face) is normalized to a coplanar construction plane at generation time.
+  Selection filters: `ConstructionPlanes` + `PlanarFaces`; `setSelectionLimits(1, 1)`.
 - **Anchor Point** — user-specified `ConstructionPoint` or `SketchPoint`; the lobe is centred on its
-  in-plane projection `O`.
+  in-plane projection `O`. Selection filters: `ConstructionPoints` + `SketchPoints`;
+  `setSelectionLimits(1, 1)`.
 - **Disc Count** — a **dropdown** (`DropDownCommandInput`, `TextListDropDownStyle`) with items `'1'` and
   `'2'`, default **`'1'`**. `1` = single disc (today's build); `2` = two discs 180° opposed for balance.
   Read as int from the selected item's name. ⚠️ **`2` requires even `Pin Count` and even `Output Pin
@@ -97,6 +107,10 @@ parameters under the `CycloidalDrive<N>_` prefix.
   rotor disc, Housing Ring and Output Plate, and on the two **ends** of every ring pin and output pin.
   **`0` = no chamfer**. Default **0.5 mm**.
 - **Parent Component** — component, default root (pre-selected); listed last among the editable inputs.
+  Selection filters: `Occurrences` + `RootComponents`; **`setSelectionLimits(0, 1)`** (empty allowed), with
+  the root component pre-selected via `addSelection(get_design().rootComponent)`. `processInputs` falls back
+  to `get_design().rootComponent` when the selection is empty; an `Occurrence` selection resolves to its
+  `.component`.
 - **Per-field message slots** — **not** user inputs: immediately **after each value/dropdown input**
   above, `configure()` adds a hidden, read-only `TextBoxCommandInput` whose id is **that input's id +
   `'__status'`** (e.g. `pinCircleDiameter__status`). Create each with the exact signature
@@ -182,6 +196,10 @@ PARAM_PIN_RADIUS, adsk.core.ValueInput.createByReal(Rr), 'mm', …)` and likewis
 real parameters; their *value* is the snapshot). `PinCircleRadius`, `OutputPinCircleRadius`,
 `HousingInnerDiameter`, `HousingOuterDiameter`, `OutputPlateDiameter`, `Lobes` stay **live** `createByString`
 expressions (they compose cleanly from the registered inputs, including the snapshot `PinRadius`).
+**Ordering (fixed):** `processInputs` registers all **primary** parameters, then calls
+`_resolveDimensions()` (which raises the joined `evaluate_problems` messages on failure), then registers the
+**derived** parameters — required because the `PinRadius` / `OutputHoleDiameter` snapshots read the resolved
+`self.Rr` / `self.D_hole` that `_resolveDimensions` stashes.
 
 **Dialog display order (`configure()` adds inputs in exactly this sequence):** Target Plane, Anchor
 Point, Disc Count, Pin Count, Pin Circle Diameter, Pin Diameter, Eccentricity, Disk Clearance, Disc
@@ -193,8 +211,9 @@ after the selections), add that input's hidden `<id>__status` message slot, so e
 directly followed by its own slot. All numerics are `addValueInput` (read with `get_value`); selections
 via `get_selection`; the `__status` slots are `addTextBoxCommandInput` and are never read.
 `Pin Count` (`N`) and `Output Pin Count` (`M`) are integer counts —
-register the parameters but **read the counts from the dialog value rounded to int** for the Python
-formulas (`sin(π/N)`, `sin(π/M)`; Fusion user params are floats).
+their `addValueInput` **unit string is `''`** (unitless) and they are **registered as unitless parameters**
+(`get_value(inputs, <id>, '')`, unit `''`); register the parameters but **read the counts from the dialog
+value rounded to int** for the Python formulas (`sin(π/N)`, `sin(π/M)`; Fusion user params are floats).
 
 ## Live input validation
 
@@ -213,7 +232,9 @@ slot; for selection changes or the initial open it uses `DEFAULT_STATUS_INPUT_ID
   `inputs.itemById(INPUT_ID_DISC_COUNT).selectedItem.name` for the dropdown), resolves the same derived
   dimensions as `_resolveDimensions` (`Rr`, `Rr_eff`, `Rv`, `D_pin`, `D_hole` per the auto-vs-override
   rules above), runs the validity checks, and returns a list of **actionable** problem strings (empty =
-  valid). It runs on every keystroke, so keep it cheap. If a value can't be read yet (a half-typed
+  valid). It runs on every keystroke; its cost — the 2000-point curvature scan, plus the 40-iteration
+  bisection (each iteration re-running the scan) when the undercut guard fails — is **accepted as-is**; do
+  not cache or downsample. If a value can't be read yet (a half-typed
   expression), let the read raise — the shared handler catches it and treats the inputs as provisionally
   valid (the execute-time guard is the backstop).
 
@@ -250,7 +271,7 @@ to match the table. Two-disc evenness is checked first (it needs only `N`, `M`, 
 closed form, so solve it for the message: holding every other input fixed, find the largest `E*` in
 `(0, E]` for which `Rr_eff(E') < ρ_min^O(E')` still holds, where `ρ_min^O` is the existing base-trochoid
 curvature scan (`epitrochoid-trace.md` "No-undercut guard"; note both `Rr_eff` and `ρ_min^O` depend on
-`E'` when `Pin Diameter = 0`). A ~40-iteration **bisection** on `E'` is ample; report `to_mm(E*)`. If the
+`E'` when `Pin Diameter = 0`). Run exactly **40 bisection iterations** on `E'`; report `to_mm(E*)`. If the
 solve degenerates (no positive `E'` satisfies it), fall back to the plain "reduce Eccentricity" message
 without a number.
 
@@ -294,6 +315,21 @@ without a number.
   cannot be a live Fusion expression. So editing a parameter in Fusion updates the *dimensions* but does
   **not** re-cut the lobe; **regenerate** to apply a change (the normal workflow here). The dimension
   references are for parametric clarity + consistency on regen, not in-place editing of the profile.
+
+- **`Ring Casing` sketch — deliberate `[PB-FULL-CONSTRAINT]` exemption.** Unlike the fully-locked lobe
+  sketch, the casing section sketch is left **under-constrained**: the contour spline's fit points are
+  numeric snapshots but **NOT** `isFixed`, and the two spokes' outer endpoints are only **seeded** on the
+  outer circle (no coincident constraint to it). What IS constrained: the outer circle's centre (coincident
+  to the anchored local origin) and its diameter dim (`HousingOuterDiameter`); each spoke's inner end shares
+  the spline's end fit point. The sketch is consumed immediately by the sector extrude and never re-solved,
+  so the free geometry is accepted as-is.
+
+**Sketch-first status (`[PB-SKETCH-FIRST]`) — waived, not satisfied.** There is **no**
+`spec/cycloidal/sketch/` bench proof for this gear. Rationale: the lobe sketch's shape comes from a fitted
+spline through Python-computed points, locked by fixing every interior fit point and pinning the ends by
+radius + angle — a trivial constraint scheme rather than a solver-driven one; the `Ring Casing` sketch is
+deliberately under-constrained per the exemption above. A bench proof of the lobe reference frame is future
+work; this paragraph records the waiver honestly rather than claiming a proof exists.
 
 ## Method contract — call graph
 
@@ -407,9 +443,9 @@ dimension = `Eccentricity`; `s_d` is the sign). The lobe is `disk_point(t, cx = 
    with an **along-path text label `'Output Pin Circle'`**;
 3. **root/valley circle** (radius `Rv = R − Rr_eff − E`) construction, centred on **`Od`**, diameter dim,
    with an **along-path text label `'Root Circle'`**;
-4. the **lobe** — the open lobe spline about `Od`, **adaptively sampled** by bounded turn angle (≤ ~5°,
-   `epitrochoid-trace.md` "Sampling") so the fitted spline doesn't overshoot near the undercut limit
-   (**not** uniform `t`); **not** `isClosed`, no arc;
+4. the **lobe** — the open lobe spline about `Od`, **adaptively sampled** by bounded turn angle (threshold
+   **5.0°** over a **2000-step** fine trace, `epitrochoid-trace.md` "Sampling") so the fitted spline doesn't
+   overshoot near the undercut limit (**not** uniform `t`); **not** `isClosed`, no arc;
 5. **lock the spline**: fix every **interior** fit point (`isFixed = True`) and coincide each **endpoint
    onto the root circle** (pins the valley radii) — do **not** fix the whole spline;
 6. **spoke line 1** from `Od` to the lobe's **first** point, `coincident(line1.end, spline first point)` +
@@ -487,8 +523,8 @@ Join into one connected, printable part. `stackTopExpr` per §0.
    `[CYCLOIDAL-F-RING-PINS]`, `epitrochoid-trace.md` "Pinless ring casing"). The inner wall follows the disc's
    **swept envelope** `contour(φ) = env(φ) + c` (smooth — replaces the old constant-radius bridge circle).
    - **Compute one pin-pitch of the contour.** Sweep the disc `disk_point(t, E·cosθ, E·sinθ, −θ/L)` over
-     `θ, t ∈ [0, 2π)` (≈ 240 each); bin points whose angle is in `[−π/N, π/N]` into `nbins` by angle, keep max
-     radius per bin → `env`. ⚠️ **Emit the points at bin EDGES so the first/last land EXACTLY on `∓π/N`**:
+     `θ, t ∈ [0, 2π)` (**240 each**); bin points whose angle is in `[−π/N, π/N]` into **`nbins = 80`** by
+     angle, keep max radius per bin → `env`. ⚠️ **Emit the points at bin EDGES so the first/last land EXACTLY on `∓π/N`**:
      `nbins+1` points at `φ_i = −π/N + (2π/N)·i/nbins` (`i = 0…nbins`), radius `c + max(binMax[i−1], binMax[i])`
      — **NOT bin centres**, which inset the ends by half a bin and leave a gap between every patterned sector so
      the ×`N` sectors don't touch and won't Join into one casing (the "several unnamed bodies" bug). Point =

--- a/spec/cycloidal/instructions.md
+++ b/spec/cycloidal/instructions.md
@@ -303,8 +303,8 @@ DiscThickness`, `g = DiscGap`): centre **`Od_d = O + s_d·E·X̂`** (`s_0 = +1`,
 `[z_d, z_d + T]`); plane = `self.plane` for `d=0`, else a construction plane offset `z_d`. Stack top
 **`stackTop = (D−1)·(T+g) + T`**. The **per-disc stashes are LISTS** indexed by `d`: `self.diskBodies[d]`,
 `self.diskAxes[d]`, `self.lobeSplines[d]`, `self.outputHoles[d]`, `self.lobeDiskCentres[d]`,
-`self.discPlanes[d]`. (`self.lobePinCircle` — disc 0's pin circle only — is still scalar, for the ring-pin
-projection.) ⚠️ **EVERY Fusion expression string — construction-plane offsets AND extrude extents, not just
+`self.discPlanes[d]`. (`self.lobePinCircle` — disc 0's pin circle only — is still scalar; it is stashed as
+part of the attribute surface but **never read** — legacy of the pinned-ring design.) ⚠️ **EVERY Fusion expression string — construction-plane offsets AND extrude extents, not just
 `.parameter.expression` dims — must use the PREFIXED parameter name via `self.parameterName(PARAM_…)`.** The
 params register under `CycloidalDrive<N>_`, so a bare `'DiscThickness'`/`'DiscGap'` in any
 `ValueInput.createByString(...)` raises **`RuntimeError: invalid expression`**. Build the literal string for
@@ -367,13 +367,16 @@ E·X̂`, clocking `phi = 0`, on `self.plane`); for general `d` substitute:
   place `Od` at `(−E, 0)` and the spokes/lobe on it. (Generator: a signed `E`.)
 - **Clocking** `phi_d = d·π`. Disc 1's lobe is `disk_point(t, cx = −E, cy = 0, phi = π)` — exactly the **180°
   rotation of disc 0 about `O`** (`disk_point(cx=−E, phi=π) ≡ −disk_point(cx=+E, phi=0)`), which is what
-  meshes the second disc with the **same** ring pins (even `N`) at the opposite eccentric. The two spokes
-  and the angle dim rotate with `phi_d` too (spoke 1 along `−X̂` for disc 1, i.e. the lobe's first valley at
-  `Od_1 + Rv·(cos π, −sin π) = Od_1 + (−Rv, 0)`).
+  meshes the second disc with the **same** ring pins (even `N`) at the opposite eccentric. The spoke **seed
+  coordinates and the angle-dim text point are NOT rotated with `phi_d`** — only the signed `E` is
+  substituted (spoke 1 is still seeded at `Od_d + (Rv, 0)`, the text point at the unrotated bisector). The
+  coincident constraints onto the spline's end fit points drag the spokes onto the rotated valleys (disc 1's
+  first valley `Od_1 + (−Rv, 0)` still lies on spoke 1's horizontal), so the solve lands correctly.
 - **Names** carry `{d+1}`: `'Rotor Lobe {d+1}'`, `'Cycloidal Disk {d+1}'`, `'Output Hole {d+1}'`,
   `'Disc Bore {d+1}'`. **Stash into the `[d]` lists** (`self.diskBodies[d]`, `self.diskAxes[d]`,
   `self.lobeSplines[d]`, `self.outputHoles[d]`, `self.lobeDiskCentres[d]`). The **pin circle** (on `O`) is
-  drawn and stashed (`self.lobePinCircle`) **only for `d = 0`** — the ring pins reuse it.
+  drawn and stashed (`self.lobePinCircle`) **only for `d = 0`**; the stash is **unused** (nothing reads it —
+  the pinless casing computes its own contour).
 - The disc-`d` extrude, axis (`buildDiskAxis` from `plane(d)`-extrude cap face at `Od_d`), lobe pattern, and
   output-hole pattern are all about **`self.diskAxes[d]`** (at `Od_d`). `buildDiskBore(d)` is the center-bore
   cut (formerly inside `buildCam` step 1) on `Od_d` through `self.diskBodies[d]`.
@@ -395,9 +398,10 @@ to the Anchor (`[CYCLOIDAL-F-ANCHOR-CHAIN]`), then make the **eccentric disk cen
 dimension = `Eccentricity`; `s_d` is the sign). The lobe is `disk_point(t, cx = s_d·E, cy = 0, phi = d·π)`
 (disc 1 = disc 0 rotated 180° about `O`). Per `[CYCLOIDAL-F-DISK-LOBE]`, build in order:
 1. **pin circle** (radius `R`) construction, centred on **`O`** (the fixed ring), diameter dim, with an
-   **along-path text label `'Pin Circle'`** — **for `d = 0` only**: **stash it on `self.lobePinCircle`** so
-   `buildRingPins` projects it (`[CYCLOIDAL-F-RING-PINS]`). (Disc 1 doesn't need its own pin circle; draw it
-   for the lobe reference if convenient but the ring pins use disc 0's.)
+   **along-path text label `'Pin Circle'`** — **for `d = 0` only**: **stash it on `self.lobePinCircle`**.
+   The stash is part of the declared attribute surface but is **never read** — legacy of the old pinned-ring
+   build (`buildRingPins` computes the pinless contour instead, `[CYCLOIDAL-F-RING-PINS]`); a future regen
+   may drop it. (Disc 1 doesn't need its own pin circle; draw it for the lobe reference if convenient.)
 2. **output-pin circle** (radius `Rop`) construction, centred on **`Od`** (the disk centre — concentric
    with the root circle, where the disk's output holes sit; the innermost reference circle), diameter dim,
    with an **along-path text label `'Output Pin Circle'`**;


### PR DESCRIPTION
- fix spec-vs-code contradictions (casing arc formula, build order, join target, phantom fallbacks)
- pin exact constants, empty-bin fallback, dialog selection/unit details, resolve ordering
- refresh stale one-lobe headers, generalize per-disc names, dedup validity and `__status` text

## Decisions for reviewer

- disc-1 spoke seeds/angle-dim text point: spec now matches code (NOT rotated with `phi_d`)
- rotating them per `[PB-ANGULAR-DIM]`/`[PB-SEED-NEAR]` would be a code change needing a regen
- count/mm bullet bounds documented as authoring-only; enforcing them is a follow-up needing a regen
- `Ring Casing` sketch documented as a deliberate `[PB-FULL-CONSTRAINT]` exemption
- `self.lobePinCircle` documented as legacy/unused; dropping it at the next regen is the follow-up
