### PR TITLE
gate misnamed proof run build arguments

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -15,7 +15,9 @@ until the proof is green and both describe the same build.
 ## Inputs
 
 - `gear` (default `spurgear`) names `spec/<gear>/instructions.md` and the outputs
-  `spec/<gear>/steps.md` and `proof/<gear>/<gear>_test.go`.
+  `spec/<gear>/steps.md` and the proof directory `proof/<gear>/`. The proof is a directory, not a
+  single file: a gear splits its sketch proof, its solid proof and the geometry they share across
+  as many Go files as the split needs.
 
 ## What a step is
 
@@ -24,13 +26,22 @@ geometry and however many constraints go into it. Each extrude, chamfer, pattern
 fillet is a step. The detail inside one step stays inside it rather than being split across
 several.
 
-A step is `[GO]` when the proof exercises it and `[PROSE]` when nothing can. Everything 3D is
-`[PROSE]` until `decad` can carry these shapes.
+A step is `[GO]` when one of the two harnesses can exercise it. `proofkit` covers the sketch and
+constraint steps, in the sketch engine. `proofkit3d` covers the solid steps, in `decad`, which
+builds bodies by extrude, revolve and loft, combines them with union, cut and intersect, blends
+their edges with chamfer and fillet, hollows one with shell, and repeats one as placed copies,
+which is how a pattern is expressed.
+
+A step is `[PROSE]` when neither harness reaches it: reading the dialog, creating the component and
+registering its parameters, visibility and cleanup, and any solid operation `decad` cannot
+represent. `[PROSE]` says something about the harnesses, not about the dimension. A 3D step whose
+shape `decad` can build is `[GO]` like any other.
 
 ## Procedure
 
 1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Read this file,
-   `PLAYBOOK.md`, the gear's spec end to end, and `proof/proofkit/` for the harness API.
+   `PLAYBOOK.md`, the gear's spec end to end, and both harness APIs, `proof/proofkit/` and
+   `proof/proofkit3d/`.
 
 2. **Record provenance.** Use the provenance input set owned by
    `.claude/skills/generate-gear/check_compile.py`: existing `spec/<gear>/instructions.md`, optional
@@ -40,12 +51,12 @@ A step is `[GO]` when the proof exercises it and `[PROSE]` when nothing can. Eve
    steps cite its rules by anchor, so a playbook fix leaves every step list stale until it is recompiled.
 
 3. **Draft.** Spawn a subagent with the verbatim prompt in the appendix, substituting only
-   `<gear>`. It writes `.tmp/<gear>.steps.md` and `.tmp/<gear>_test.go`. Do **not** add per-gear
-   hints, gotcha reminders or "high-risk" lists to that prompt. A hand-tuned prompt varies run to
-   run and hides gaps by spoon-feeding what the prose should have said, so a green run would no
-   longer say anything about the spec.
+   `<gear>`. It writes `.tmp/<gear>.steps.md` and the proof files under `.tmp/<gear>-proof/`. Do
+   **not** add per-gear hints, gotcha reminders or "high-risk" lists to that prompt. A hand-tuned
+   prompt varies run to run and hides gaps by spoon-feeding what the prose should have said, so a
+   green run would no longer say anything about the spec.
 
-4. **Run the proof.** Copy the drafted test into `proof/<gear>/` and run
+4. **Run the proof.** Copy every drafted proof file into `proof/<gear>/` and run
    `bash proof/run.sh`. The wrapper enters the `proof/` module and configures the local engine
    replacements; the proof must pass with nothing waived.
 
@@ -57,8 +68,8 @@ A step is `[GO]` when the proof exercises it and `[PROSE]` when nothing can. Eve
 6. **Diagnose and loop.** Classify any failure with the table below. A draft fault goes back to
    step 3 with the failure text appended, up to about three rounds. A prose fault stops the run.
 
-7. **Place.** On success, move both drafts into the working tree. This writes files only; it does
-   not commit, push, or touch Fusion's add-in directory.
+7. **Place.** On success, move the drafted step list and every drafted proof file into the working
+   tree. This writes files only; it does not commit, push, or touch Fusion's add-in directory.
 
 8. **Report.** State what was produced, the coverage list, and every prose fault found.
 
@@ -73,6 +84,7 @@ A step is `[GO]` when the proof exercises it and `[PROSE]` when nothing can. Eve
 | A provenance hash does not match | Draft fault, or someone edited the spec mid-run |
 | **A named API call does not exist, and the spec named it** | **Prose fault** |
 | **The proof cannot fully constrain after three rounds** | **Prose fault** |
+| **The proof cannot build a sound solid after three rounds** | **Prose fault** |
 | **The drafter reports the spec as contradictory** | **Prose fault** |
 
 The two bold API rows are the same check with different blame. When the spec itself writes
@@ -94,11 +106,14 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 ## Standard drafting prompt (use verbatim — substitute only `<gear>`)
 
 > Compile the specification for `<gear>` into a step list and a runnable proof. Work in the repo
-> worktree. Write `.tmp/<gear>.steps.md` and `.tmp/<gear>_test.go`.
+> worktree. Write the step list to `.tmp/<gear>.steps.md`, and the proof, as one or more Go files,
+> to `.tmp/<gear>-proof/`.
 >
 > **Read, in full, only these:** `spec/<gear>/instructions.md`, `spec/<gear>/fusion.md` if it
-> exists, every document those reference by name, `.claude/skills/generate-gear/PLAYBOOK.md`, and
-> `proof/proofkit/` for the harness API.
+> exists, every document those reference by name, `.claude/skills/generate-gear/PLAYBOOK.md`,
+> `proof/proofkit/` for the sketch harness API, `proof/proofkit3d/` for the solid harness API, and
+> `proof/involute/` for the involute tooth math the spur family shares, so you import it rather
+> than deriving it again.
 >
 > **Do not read** `lib/geargen/<gear>.py`, any other gear's implementation, or a previous
 > `steps.md` or proof for this gear. If the spec is unclear, record it as a spec gap in your report
@@ -127,18 +142,43 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > a call the API does not have, or passes an argument of the wrong type, say so in your report and
 > do not quietly correct it.
 >
-> **The proof is a Go test** in package `<gear>_test`, with one function per step named
-> `step<Title>`, matching what the step list names. It builds a table of parameter cases and runs
-> them through `proofkit.Run`. Model what Fusion does: use `CreateReferencePoint` for anything
-> projected in rather than fixing coordinates, mark solid and construction geometry as Fusion
-> would, and let profile detection split curves at crossings rather than drawing boundary arcs by
-> hand. Call `proofkit.Step` as you move between parts of a step, and `proofkit.Unmodelled` for a
-> case the proof cannot represent, never a silent return.
+> **The proof is a Go test** in package `<gear>_test`, spread over as many files as the split
+> needs, with one function per step. Every step function, 2D or 3D alike, is named `step<Title>`,
+> matching what the step list names, and is passed as the build argument — the third — to a
+> `proofkit.Run`, `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` call inside a
+> Go `Test` function. A build function under any other name, or one no `Test` reaches, is invisible
+> to the gate, and the step naming it fails the check. Each run takes a table of parameter cases,
+> one subtest each.
 >
-> **The proof must pass with nothing waived.** `proofkit` gates on the engine's full verdict,
-> including that the constraints admit only one solution. A scheme that reaches DOF 0 but still
-> allows a mirrored or rotated answer fails, and the fix is a constraint that carries a direction,
+> **A sketch step** builds through `proofkit.Run`, whose build function is
+> `func(t testing.TB, s *sketch.Sketch, p map[string]float64)`. Model what Fusion does: use
+> `CreateReferencePoint` for anything projected in rather than fixing coordinates, mark solid and
+> construction geometry as Fusion would, and let profile detection split curves at crossings rather
+> than drawing boundary arcs by hand. Call `proofkit.Step` as you move between parts of a step, and
+> `proofkit.Unmodelled` for a case the proof cannot represent, never a silent return.
+>
+> **A solid step** builds through `proofkit3d`, whose build function is
+> `func(t *testing.T, doc *decad.Document, params map[string]float64) []*decad.Body` and returns
+> the bodies the step leaves behind. Every `proofkit3d` run also takes an assertion,
+> `func(t *testing.T, doc *decad.Document, bodies []*decad.Body, params map[string]float64)`, which
+> runs after the gate and checks the measurements the step is supposed to produce; it is required,
+> and a nil one fails the run. `proofkit3d.Unmodelled` is the 3D counterpart of
+> `proofkit.Unmodelled`, for a case `decad` cannot represent.
+>
+> **The proof must pass with nothing waived.** `proofkit` gates a sketch on
+> `sketch.VerificationReport.Check`, which asks for more than DOF 0: no conflicting or redundant
+> constraint, no stale or broken reference geometry, valid profiles, a system that is not
+> near-singular, and no discrete ambiguity. A scheme that reaches DOF 0 but still allows a mirrored
+> or 180-degree-rotated answer fails there, and the fix is a constraint that carries a direction,
 > not a comment.
+>
+> `proofkit3d.Run` gates a solid on `decad`'s own verification verdict: the document report has to
+> come back trustworthy, and the build has to return bodies rather than nothing or a nil.
+> `proofkit3d.RunSolid` reads the same report but tolerates exactly one kind of diagnostic, an area
+> or centroid reading a faceted boolean left outside the default tolerance, and adds the topology a
+> solid has to have: every body reports as solid, watertight, manifold and free of
+> self-intersection, with a single lump and no voids. `proofkit3d.RunWithGate` takes the gate as an
+> argument; do not pass a weaker one to get a build through.
 >
 > **The two artifacts must describe the same build.** Every `[GO]` step names its proof function,
 > and every proof function is named by a step.


### PR DESCRIPTION
- `proofkit3d` and `check_compile.py` already gate solid steps; only the skill text still forbade them.
- The prompt's read list omitted `proof/proofkit3d/` and `proof/involute/`, so a fresh compile re-derived tooth math.
- The proof is a directory of Go files, not one `<gear>_test.go`.
