### PR TITLE
fix setByOffset offset type in spur spec

### DIFF
--- a/spec/spurgear/instructions.md
+++ b/spec/spurgear/instructions.md
@@ -379,7 +379,7 @@ So the rule is: pull every selection input (Parent, Target Plane, Anchor Point) 
 
 ### 1: Normalize the Target Plane
 
-If the user-selected plane is not already a `ConstructionPlane` (for example they picked a planar face of an existing body), create a coplanar construction plane via `ConstructionPlaneInput.setByOffset(selectedPlane, 0)` and use that for all subsequent operations. This keeps the downstream profile-detection code from having to filter out the selected face's native profile.
+If the user-selected plane is not already a `ConstructionPlane` (for example they picked a planar face of an existing body), create a coplanar construction plane via `ConstructionPlaneInput.setByOffset(selectedPlane, adsk.core.ValueInput.createByReal(0))` and use that for all subsequent operations. The offset argument is a **`ValueInput`, not a bare number** — `setByOffset(plane, 0)` is a runtime `TypeError` (`[PB-CONSTRUCTION-PLANES]` gives the signature). The same applies to the `Extrusion End Plane` in step 2: its `Thickness` offset is passed as `ValueInput.createByReal(thickness)`. This keeps the downstream profile-detection code from having to filter out the selected face's native profile.
 
 ### 2: Tools Sketch
 


### PR DESCRIPTION
- step 1 said `setByOffset(selectedPlane, 0)`, but the offset is a `ValueInput`; a bare number raises
- `spurgear.py:481` already does it right, so only the spec was wrong
- also states the rule for step 2's `Extrusion End Plane` offset
