### PR TITLE
fail all-skipped 3d proof tables

### DIFF
--- a/proof/proofkit/proofkit.go
+++ b/proof/proofkit/proofkit.go
@@ -46,18 +46,26 @@ type Build func(t testing.TB, s *sketch.Sketch, p map[string]float64)
 // Run proves build against every case, one subtest each.
 //
 // Each case gets a fresh world and sketch, and is gated with [RequireSound]
-// after build returns. A case that fails does not stop the others.
+// after build returns. A case that fails does not stop the others. At least one
+// case must complete; a proof table where every case is unmodelled proves no
+// sketch.
 func Run(t *testing.T, cases []Case, build Build) {
 	t.Helper()
 	if len(cases) == 0 {
 		t.Fatal("proofkit: no cases — a proof with nothing to prove passes vacuously")
 	}
+	completed := 0
 	for _, c := range cases {
+		c := c
 		t.Run(c.Name, func(t *testing.T) {
 			s := NewSketch(t)
 			build(t, s, c.Params)
 			RequireSound(t, s)
+			completed++
 		})
+	}
+	if completed == 0 && !t.Failed() {
+		t.Fatal("proofkit: no non-skipped proof cases completed — every proof must prove at least one sketch")
 	}
 }
 

--- a/proof/proofkit/proofkit_test.go
+++ b/proof/proofkit/proofkit_test.go
@@ -1,0 +1,65 @@
+package proofkit
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-3d/sketch"
+)
+
+const skipCase = "skip"
+
+func TestRunAllowsCompletedCase(t *testing.T) {
+	var built int
+	Run(t, []Case{
+		{Name: "complete", Params: map[string]float64{}},
+	}, countingBuild(&built))
+
+	if built != 1 {
+		t.Fatalf("completed case count: build=%d", built)
+	}
+}
+
+func TestRunAllowsMixedCompletedAndSkippedCases(t *testing.T) {
+	var built int
+	Run(t, []Case{
+		{Name: "skipped", Params: map[string]float64{skipCase: 1}},
+		{Name: "complete", Params: map[string]float64{}},
+	}, countingBuild(&built))
+
+	if built != 2 {
+		t.Fatalf("mixed case count: build=%d", built)
+	}
+}
+
+func TestRunRejectsAllSkippedCases(t *testing.T) {
+	if os.Getenv("PROOFKIT_ALL_SKIPPED_HELPER") == "1" {
+		Run(t, []Case{
+			{Name: "skipped", Params: map[string]float64{skipCase: 1}},
+		}, countingBuild(new(int)))
+		t.Fatal("Run returned after every case skipped")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunRejectsAllSkippedCases$")
+	cmd.Env = append(os.Environ(), "PROOFKIT_ALL_SKIPPED_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("all-skipped Run passed; output:\n%s", output)
+	}
+	if !strings.Contains(string(output), "proofkit: no non-skipped proof cases completed") {
+		t.Fatalf("all-skipped failure did not explain the invariant; output:\n%s", output)
+	}
+}
+
+func countingBuild(count *int) Build {
+	return func(t testing.TB, s *sketch.Sketch, params map[string]float64) {
+		(*count)++
+		if params[skipCase] == 1 {
+			Unmodelled(t, "fixture case is intentionally unsupported")
+		}
+		anchor := s.CreateReferencePoint(0, 0, "anchorPoint")
+		anchor.SetName("fixture anchor")
+	}
+}

--- a/proof/proofkit3d/proofkit3d.go
+++ b/proof/proofkit3d/proofkit3d.go
@@ -33,7 +33,9 @@ func RunSolid(t *testing.T, cases []Case, build Build, assert Assert) {
 	RunWithGate(t, cases, build, RequireSolid, assert)
 }
 
-// RunWithGate proves every case with the supplied verification gate.
+// RunWithGate proves every case with the supplied verification gate. At least
+// one case must complete; a proof table where every case is unmodelled proves
+// no solid.
 func RunWithGate(t *testing.T, cases []Case, build Build, gate Gate, assert Assert) {
 	t.Helper()
 	if len(cases) == 0 {
@@ -48,6 +50,7 @@ func RunWithGate(t *testing.T, cases []Case, build Build, gate Gate, assert Asse
 	if assert == nil {
 		t.Fatal("proofkit3d: nil assertion function")
 	}
+	completed := 0
 	for _, c := range cases {
 		c := c
 		t.Run(c.Name, func(t *testing.T) {
@@ -55,7 +58,11 @@ func RunWithGate(t *testing.T, cases []Case, build Build, gate Gate, assert Asse
 			bodies := build(t, doc, c.Params)
 			gate(t, doc, bodies)
 			assert(t, doc, bodies, c.Params)
+			completed++
 		})
+	}
+	if completed == 0 && !t.Failed() {
+		t.Fatal("proofkit3d: no non-skipped proof cases completed — every proof must prove at least one solid")
 	}
 }
 

--- a/proof/proofkit3d/proofkit3d_test.go
+++ b/proof/proofkit3d/proofkit3d_test.go
@@ -1,0 +1,76 @@
+package proofkit3d
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-3d/decad"
+)
+
+const skipCase = "skip"
+
+func TestRunWithGateAllowsCompletedCase(t *testing.T) {
+	var built, gated, asserted int
+	RunWithGate(t, []Case{
+		{Name: "complete", Params: map[string]float64{}},
+	}, countingBuild(&built), countingGate(&gated), countingAssert(&asserted))
+
+	if built != 1 || gated != 1 || asserted != 1 {
+		t.Fatalf("completed case counts: build=%d gate=%d assert=%d", built, gated, asserted)
+	}
+}
+
+func TestRunWithGateAllowsMixedCompletedAndSkippedCases(t *testing.T) {
+	var built, gated, asserted int
+	RunWithGate(t, []Case{
+		{Name: "skipped", Params: map[string]float64{skipCase: 1}},
+		{Name: "complete", Params: map[string]float64{}},
+	}, countingBuild(&built), countingGate(&gated), countingAssert(&asserted))
+
+	if built != 2 || gated != 1 || asserted != 1 {
+		t.Fatalf("mixed case counts: build=%d gate=%d assert=%d", built, gated, asserted)
+	}
+}
+
+func TestRunWithGateRejectsAllSkippedCases(t *testing.T) {
+	if os.Getenv("PROOFKIT3D_ALL_SKIPPED_HELPER") == "1" {
+		RunWithGate(t, []Case{
+			{Name: "skipped", Params: map[string]float64{skipCase: 1}},
+		}, countingBuild(new(int)), countingGate(new(int)), countingAssert(new(int)))
+		t.Fatal("RunWithGate returned after every case skipped")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunWithGateRejectsAllSkippedCases$")
+	cmd.Env = append(os.Environ(), "PROOFKIT3D_ALL_SKIPPED_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("all-skipped RunWithGate passed; output:\n%s", output)
+	}
+	if !strings.Contains(string(output), "proofkit3d: no non-skipped proof cases completed") {
+		t.Fatalf("all-skipped failure did not explain the invariant; output:\n%s", output)
+	}
+}
+
+func countingBuild(count *int) Build {
+	return func(t *testing.T, _ *decad.Document, params map[string]float64) []*decad.Body {
+		(*count)++
+		if params[skipCase] == 1 {
+			Unmodelled(t, "fixture case is intentionally unsupported")
+		}
+		return nil
+	}
+}
+
+func countingGate(count *int) Gate {
+	return func(t *testing.T, _ *decad.Document, _ []*decad.Body) {
+		(*count)++
+	}
+}
+
+func countingAssert(count *int) Assert {
+	return func(t *testing.T, _ *decad.Document, _ []*decad.Body, _ map[string]float64) {
+		(*count)++
+	}
+}


### PR DESCRIPTION
- Prevents vacuous green proof tables where every case calls `Unmodelled`.
- Enforces one completed proof case for both `proofkit.Run` and `proofkit3d.RunWithGate`.
- Covers all-skipped failure and mixed skipped/completed cases for both runners.
