### PR TITLE
fix spur root endpoint constraints

### DIFF
--- a/lib/geargen/spurgear.py
+++ b/lib/geargen/spurgear.py
@@ -336,10 +336,23 @@ class SpurGearInvoluteToothDesignGenerator:
         rootEnd = adsk.core.Point3D.create(rootR * g.x / n, rootR * g.y / n, 0)
         # Share the flank start SketchPoint directly as the far endpoint.
         line = sketch.sketchCurves.sketchLines.addByTwoPoints(rootEnd, flankStart)
-        # (a) root end on the root circle.
-        sketch.geometricConstraints.addCoincident(line.startSketchPoint, self.rootCircle)
-        # (b) local origin on the line (radial direction).
-        sketch.geometricConstraints.addCoincident(origin, line)
+        rootEndPoint = line.startSketchPoint
+        og = origin.geometry
+        dx = rootEnd.x - og.x
+        dy = rootEnd.y - og.y
+        # Exactly two signed dimensions from the local origin. Do not constrain
+        # the root endpoint to the root circle or the origin to this line: that
+        # leaves the far-side root-circle intersection available too.
+        horizontalDimension = sketch.sketchDimensions.addDistanceDimension(
+            origin, rootEndPoint,
+            adsk.fusion.DimensionOrientations.HorizontalDimensionOrientation,
+            adsk.core.Point3D.create(og.x + dx / 2, og.y, 0))
+        horizontalDimension.parameter.value = dx
+        verticalDimension = sketch.sketchDimensions.addDistanceDimension(
+            origin, rootEndPoint,
+            adsk.fusion.DimensionOrientations.VerticalDimensionOrientation,
+            adsk.core.Point3D.create(rootEnd.x, og.y + dy / 2, 0))
+        verticalDimension.parameter.value = dy
 
     def drawBore(self, anchorPoint, diameter):
         sketch = self.sketch

--- a/proof/spurgear/root_constraints_test.go
+++ b/proof/spurgear/root_constraints_test.go
@@ -1,0 +1,86 @@
+package spurgear_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRootEndSignedConstraintRecipeDoesNotDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		file string
+		want []string
+		ban  []string
+	}{
+		{
+			name: "generator",
+			file: "lib/geargen/spurgear.py",
+			want: []string{
+				"addDistanceDimension(\n            origin, rootEndPoint,\n            adsk.fusion.DimensionOrientations.HorizontalDimensionOrientation",
+				"addDistanceDimension(\n            origin, rootEndPoint,\n            adsk.fusion.DimensionOrientations.VerticalDimensionOrientation",
+				"horizontalDimension.parameter.value = dx",
+				"verticalDimension.parameter.value = dy",
+			},
+			ban: []string{
+				"addCoincident(line.startSketchPoint, self.rootCircle)",
+				"addCoincident(origin, line)",
+			},
+		},
+		{
+			name: "sketch prototype",
+			file: "spec/spurgear/sketch/main.go",
+			want: []string{
+				"sketch.NewHorizontalDistance(origin, re, rx)",
+				"sketch.NewVerticalDistance(origin, re, ry)",
+			},
+			ban: []string{
+				"sketch.NewPointOnCircle(re, rootCircle)",
+				"sketch.NewPointOnLine(origin, line)",
+			},
+		},
+		{
+			name: "sketch README",
+			file: "spec/spurgear/sketch/README.md",
+			want: []string{
+				"flank-to-root lines: root endpoint pinned by signed Δx and Δy from the local origin",
+				"NewHorizontalDistance(origin, rootEnd, dx)",
+				"NewVerticalDistance(origin, rootEnd, dy)",
+			},
+			ban: []string{
+				"flank-to-root lines: root-end-on-circle + origin-on-line",
+				"NewPointOnCircle` + `NewPointOnLine",
+				"origin-on-line\" constraint",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := os.ReadFile(repoPath(t, tc.file))
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.file, err)
+			}
+			text := string(data)
+			for _, want := range tc.want {
+				if !strings.Contains(text, want) {
+					t.Fatalf("%s no longer contains required root-end signed-dimension text %q", tc.file, want)
+				}
+			}
+			for _, ban := range tc.ban {
+				if strings.Contains(text, ban) {
+					t.Fatalf("%s contains rejected root-end coincidence recipe %q", tc.file, ban)
+				}
+			}
+		})
+	}
+}
+
+func repoPath(t *testing.T, rel string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", rel)
+}

--- a/proof/spurgear/spurgear_test.go
+++ b/proof/spurgear/spurgear_test.go
@@ -344,11 +344,12 @@ func stepGearProfileSketch(t testing.TB, s *sketch.Sketch, p map[string]float64)
 			rx, ry := f.at.X*scale, f.at.Y*scale
 			rootEnd := s.CreatePoint(rx, ry)
 			rootEnd.SetName(f.name + " flank root end")
-			s.CreateLine(rootEnd, f.end) // solid: it is part of the tooth loop
+			stub := s.CreateLine(rootEnd, f.end) // solid: it is part of the tooth loop
 			s.AddConstraint(
 				sketch.NewHorizontalDistance(origin, rootEnd, rx),
 				sketch.NewVerticalDistance(origin, rootEnd, ry),
 			)
+			checkRootEndConstraintRecipe(t, s, origin, rootEnd, stub)
 		}
 	}
 
@@ -384,6 +385,36 @@ func axisName(vertical bool) string {
 		return "vertical"
 	}
 	return "horizontal"
+}
+
+func checkRootEndConstraintRecipe(t testing.TB, s *sketch.Sketch, origin, rootEnd *sketch.Point, stub *sketch.Line) {
+	t.Helper()
+
+	var horizontal, vertical int
+	var rejected []string
+	for _, c := range s.Constraints() {
+		kind := sketch.ConstraintKind(c)
+		pts, ents := sketch.ConstraintRefs(c)
+		if kind == "hdistance" && len(pts) == 2 && pts[0] == origin && pts[1] == rootEnd {
+			horizontal++
+			continue
+		}
+		if kind == "vdistance" && len(pts) == 2 && pts[0] == origin && pts[1] == rootEnd {
+			vertical++
+			continue
+		}
+		if kind == "point_on_circle" && len(pts) == 1 && pts[0] == rootEnd {
+			rejected = append(rejected, "root end on root circle")
+			continue
+		}
+		if kind == "point_on_line" && len(pts) == 1 && pts[0] == origin && len(ents) == 1 && ents[0] == stub {
+			rejected = append(rejected, "local origin on flank-to-root line")
+		}
+	}
+	if horizontal != 1 || vertical != 1 || len(rejected) > 0 {
+		t.Fatalf("root endpoint constraints must be exactly signed horizontal+vertical dimensions from the local origin; got horizontal=%d vertical=%d rejected=%v",
+			horizontal, vertical, rejected)
+	}
 }
 
 // stepBoreProfileSketch proves S14, the Bore Profile sketch.

--- a/spec/spurgear/sketch/README.md
+++ b/spec/spurgear/sketch/README.md
@@ -47,7 +47,7 @@ prescribe, mapping each Fusion constraint to its sketch-engine equivalent:
 | tooth-top arc `addByCenterStartEnd` without a diameter; root-circle split (`[SPUR-F-TOOTHTOP-ARC]`) | `CreateArc(origin, a, b)`; root split uses `CreateArc(freeCenter, a, b)` + `NewDiameter` |
 | +X reference and angular pin (`[SPUR-F-SPINE]`, every angle) | `NewHorizontalDistance` + `NewVerticalDistance` + `NewAngle` |
 | ribs: signed across-spine dimension, midpoint-on-spine, midpoint, ⊥ except on the final rib, signed along-spine chain dims (`[SPUR-F-RIBS]`) | `NewHorizontalDistance` or `NewVerticalDistance` by axis, `NewPointOnLine`, `NewMidpoint`, `NewPerpendicular` except on the final rib |
-| flank-to-root lines: root-end-on-circle + origin-on-line (`[SPUR-F-FLANK-ROOT]`) | `NewPointOnCircle` + `NewPointOnLine` |
+| flank-to-root lines: root endpoint pinned by signed Δx and Δy from the local origin (`[SPUR-F-FLANK-ROOT]`) | `NewHorizontalDistance(origin, rootEnd, dx)` + `NewVerticalDistance(origin, rootEnd, dy)` |
 
 The involute sampling (`calculateInvolutePoint`, the mirror/rotate) is the spec's
 exact math. The check runs across several `Module` / `Tooth Number` sizes and zero,
@@ -84,11 +84,9 @@ all of solvable + DOF 0 + no redundant + no conflict.
 ## A fragility the gate catches
 
 Near the embedded transition (`base ≈ root`, about `N = 42` at 20° pressure
-angle) the flank-to-root stubs shrink toward zero length and the "origin-on-line"
-constraint through two near-coincident points turns ill-conditioned: e.g.
-`M=1.5, N=40` gives `Conditioning ≈ 1.6e-8` and the solve fails to converge. That
-is a real fragility surfaced here rather than in Fusion. The healthy sizes this
-proof runs are comfortably clear of it.
+angle) the flank-to-root stubs shrink toward zero length, which leaves the root
+endpoint signed offsets close to the flank start. The healthy sizes this proof
+runs are comfortably clear of it.
 
 ## Scope
 

--- a/spec/spurgear/sketch/main.go
+++ b/spec/spurgear/sketch/main.go
@@ -97,7 +97,7 @@ func checkGearProfile(ctx context.Context, module, toothNumber, pressureAng, ang
 		s.AddConstraint(sketch.NewDiameter(c, 2*r))
 		return c
 	}
-	rootCircle := mkCircle(rootR)
+	mkCircle(rootR)
 	tipCircle := mkCircle(tipR)
 	mkCircle(baseR)
 	mkCircle(pitchR)
@@ -168,13 +168,16 @@ func checkGearProfile(ctx context.Context, module, toothNumber, pressureAng, ang
 	}
 
 	// flank-to-root lines (non-embedded): radial line root circle -> flank start,
-	// with exactly two constraints ([SPUR-F-FLANK-ROOT]).
+	// with exactly two signed dimensions from the local origin ([SPUR-F-FLANK-ROOT]).
 	addFlankRoot := func(flankStart *sketch.Point, seed pt) *sketch.Point {
 		n := math.Hypot(seed.x, seed.y)
-		re := s.CreatePoint(rootR*seed.x/n, rootR*seed.y/n)
-		line := s.CreateLine(re, flankStart)
-		s.AddConstraint(sketch.NewPointOnCircle(re, rootCircle)) // (a) root end on root circle
-		s.AddConstraint(sketch.NewPointOnLine(origin, line))     // (b) origin on line (radial)
+		rx, ry := rootR*seed.x/n, rootR*seed.y/n
+		re := s.CreatePoint(rx, ry)
+		s.CreateLine(re, flankStart)
+		s.AddConstraint(
+			sketch.NewHorizontalDistance(origin, re, rx),
+			sketch.NewVerticalDistance(origin, re, ry),
+		)
 		return re
 	}
 	leftFoot := addFlankRoot(leftPts[0], left[0])


### PR DESCRIPTION
- keep spur root endpoints on signed Δx/Δy offsets
- align the proof and sketch prototype with the spec
- guard against the rejected root-circle coincidence recipe
