### PR TITLE
gate proof regression tests in CI

### DIFF
--- a/.claude/skills/generate-gear/test_check_step_calls.py
+++ b/.claude/skills/generate-gear/test_check_step_calls.py
@@ -90,6 +90,8 @@ class CheckApiCallsTest(unittest.TestCase):
                     API_CHECKER.fusion_api, 'lookup_many',
                     side_effect=lambda names: {name: [] for name in names}), \
                     mock.patch.object(API_CHECKER.fusion_api, 'similar', return_value=[]), \
+                    mock.patch.object(API_CHECKER.fusion_api, 'query_script',
+                                      return_value='/hermetic/fusion-query-api.py'), \
                     contextlib.redirect_stdout(output):
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore', ResourceWarning)

--- a/.github/workflows/3d-proof.yml
+++ b/.github/workflows/3d-proof.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           go-version-file: gears/proof/go.mod
 
+      - name: Run step-call checker regression tests
+        run: python3 .claude/skills/generate-gear/test_check_step_calls.py
+        working-directory: gears
+
+      - name: Run proof runner regression tests
+        run: bash proof/run_test.sh
+        working-directory: gears
+
       - name: Run the 3D proof
         env:
           SKETCH_DIR: ${{ github.workspace }}/sketch

--- a/proof/run_test.sh
+++ b/proof/run_test.sh
@@ -18,8 +18,8 @@ printf 'module github.com/lestrrat-3d/sketch\ngo 1.26.1\n' > "$fixture/sketch/go
 printf 'module github.com/lestrrat-3d/decad\ngo 1.26.1\n' > "$fixture/decad/go.mod"
 
 output=$(cd "$fixture/repo/proof" && ./run.sh)
-printf '%s\n' "$output" | rg -Fq "using sketch engine at: $fixture/repo/../sketch"
-printf '%s\n' "$output" | rg -Fq "using decad engine at: $fixture/repo/../decad"
+printf '%s\n' "$output" | grep -Fq "using sketch engine at: $fixture/repo/../sketch"
+printf '%s\n' "$output" | grep -Fq "using decad engine at: $fixture/repo/../decad"
 
 first_output="$fixture/first.out"
 second_output="$fixture/second.out"
@@ -42,9 +42,9 @@ second_status=$?
 set -e
 test "$first_status" -eq 0
 test "$second_status" -eq 0
-rg -Fq "using sketch engine at: $fixture/repo/../sketch" "$first_output"
-rg -Fq "using sketch engine at: $fixture/repo/../sketch" "$second_output"
-rg -Fq "using decad engine at: $fixture/repo/../decad" "$first_output"
-rg -Fq "using decad engine at: $fixture/repo/../decad" "$second_output"
+grep -Fq "using sketch engine at: $fixture/repo/../sketch" "$first_output"
+grep -Fq "using sketch engine at: $fixture/repo/../sketch" "$second_output"
+grep -Fq "using decad engine at: $fixture/repo/../decad" "$first_output"
+grep -Fq "using decad engine at: $fixture/repo/../decad" "$second_output"
 
 printf '%s\n' 'proof/run.sh path fixture: OK'


### PR DESCRIPTION
- PR #27 only ran `proof/run.sh`, so CI missed checker and proof-runner regressions.
- checker regression now runs without relying on a local Fusion plugin install.
- verified with the checker and proof-runner regression commands.
