### PR TITLE
fix rotted spur and helical sketch benches

### DIFF
--- a/.github/workflows/sketch-bench.yml
+++ b/.github/workflows/sketch-bench.yml
@@ -1,0 +1,45 @@
+name: sketch bench
+
+# Builds and runs the sketch-first proofs ([PB-SKETCH-FIRST]). A bench that stops
+# compiling — as both did when the engine added a context parameter to Solve and
+# Verify — is a silent loss of the only mechanical check the gear geometry has.
+#
+# The engine is tracked at its default branch on purpose, so that drift shows up
+# here as a red build instead of rotting unnoticed. It also means an unrelated
+# change in lestrrat-3d/sketch can turn this red; pin `ref:` to a commit if that
+# becomes noisy.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gear: [spurgear, helicalgear]
+    steps:
+      - name: Check out the gear repo
+        uses: actions/checkout@v4
+        with:
+          path: gears
+
+      - name: Check out the sketch engine
+        uses: actions/checkout@v4
+        with:
+          repository: lestrrat-3d/sketch
+          path: sketch
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: gears/spec/${{ matrix.gear }}/sketch/go.mod
+
+      - name: Run the ${{ matrix.gear }} bench
+        env:
+          SKETCH_DIR: ${{ github.workspace }}/sketch
+        run: ./run.sh
+        working-directory: gears/spec/${{ matrix.gear }}/sketch

--- a/.github/workflows/sketch-bench.yml
+++ b/.github/workflows/sketch-bench.yml
@@ -4,10 +4,11 @@ name: sketch bench
 # compiling — as both did when the engine added a context parameter to Solve and
 # Verify — is a silent loss of the only mechanical check the gear geometry has.
 #
-# The engine is tracked at its default branch on purpose, so that drift shows up
-# here as a red build instead of rotting unnoticed. It also means an unrelated
-# change in lestrrat-3d/sketch can turn this red; pin `ref:` to a commit if that
-# becomes noisy.
+# The engine is pinned to a commit, so a green build means the benches pass
+# against a known engine rather than against whatever landed on its main today.
+# lestrrat-3d/sketch publishes no tags, so a SHA is the only stable handle.
+# Bumping that SHA is a deliberate PR, and the benches are what decide whether
+# the new engine is acceptable.
 
 on:
   push:
@@ -32,6 +33,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: lestrrat-3d/sketch
+          # main @ 2026-07-13, "bump units to dimension-exponent kind api (#42)"
+          ref: e1313e1cd01c48635ceb5aff46aed2ded4925480
           path: sketch
 
       - uses: actions/setup-go@v5

--- a/spec/helicalgear/sketch/main.go
+++ b/spec/helicalgear/sketch/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -43,7 +44,7 @@ func dist(a, b pt) float64 { return math.Hypot(a.x-b.x, a.y-b.y) }
 // drawn at `helixAngle`) and returns whether it PASSES the primary
 // full-constraint gate. helixAngle is in radians; helixAngle==0 reduces to the
 // spur (untwisted) profile.
-func checkTwistedProfile(module, toothNumber, pressureAng, helixAngle float64, involSteps int) bool {
+func checkTwistedProfile(ctx context.Context, module, toothNumber, pressureAng, helixAngle float64, involSteps int) bool {
 	angle := helixAngle // the whole tooth is drawn pre-rotated by this (spur step 4)
 	pitchR := module * toothNumber / 2
 	baseR := pitchR * math.Cos(pressureAng)
@@ -70,12 +71,18 @@ func checkTwistedProfile(module, toothNumber, pressureAng, helixAngle float64, i
 	}
 	px, py, _ := calculateInvolutePoint(baseR, pitchR)
 	rotateAngle := math.Pi/(2*toothNumber) - math.Atan2(-py, px)
+	// The right flank is the mirror of the +X-symmetric LEFT flank, taken BEFORE
+	// the twist is applied; both are then swung by `angle` together. Mirroring
+	// after the swing leaves the tooth symmetric about +X rather than about the
+	// twist direction, which is a different (wrong) tooth at every angle != 0.
 	var left, right []pt
 	for _, p := range mirrored {
 		lx, ly := rot(p.x, p.y, rotateAngle)
+		rx, ry := lx, -ly
 		lx, ly = rot(lx, ly, angle)
+		rx, ry = rot(rx, ry, angle)
 		left = append(left, pt{lx, ly})
-		right = append(right, pt{lx, -ly})
+		right = append(right, pt{rx, ry})
 	}
 
 	w := sketch.NewWorld()
@@ -171,11 +178,11 @@ func checkTwistedProfile(module, toothNumber, pressureAng, helixAngle float64, i
 	rootArc := s.CreateArc(s.CreatePoint(rot(0, -rootR*0.1, angle)), rightFoot, leftFoot)
 	s.AddConstraint(sketch.NewDiameter(rootArc, 2*rootR))
 
-	res, err := s.Solve()
+	res, err := s.Solve(ctx)
 	if err != nil {
 		fmt.Println("solve error:", err)
 	}
-	rep := s.Verify(sketch.WithProbe())
+	rep := s.Verify(ctx, sketch.WithProbe())
 	fmt.Printf("Solve: converged=%v DOF=%d redundant=%d residual=%.1e | Verify: status=%s conditioning=%.2e\n",
 		res.Converged, res.DOF, res.Redundant, res.Residual, rep.Status, rep.Conditioning)
 
@@ -191,9 +198,10 @@ func main() {
 	const pa = 20.0 * math.Pi / 180.0
 	deg := func(d float64) float64 { return d * math.Pi / 180.0 }
 
+	ctx := context.Background()
 	allPass := true
 	check := func(m, n, helix float64) {
-		if !checkTwistedProfile(m, n, pa, helix, 15) {
+		if !checkTwistedProfile(ctx, m, n, pa, helix, 15) {
 			allPass = false
 		}
 	}

--- a/spec/spurgear/sketch/main.go
+++ b/spec/spurgear/sketch/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -39,7 +40,7 @@ func dist(a, b pt) float64 { return math.Hypot(a.x-b.x, a.y-b.y) }
 
 // checkGearProfile builds the spur Gear Profile sketch for the given parameters
 // and returns whether it PASSES the primary full-constraint gate.
-func checkGearProfile(module, toothNumber, pressureAng float64, involSteps int) bool {
+func checkGearProfile(ctx context.Context, module, toothNumber, pressureAng float64, involSteps int) bool {
 	const angle = 0.0 // spur seed tooth (helical/herringbone pass a nonzero angle)
 	pitchR := module * toothNumber / 2
 	baseR := pitchR * math.Cos(pressureAng)
@@ -66,12 +67,18 @@ func checkGearProfile(module, toothNumber, pressureAng float64, involSteps int) 
 	}
 	px, py, _ := calculateInvolutePoint(baseR, pitchR)
 	rotateAngle := math.Pi/(2*toothNumber) - math.Atan2(-py, px)
+	// The right flank is the mirror of the +X-symmetric LEFT flank, taken BEFORE
+	// the requested `angle` is applied; both are then swung by `angle` together.
+	// Mirroring after the swing would leave the tooth symmetric about +X instead
+	// of about the `angle` direction (no observable difference at angle == 0).
 	var left, right []pt
 	for _, p := range mirrored {
 		lx, ly := rot(p.x, p.y, rotateAngle)
+		rx, ry := lx, -ly
 		lx, ly = rot(lx, ly, angle)
+		rx, ry = rot(rx, ry, angle)
 		left = append(left, pt{lx, ly})
-		right = append(right, pt{lx, -ly})
+		right = append(right, pt{rx, ry})
 	}
 
 	w := sketch.NewWorld()
@@ -163,11 +170,11 @@ func checkGearProfile(module, toothNumber, pressureAng float64, involSteps int) 
 	s.AddConstraint(sketch.NewDiameter(rootArc, 2*rootR))
 
 	// --- solve & verify ---
-	res, err := s.Solve()
+	res, err := s.Solve(ctx)
 	if err != nil {
 		fmt.Println("solve error:", err)
 	}
-	rep := s.Verify(sketch.WithProbe())
+	rep := s.Verify(ctx, sketch.WithProbe())
 	fmt.Printf("Solve: converged=%v DOF=%d redundant=%d residual=%.1e | Verify: status=%s conditioning=%.2e profiles=%d\n",
 		res.Converged, res.DOF, res.Redundant, res.Residual, rep.Status, rep.Conditioning, len(rep.Profiles))
 
@@ -207,9 +214,10 @@ func main() {
 	}{
 		{1, 12}, {1, 17}, {2, 20}, {3, 15},
 	}
+	ctx := context.Background()
 	allPass := true
 	for _, c := range cases {
-		if !checkGearProfile(c.module, c.teeth, pa, 15) {
+		if !checkGearProfile(ctx, c.module, c.teeth, pa, 15) {
 			allPass = false
 		}
 	}


### PR DESCRIPTION
- pass `context.Context` to `Solve`/`Verify`; neither bench had compiled since the engine added it
- mirror the right flank pre-twist, matching `spurgear.py:229-232`
- both benches pass again: DOF=0, no redundant constraints, conditioning ~1e-3
