### PR TITLE
fix provenance citation validation

### DIFF
--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -44,6 +44,10 @@ sys.path.insert(0, HERE)
 import fusion_api  # noqa: E402  (sibling module; sys.path is fixed up just above)
 
 MIN_CALL_LEN = 6
+PATH_REF = r'[\w./-]+\.(?:md|go|py|json|sh)'
+PATH_TOKEN = re.compile(r'`(%s)`' % PATH_REF)
+INLINE_CITATION = re.compile(r'`(%s):(\d+)(?:\s*[-\u2013]\s*(\d+))?`' % PATH_REF)
+LINE_RANGE = re.compile(r'\bL(\d+)(?:\s*[-\u2013]\s*(\d+))?\b')
 
 
 def provenance_inputs(gear):
@@ -77,16 +81,90 @@ def steps_of(src):
     return out
 
 
-def citations(body):
-    """Every (file, first, last) named by a step's From block."""
-    out = []
-    match = re.search(r'^\*\*From:\*\*(.*?)(?=\n\s*\n|$)', body, re.M | re.S)
+def from_block(body):
+    """The raw text after a step's From marker, if any."""
+    match = re.search(r'^\*\*From:\*\*(.*?)(?=\n\s*\n|\Z)', body, re.M | re.S)
     if not match:
-        return out
-    for m in re.finditer(r'`([\w./-]+\.(?:md|go)):(\d+)(?:-(\d+))?`', match.group(1)):
+        return None
+    return match.group(1)
+
+
+def citations_from_block(block):
+    """Every (file, first, last) named by a From block.
+
+    The committed step lists write citations as a backtick path followed by one or
+    more `L<line>` or `L<first>–<last>` ranges. Older inline
+    `` `path:line[-last]` `` citations remain parseable so fixtures and drafts
+    fail on validation, not on syntax churn.
+    """
+    out = []
+    for m in INLINE_CITATION.finditer(block):
         first = int(m.group(2))
         out.append((m.group(1), first, int(m.group(3) or first)))
+
+    paths = list(PATH_TOKEN.finditer(block))
+    for i, path_match in enumerate(paths):
+        end = paths[i + 1].start() if i + 1 < len(paths) else len(block)
+        for line_match in LINE_RANGE.finditer(block, path_match.end(), end):
+            first = int(line_match.group(1))
+            out.append((path_match.group(1), first, int(line_match.group(2) or first)))
     return out
+
+
+def resolve_citation_path(path, gear):
+    """Resolve a cited path from the repo root, with bare spec filenames allowed."""
+    if os.path.exists(path):
+        return path
+    spec_path = os.path.join('spec', gear, path)
+    if os.path.exists(spec_path):
+        return spec_path
+    return None
+
+
+def citation_label(path, first, last):
+    """A compact, actionable citation label for diagnostics."""
+    if first == last:
+        return '%s L%d' % (path, first)
+    return '%s L%d–%d' % (path, first, last)
+
+
+def validate_citations(body, gear):
+    """Return (valid citations, problems) for one step body."""
+    block = from_block(body)
+    if block is None or not block.strip():
+        return [], ["has no nonempty **From:** citation"]
+
+    parsed = citations_from_block(block)
+    if not parsed:
+        return [], ["has no parseable **From:** file-and-line citation; expected `path` L1 or "
+                    "`path` L1–2-style ranges"]
+
+    valid = []
+    problems = []
+    for path, first, last in parsed:
+        label = citation_label(path, first, last)
+        if first < 1 or last < 1:
+            problems.append("cites %s, but line numbers start at 1" % label)
+            continue
+        if first > last:
+            problems.append("cites %s, but the first line is after the last line" % label)
+            continue
+        full = resolve_citation_path(path, gear)
+        if full is None:
+            problems.append("cites %s, which does not exist" % path)
+            continue
+        total = len(read(full).splitlines())
+        if last > total:
+            problems.append("cites %s, but that file has %d lines" % (label, total))
+            continue
+        valid.append((full, first, last))
+    return valid, problems
+
+
+def citations(body, gear):
+    """Every valid (file, first, last) named by a step's From block."""
+    valid, _ = validate_citations(body, gear)
+    return valid
 
 
 # Framework modules the generated code calls into. The per-gear implementations are
@@ -210,23 +288,13 @@ def main(argv):
     # 1. citations resolve
     cited = {}
     for sid, _, body in steps:
-        from_match = re.search(r'^\*\*From:\*\*(.*?)(?=\n\s*\n|$)', body, re.M | re.S)
-        if not from_match or not from_match.group(1).strip():
-            problems.append("  %s has no nonempty **From:** citation" % sid)
-            continue
-        for path, first, last in citations(body):
+        valid, citation_problems = validate_citations(body, gear)
+        for problem in citation_problems:
+            problems.append("  %s %s" % (sid, problem))
+        for path, first, last in valid:
             if not path.endswith('.md'):
                 continue
-            full = path if os.path.exists(path) else os.path.join('spec', gear, path)
-            if not os.path.exists(full):
-                problems.append("  %s cites %s, which does not exist" % (sid, path))
-                continue
-            total = len(read(full).splitlines())
-            if last > total:
-                problems.append("  %s cites %s:%d-%d, but that file has %d lines"
-                                % (sid, path, first, last, total))
-                continue
-            cited.setdefault(full, set()).update(range(first, last + 1))
+            cited.setdefault(path, set()).update(range(first, last + 1))
 
     # 2. steps and proof agree
     functions = proof_functions(proof_dir)

--- a/.claude/skills/generate-gear/test_check_step_calls.py
+++ b/.claude/skills/generate-gear/test_check_step_calls.py
@@ -117,7 +117,19 @@ class CheckApiCallsTest(unittest.TestCase):
 
 
 class CheckCompileTest(unittest.TestCase):
-    def run_checker(self, provenance, from_line='**From:** `instructions.md:1`'):
+    SOURCE_PATHS = (
+        'spec/gear/instructions.md',
+        'spec/gear/fusion.md',
+        '.claude/skills/generate-gear/PLAYBOOK.md',
+    )
+
+    def provenance_rows(self, root, paths=None):
+        paths = paths or self.SOURCE_PATHS
+        return '\n'.join(
+            '| `%s` | `%s` |' % (path, COMPILE_CHECKER.blob_hash(str(root / path)))
+            for path in paths)
+
+    def run_checker(self, provenance=None, from_line='**From:** `spec/gear/instructions.md` L1'):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / 'spec' / 'gear').mkdir(parents=True)
@@ -127,7 +139,9 @@ class CheckCompileTest(unittest.TestCase):
                     root / 'spec' / 'gear' / 'instructions.md',
                     root / 'spec' / 'gear' / 'fusion.md',
                     root / '.claude' / 'skills' / 'generate-gear' / 'PLAYBOOK.md'):
-                path.write_text('source\n')
+                path.write_text('source\nline two\nline three\n')
+            if provenance is None:
+                provenance = self.provenance_rows(root)
             (root / 'proof' / 'gear' / 'proof.go').write_text('func stepOne() {}\n')
             table = '\n'.join((
                 '| Source | Blob hash |',
@@ -153,26 +167,55 @@ class CheckCompileTest(unittest.TestCase):
                 os.chdir(prior)
             return result, output.getvalue()
 
-    def complete_provenance(self):
-        return (
-            '| `spec/gear/instructions.md` | `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |\n'
-            '| `spec/gear/fusion.md` | `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |\n'
-            '| `.claude/skills/generate-gear/PLAYBOOK.md` | `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |'
-        )
-
     def test_all_declared_compile_inputs_are_required(self):
-        provenance = self.complete_provenance().splitlines()[:-1]
-
-        result, output = self.run_checker('\n'.join(provenance))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for path in self.SOURCE_PATHS:
+                (root / path).parent.mkdir(parents=True, exist_ok=True)
+                (root / path).write_text('source\nline two\nline three\n')
+            provenance = self.provenance_rows(root, self.SOURCE_PATHS[:-1])
+        result, output = self.run_checker(provenance)
 
         self.assertEqual(result, 1)
         self.assertIn('provenance omits required source', output)
 
     def test_each_step_requires_a_from_citation(self):
-        result, output = self.run_checker(self.complete_provenance(), from_line='')
+        result, output = self.run_checker(from_line='')
 
         self.assertEqual(result, 1)
         self.assertIn('has no nonempty **From:** citation', output)
+
+    def test_prose_only_from_block_is_not_a_citation(self):
+        result, output = self.run_checker(from_line='**From:** the gear instructions prose')
+
+        self.assertEqual(result, 1)
+        self.assertIn('has no parseable **From:** file-and-line citation', output)
+
+    def test_citation_line_zero_is_rejected(self):
+        result, output = self.run_checker(from_line='**From:** `spec/gear/instructions.md` L0')
+
+        self.assertEqual(result, 1)
+        self.assertIn('line numbers start at 1', output)
+
+    def test_citation_reversed_range_is_rejected(self):
+        result, output = self.run_checker(from_line='**From:** `spec/gear/instructions.md` L3–2')
+
+        self.assertEqual(result, 1)
+        self.assertIn('first line is after the last line', output)
+
+    def test_citation_out_of_range_is_rejected(self):
+        result, output = self.run_checker(from_line='**From:** `spec/gear/instructions.md` L1–4')
+
+        self.assertEqual(result, 1)
+        self.assertIn('but that file has 3 lines', output)
+
+    def test_current_format_citation_is_valid(self):
+        result, output = self.run_checker(
+            from_line='**From:** `spec/gear/instructions.md` L1-2,\n'
+            'L3; `spec/gear/fusion.md` L1–2')
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR #27 findings: `review-27-6.a2.findings.jsonl`, `audit-27-6.jsonl`
- Prose-only `From` blocks and malformed ranges such as `L0` passed.

### Root cause and fix
- Citation checks were weak; the checker now parses `path` plus `L` ranges and validates file line bounds.

### Changed files
- `.claude/skills/generate-gear/check_compile.py`
- `.claude/skills/generate-gear/test_check_step_calls.py`

### Verification
- `python3 .claude/skills/generate-gear/test_check_step_calls.py`
- `python3 .claude/skills/generate-gear/check_compile.py spurgear`
