### PR TITLE
report unreadable proof run build arguments

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -180,11 +180,25 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > needs, with one function per step. Every step function, 2D or 3D alike, is named `step<Title>`,
 > matching what the step list names, and is passed as the build argument — the third — to a
 > `proofkit.Run`, `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` call inside a
-> Go `Test` function. A build function under any other name, or one no `Test` reaches, is invisible
-> to the gate, and the step naming it fails the check. Write each run's arguments out one by one:
-> a run that forwards them from a single call, as in `proofkit3d.Run(runArgs(t))`, hides its build
-> argument from the gate and fails the check too. Each run takes a table of parameter cases, one
-> subtest each.
+> Go `Test` function. A build function under any other name fails the check, and the step naming
+> it fails with it.
+>
+> **Write every run where the gate can read it.** The gate reads Go by matching braces rather than
+> by compiling it, so it refuses to guess wherever the guess could be wrong, and a run it refuses
+> to read blocks the compile check for the whole proof directory. Four shapes make it refuse:
+>
+> - A run whose arguments are forwarded from a single call, as in `proofkit3d.Run(runArgs(t))`.
+>   Write each run's arguments out one by one.
+> - A run whose build argument is anything but a literal `step<Title>` identifier — a table entry,
+>   a loop variable, a struct field, a call.
+> - A run in a `Test` body that binds a `step<Title>` name of its own, by any means: `:=`, `var`,
+>   a loop or `if` or `switch` header, a `case` clause, a func-literal parameter. Once such a name
+>   is bound anywhere in the body, every run in that body is refused, wherever the binding sits.
+>   Name locals anything else.
+> - A run under a condition the gate cannot read, or in a helper rather than in a `Test` body.
+>   Register each step from a `Test` body, unguarded.
+>
+> Each run takes a table of parameter cases, one subtest each.
 >
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -185,7 +185,7 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 >
 > **Write every run where the gate can read it.** The gate reads Go by matching braces rather than
 > by compiling it, so it refuses to guess wherever the guess could be wrong, and a run it refuses
-> to read blocks the compile check for the whole proof directory. Four shapes make it refuse:
+> to read blocks the compile check for the whole proof directory. Five shapes make it refuse:
 >
 > - A run whose arguments are forwarded from a single call, as in `proofkit3d.Run(runArgs(t))`.
 >   Write each run's arguments out one by one.
@@ -197,6 +197,10 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 >   Name locals anything else.
 > - A run under a condition the gate cannot read, or in a helper rather than in a `Test` body.
 >   Register each step from a `Test` body, unguarded.
+> - A run inside a func literal that is stored under a name and never called in that `Test` body,
+>   as in `run := func() { proofkit.Run(...) }`. A literal handed to `t.Run`, invoked where it
+>   stands, deferred or started with `go`, and one stored under a name the body then calls, are
+>   all read as running.
 >
 > Each run takes a table of parameter cases, one subtest each.
 >

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -559,35 +559,61 @@ def go_statement_ends_at_line(text):
     return re.search(r'(?:\w|[)\]}\'"]|\+\+|--)$', stripped) is not None
 
 
+def go_statement_end(body, start):
+    """Where the Go statement running from start stops, as written.
+
+    It stops at a `;`, at a line break whose last token can end a statement, or at the `}`
+    that closes the block the statement sits in, and only at the statement's own nesting
+    depth, so a composite literal or a wrapped initializer cannot end it early. A declaration
+    stops where the name it binds comes into scope, which is what this position is read for.
+    """
+    depth = 0
+    current = ''
+    for pos in range(start, len(body)):
+        ch = body[pos]
+        if ch in '([{':
+            depth += 1
+        elif ch in ')]}':
+            if depth == 0 and ch == '}':
+                return pos
+            depth -= 1
+        if depth == 0 and (ch == ';' or (ch == '\n' and go_statement_ends_at_line(current))):
+            return pos
+        current += ch
+    return len(body)
+
+
 def go_var_specs(body, start):
-    """The declaration specs of the var declaration at start, as written.
+    """The declaration specs of the var declaration at start, as (spec, end) pairs.
 
     One spec for a single `var` declaration, and one per declaration for a parenthesised
     block. Specs are cut at the block's own nesting depth, so a composite literal or a call in
     an initializer cannot split one, and only where Go would end the statement, so a wrapped
-    initializer cannot either.
+    initializer cannot either. Each end is where that spec stops in body, because a local is
+    in scope from the end of its own spec and not before it.
     """
     rest = body[start:]
     offset = len(rest) - len(rest.lstrip())
     if rest[offset:offset + 1] != '(':
-        return [rest]
+        return [(rest, go_statement_end(body, start))]
     closing = matching_delimiter(body, start + offset)
     if closing is None:
         return []
     specs = []
     current = ''
     depth = 0
-    for ch in body[start + offset + 1:closing]:
+    first = start + offset + 1
+    for index, ch in enumerate(body[first:closing]):
         if ch in '([{':
             depth += 1
         elif ch in ')]}':
             depth -= 1
         if depth == 0 and (ch == ';' or (ch == '\n' and go_statement_ends_at_line(current))):
-            specs.append(current)
+            specs.append((current, first + index))
             current = ''
             continue
         current += ch
-    specs.append(current)
+    specs.append((current, closing))
     return specs
 
 
@@ -595,8 +621,8 @@ def go_declared_names(spec):
     """The names one var declaration binds: the identifier list before the type and any `=`.
 
     Only the left-hand side, because a declaration's initializer may name a real step function,
-    and treating that name as a local would make a literal registration of it elsewhere in the
-    same function look unreadable.
+    and treating that name as a local would make a literal registration of it anywhere in that
+    declaration's own scope look unreadable.
     """
     match = re.match(r'\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)', spec)
     if match is None:
@@ -604,10 +630,60 @@ def go_declared_names(spec):
     return re.findall(r'[A-Za-z_]\w*', match.group(1))
 
 
-def go_local_bindings(body):
-    """Every name a Go function body binds with := or var, as far as those two forms show.
+def go_enclosing_block_close(body, brace_pairs, pos):
+    """Where the innermost block containing pos closes, or the end of body when none does.
 
-    A build argument that is one of these is a local holding a build, not the name of one, so
+    body is a function body with its own braces already stripped, so a declaration at the top
+    level of the function is inside no pair and its block closes with the function.
+    """
+    close = len(body)
+    innermost = None
+    for opening, closing in brace_pairs.items():
+        if opening < pos <= closing and (innermost is None or opening > innermost):
+            innermost = opening
+            close = closing
+    return close
+
+
+def go_header_block_close(body, brace_pairs, pos):
+    """Where the block a statement header introduces closes, or None when none follows.
+
+    A `for` or `if` header is written in the enclosing block, but what it binds is scoped to
+    the block that header opens, so that block is what bounds it. The scan skips balanced
+    groups, and takes the first brace at the header's own depth that follows whitespace: gofmt
+    writes a space before a block's opening brace and none before a composite literal's, which
+    is what tells the block in `for _, build := range []proofkit.Build{stepOne} {` from the
+    literal in the same header.
+    """
+    depth = 0
+    while pos < len(body):
+        ch = body[pos]
+        if ch in '([':
+            depth += 1
+        elif ch in ')]':
+            depth -= 1
+        elif ch == '}':
+            return None
+        elif ch == '{':
+            if pos not in brace_pairs:
+                return None
+            if depth == 0 and pos > 0 and body[pos - 1].isspace():
+                return brace_pairs[pos]
+            pos = brace_pairs[pos]
+        pos += 1
+    return None
+
+
+def go_local_bindings(body, brace_pairs):
+    """Every name a Go function body binds with := or var, with the span where it is in scope.
+
+    Each binding is a (name, decl_end, block_close) triple, and it holds the name over
+    decl_end < position <= block_close, which is Go's own rule: a local is in scope from the
+    end of its own spec to the end of the innermost block containing that spec. Reading the
+    names alone made every binding cover the whole function, so a same-named declaration in a
+    later or a sibling block hid an outer literal registration.
+
+    A build argument that a binding holds is a local holding a build, not the name of one, so
     the gate cannot say which function the run builds with. Telling the two apart matters:
     calling a loop variable a misnamed build function sends a drafter to rename the wrong
     thing. A stray keyword swept up by the scan is harmless, because no build argument is
@@ -615,13 +691,32 @@ def go_local_bindings(body):
     and the ones inside a parenthesised block, or a run on a local declared in either shape
     would be read as a registration of a step function by that name.
     """
-    names = set()
+    bindings = []
     for match in re.finditer(r'([^\n;{}]*?):=', body):
-        names.update(re.findall(r'[A-Za-z_]\w*', match.group(1)))
+        names = re.findall(r'[A-Za-z_]\w*', match.group(1))
+        if re.match(r'\s*(?:else\s+)?(?:for|if|switch)\b', match.group(1)):
+            # A header binding sits outside the braces it belongs to, so its scope is the
+            # block the header opens and it starts at the := rather than at the header's end.
+            decl_end = match.end()
+            block_close = go_header_block_close(body, brace_pairs, decl_end)
+            if block_close is None:
+                block_close = go_enclosing_block_close(body, brace_pairs, decl_end)
+        else:
+            decl_end = go_statement_end(body, match.end())
+            block_close = go_enclosing_block_close(body, brace_pairs, decl_end)
+        bindings.extend((name, decl_end, block_close) for name in names)
     for match in re.finditer(r'\bvar\b', body):
-        for spec in go_var_specs(body, match.end()):
-            names.update(go_declared_names(spec))
-    return names
+        for spec, spec_end in go_var_specs(body, match.end()):
+            block_close = go_enclosing_block_close(body, brace_pairs, spec_end)
+            bindings.extend(
+                (name, spec_end, block_close) for name in go_declared_names(spec))
+    return bindings
+
+
+def go_local_names_at(bindings, pos):
+    """The names the function's local bindings hold at pos."""
+    return {name for name, decl_end, block_close in bindings
+            if decl_end < pos <= block_close}
 
 
 def go_build_argument_names_a_function(argument, local_names):
@@ -662,11 +757,14 @@ def registered_step_functions(src):
     unreadable = set()
     for _, body in go_func_bodies(src, r'Test[A-Z]\w*'):
         brace_pairs = go_brace_pairs(body)
-        local_names = go_local_bindings(body)
+        local_bindings = go_local_bindings(body, brace_pairs)
         for pattern, build_arg in PROOF_RUN_CALLS:
             for m in re.finditer(pattern, body):
                 if not go_call_is_reachable(body, m.start(), brace_pairs):
                     continue
+                # The run's own start, so a binding counts only where it is in scope for
+                # the whole call, and not one written inside the call's own arguments.
+                local_names = go_local_names_at(local_bindings, m.start())
                 open_paren = m.end() - 1
                 close_paren = matching_delimiter(body, open_paren)
                 if close_paren is None:

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -18,7 +18,10 @@ Four checks gate, and one is reported:
      argument list and not reached through a table or a variable, because the gate reads Go by
      matching braces rather than by compiling it: a run it cannot read to a function name is
      reported as unreadable, and it then says nothing about which steps are registered, rather
-     than calling a registered step unregistered.
+     than calling a registered step unregistered. A run is also unreadable when its own Test
+     body binds a `step<Title>` name, when a condition the gate cannot read guards it, or when
+     it sits outside every Test body. See THE CHOKEPOINT below for why those three are answered
+     by refusing to read rather than by deciding.
   3. API CALLS ARE REAL. Every Fusion call the step list names exists in the API database the
      `fusion` plugin ships. Catches a spec that names a method Fusion does not have.
   4. INPUTS HAVE NOT DRIFTED. The provenance table contains and matches the existing instructions,
@@ -406,8 +409,12 @@ def matching_delimiter(src, start):
     return None
 
 
-def go_func_bodies(src, name_pattern):
-    """Yield (name, body) for top-level Go functions whose names match name_pattern."""
+def go_func_body_spans(src, name_pattern):
+    """Yield (name, start, end) for top-level Go functions whose names match name_pattern.
+
+    start and end bound the body between the function's own braces. Positions come out with
+    the body because a run has to be placed inside or outside a Test body before it is read.
+    """
     pattern = r'(?m)^func\s+(%s)\s*\(' % name_pattern
     for m in re.finditer(pattern, src):
         open_brace = src.find('{', m.end())
@@ -416,7 +423,13 @@ def go_func_bodies(src, name_pattern):
         close_brace = matching_delimiter(src, open_brace)
         if close_brace is None:
             continue
-        yield m.group(1), src[open_brace + 1:close_brace]
+        yield m.group(1), open_brace + 1, close_brace
+
+
+def go_func_bodies(src, name_pattern):
+    """Yield (name, body) for top-level Go functions whose names match name_pattern."""
+    for name, start, end in go_func_body_spans(src, name_pattern):
+        yield name, src[start:end]
 
 
 def split_go_args(src):
@@ -524,17 +537,30 @@ def go_early_return_before(src, pos, brace_pairs):
     return False
 
 
-def go_call_is_reachable(src, pos, brace_pairs):
-    """Return whether a proof run at pos can execute on the test path."""
+def go_call_reachability(src, pos, brace_pairs):
+    """Return True, False or None for whether a proof run at pos runs on the test path.
+
+    True when nothing the gate reads keeps it from running, False when a known-false
+    condition or an unconditional early return does, and None when a block encloses it whose
+    condition the gate cannot read.
+
+    None is not False. A run the gate cannot decide about is one it cannot report on, so the
+    caller reads it as unreadable rather than dropping it. Dropping it was worse than saying
+    nothing: the steps such a run registers were then reported as registered nowhere, which
+    sends a drafter to fix a proof that already registers them.
+    """
     if go_top_level_return_before(src, pos) or go_early_return_before(src, pos, brace_pairs):
         return False
+    unknown = False
     for opening, closing in brace_pairs.items():
         if not opening < pos < closing:
             continue
         condition = go_block_condition(src, opening)
-        if condition is not True:
+        if condition is False:
             return False
-    return True
+        if condition is None:
+            unknown = True
+    return None if unknown else True
 
 
 def go_argument_label(argument):
@@ -559,43 +585,18 @@ def go_statement_ends_at_line(text):
     return re.search(r'(?:\w|[)\]}\'"]|\+\+|--)$', stripped) is not None
 
 
-def go_statement_end(body, start):
-    """Where the Go statement running from start stops, as written.
-
-    It stops at a `;`, at a line break whose last token can end a statement, or at the `}`
-    that closes the block the statement sits in, and only at the statement's own nesting
-    depth, so a composite literal or a wrapped initializer cannot end it early. A declaration
-    stops where the name it binds comes into scope, which is what this position is read for.
-    """
-    depth = 0
-    current = ''
-    for pos in range(start, len(body)):
-        ch = body[pos]
-        if ch in '([{':
-            depth += 1
-        elif ch in ')]}':
-            if depth == 0 and ch == '}':
-                return pos
-            depth -= 1
-        if depth == 0 and (ch == ';' or (ch == '\n' and go_statement_ends_at_line(current))):
-            return pos
-        current += ch
-    return len(body)
-
-
 def go_var_specs(body, start):
-    """The declaration specs of the var declaration at start, as (spec, end) pairs.
+    """The declaration specs of the var declaration at start.
 
     One spec for a single `var` declaration, and one per declaration for a parenthesised
     block. Specs are cut at the block's own nesting depth, so a composite literal or a call in
     an initializer cannot split one, and only where Go would end the statement, so a wrapped
-    initializer cannot either. Each end is where that spec stops in body, because a local is
-    in scope from the end of its own spec and not before it.
+    initializer cannot either. Only the names a spec binds are read from it.
     """
     rest = body[start:]
     offset = len(rest) - len(rest.lstrip())
     if rest[offset:offset + 1] != '(':
-        return [(rest, go_statement_end(body, start))]
+        return [rest]
     closing = matching_delimiter(body, start + offset)
     if closing is None:
         return []
@@ -603,17 +604,17 @@ def go_var_specs(body, start):
     current = ''
     depth = 0
     first = start + offset + 1
-    for index, ch in enumerate(body[first:closing]):
+    for ch in body[first:closing]:
         if ch in '([{':
             depth += 1
         elif ch in ')]}':
             depth -= 1
         if depth == 0 and (ch == ';' or (ch == '\n' and go_statement_ends_at_line(current))):
-            specs.append((current, first + index))
+            specs.append(current)
             current = ''
             continue
         current += ch
-    specs.append((current, closing))
+    specs.append(current)
     return specs
 
 
@@ -621,8 +622,8 @@ def go_declared_names(spec):
     """The names one var declaration binds: the identifier list before the type and any `=`.
 
     Only the left-hand side, because a declaration's initializer may name a real step function,
-    and treating that name as a local would make a literal registration of it anywhere in that
-    declaration's own scope look unreadable.
+    and treating that name as a binding would make a literal registration of it anywhere in the
+    same Test body look unreadable.
     """
     match = re.match(r'\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)', spec)
     if match is None:
@@ -630,129 +631,168 @@ def go_declared_names(spec):
     return re.findall(r'[A-Za-z_]\w*', match.group(1))
 
 
-def go_enclosing_block_close(body, brace_pairs, pos):
-    """Where the innermost block containing pos closes, or the end of body when none does.
+def go_short_declaration_names(body, assign):
+    """The identifiers the `:=` at assign binds, read backwards from it.
 
-    body is a function body with its own braces already stripped, so a declaration at the top
-    level of the function is inside no pair and its block closes with the function.
+    Go's short variable declaration takes an identifier list on its left, so nothing but
+    identifiers, commas and whitespace can stand there. The scan walks back over exactly that
+    and stops at anything else. That is why it can cross the newline of a left-hand side
+    written over several lines and still cannot run into the statement before it: a line whose
+    last token can end a statement stops the scan, which is the same rule Go's own semicolon
+    insertion uses.
+
+    A keyword swept up in front of the list — `for`, `if`, `case` — costs nothing, because no
+    build argument is written as one.
     """
-    close = len(body)
-    innermost = None
-    for opening, closing in brace_pairs.items():
-        if opening < pos <= closing and (innermost is None or opening > innermost):
-            innermost = opening
-            close = closing
-    return close
+    start = assign
+    while start > 0:
+        ch = body[start - 1]
+        if ch == '\n':
+            if go_statement_ends_at_line(body[:start - 1]):
+                break
+            start -= 1
+            continue
+        if ch.isalnum() or ch in '_, \t':
+            start -= 1
+            continue
+        break
+    return re.findall(r'[A-Za-z_]\w*', body[start:assign])
 
 
-def go_group_closes_the_statement(body, closing):
-    """Whether nothing but whitespace follows a brace group's close before the statement ends.
+def go_signature_names(body, open_paren):
+    """The identifiers a func literal's parameter list, and its named result list, write.
 
-    A statement ends at a newline, at a `;`, or at the `}` of the block it sits in, so a group
-    that reaches one of those with only whitespace in between is the last thing the statement
-    writes.
+    Both lists bind names in the literal's body, and both are read whole rather than split
+    into name and type: a type name swept up alongside a parameter name costs nothing, because
+    no build argument is written as a type.
     """
-    for ch in body[closing + 1:]:
-        if ch in '\n;}':
-            return True
-        if not ch.isspace():
-            return False
-    return True
+    closing = matching_delimiter(body, open_paren)
+    if closing is None:
+        return []
+    text = body[open_paren + 1:closing]
+    rest = body[closing + 1:]
+    offset = len(rest) - len(rest.lstrip())
+    if rest[offset:offset + 1] == '(':
+        results = matching_delimiter(body, closing + 1 + offset)
+        if results is not None:
+            text += ',' + body[closing + offset + 2:results]
+    return re.findall(r'[A-Za-z_]\w*', text)
 
 
-def go_header_block_close(body, brace_pairs, pos):
-    """Where the block a statement header introduces closes, or None when none follows.
+def go_bound_names(body):
+    """Every name a Go function body binds, with no scope attached to any of them.
 
-    A `for` or `if` header is written in the enclosing block, but what it binds is scoped to
-    the block that header opens, so that block is what bounds it. The scan skips every balanced
-    brace group from the binding onward and takes the group, at the header's own paren and
-    bracket depth, whose close is the last thing on the statement. The block a header opens is
-    always in that position, and nothing else in the header is: whatever a header writes before
-    the block — a composite literal, a struct or interface type, a function literal — is
-    followed by the block itself, or by the call parentheses, the `;` or the operand that
-    carries the header on.
+    Three constructs write a binding: a `:=`, a `var` declaration, and a func literal's
+    parameter or named result list. Every other binding form in Go's grammar — a for-range
+    header, a three-clause `for` init, an `if` or `switch` init, a type-switch guard, a
+    `case v := <-ch:` in a select, a case clause body — is one of those three wearing a
+    keyword, so reading the three reads them all.
 
-    The rule has to be positional. Brace matching cannot see where the range expression ends,
-    and it cannot read the spacing either: gofmt leaves a space before a multi-line
-    `[]struct {` or a function literal's own brace just as it does before a block's, so the
-    character in front of a brace says nothing about which kind it opens.
+    No position is recorded, because the chokepoint below asks only whether a name is bound
+    somewhere in the body, never where.
     """
-    depth = 0
-    while pos < len(body):
-        ch = body[pos]
-        if ch in '([':
-            depth += 1
-        elif ch in ')]':
-            depth -= 1
-        elif ch == '}':
-            return None
-        elif ch == '{':
-            if pos not in brace_pairs:
-                return None
-            closing = brace_pairs[pos]
-            if depth == 0 and go_group_closes_the_statement(body, closing):
-                return closing
-            pos = closing
-        pos += 1
-    return None
-
-
-def go_local_bindings(body, brace_pairs):
-    """Every name a Go function body binds with := or var, with the span where it is in scope.
-
-    Each binding is a (name, decl_end, block_close) triple, and it holds the name over
-    decl_end < position <= block_close, which is Go's own rule: a local is in scope from the
-    end of its own spec to the end of the innermost block containing that spec. Reading the
-    names alone made every binding cover the whole function, so a same-named declaration in a
-    later or a sibling block hid an outer literal registration.
-
-    A build argument that a binding holds is a local holding a build, not the name of one, so
-    the gate cannot say which function the run builds with. Telling the two apart matters:
-    calling a loop variable a misnamed build function sends a drafter to rename the wrong
-    thing. A stray keyword swept up by the scan is harmless, because no build argument is
-    written as one. Every name a var declaration binds counts, including the ones after a comma
-    and the ones inside a parenthesised block, or a run on a local declared in either shape
-    would be read as a registration of a step function by that name.
-    """
-    bindings = []
-    for match in re.finditer(r'([^\n;{}]*?):=', body):
-        names = re.findall(r'[A-Za-z_]\w*', match.group(1))
-        if re.match(r'\s*(?:else\s+)?(?:for|if|switch)\b', match.group(1)):
-            # A header binding sits outside the braces it belongs to, so its scope is the
-            # block the header opens and it starts at the := rather than at the header's end.
-            decl_end = match.end()
-            block_close = go_header_block_close(body, brace_pairs, decl_end)
-            if block_close is None:
-                block_close = go_enclosing_block_close(body, brace_pairs, decl_end)
-        else:
-            decl_end = go_statement_end(body, match.end())
-            block_close = go_enclosing_block_close(body, brace_pairs, decl_end)
-        bindings.extend((name, decl_end, block_close) for name in names)
+    names = set()
+    for match in re.finditer(r':=', body):
+        names.update(go_short_declaration_names(body, match.start()))
     for match in re.finditer(r'\bvar\b', body):
-        for spec, spec_end in go_var_specs(body, match.end()):
-            block_close = go_enclosing_block_close(body, brace_pairs, spec_end)
-            bindings.extend(
-                (name, spec_end, block_close) for name in go_declared_names(spec))
-    return bindings
+        for spec in go_var_specs(body, match.end()):
+            names.update(go_declared_names(spec))
+    for match in re.finditer(r'\bfunc\s*\(', body):
+        names.update(go_signature_names(body, match.end() - 1))
+    return names
 
 
-def go_local_names_at(bindings, pos):
-    """The names the function's local bindings hold at pos."""
-    return {name for name, decl_end, block_close in bindings
-            if decl_end < pos <= block_close}
+# THE CHOKEPOINT, AND WHAT IT GIVES UP
+#
+# A Test body that binds a `step<Title>` name itself makes every proof run in that body
+# unreadable. The rule makes no scope decision at all, so no header shape can defeat it.
+#
+# A root-cause map of this gate's local-binding handling found seven gaps across the Go binding
+# constructs and offered two ways out: this one, the conservative chokepoint, and a real parse.
+# The conservative one was ruled, and the reasoning on both sides is kept here rather than in a
+# commit message, because the next reader of this file is the one who needs it.
+#
+# It replaces a character-level guess at Go's scoping rule — "the brace group whose close is
+# the last thing on the statement is the block this header opens". Three review rounds each
+# repaired one header shape that defeated that guess, and each time a fourth shape appeared,
+# because the guess is not an approximation of Go's grammar but a different rule that happens
+# to agree with it on the shapes anyone had written down yet.
+#
+# What this deliberately gives up is precision. It reports runs unreadable that a real scope
+# analysis would accept: a `step<Title>` local declared in a sibling block, or after the run,
+# or inside a loop the run is not in, now blocks the whole body. That is the price of a rule
+# with no grammar of its own, and it is paid in false failures, which are loud, rather than in
+# false passes, which are silent and let unproven geometry through a green gate. A proof pays
+# it only by naming a local `step<Title>`, which no proof needs to do.
+#
+# THREE THINGS BRACE MATCHING CANNOT DECIDE, EVEN IN PRINCIPLE
+#
+#   1. A brace group that ends a header clause. In `for a, b := f(), []T{x}; cond; post {` the
+#      clause-ending group and the block are character-identical, and gofmt spaces them the
+#      same way. Telling them apart means knowing how many `;`-separated clauses the header
+#      has and which one the scan is in, which is parsing, not matching.
+#   2. A binding with no brace to hang it on. A `switch` case clause is an implicit block that
+#      writes no brace; func-literal parameters and named results bind inside parentheses;
+#      `const`, `type` and labelled statements are grammar facts with no delimiter of their
+#      own. No refinement of "what follows the brace" reaches any of them.
+#   3. Whether a guarded run executes. `if cond { run }` is decidable only by evaluating
+#      `cond`, which is undecidable in general. The gate reads such a run as unreadable, which
+#      is the honest answer, rather than deciding it either way.
+#
+# Item 3's sibling is the run written in a helper rather than in a `Test` body. Whether a Test
+# reaches it is a call-graph question this gate does not ask, so such a run is reported
+# unreadable too. That is a known limit, not a fix: a helper that a Test really does call
+# still has to be reported, because nothing here can tell it from one that no Test calls.
+#
+# OPTION B, DEFERRED AND KEPT OPEN
+#
+# The sound fix is a real parse: a small `go/parser` plus `go/ast` helper emitting binding
+# spans and the resolved build-argument identifier, leaving this module with one lookup and no
+# grammar of its own. It closes all three items above, because a parser answers by
+# construction what brace matching can only guess at. The repo already ships a Go module and
+# toolchain under `proof/`, so the dependency exists. It is deferred, not rejected, because it
+# makes this Python gate depend on the Go toolchain being present to run at all, which is a
+# structural change beyond the scope this decision was taken in. Take it up and this whole
+# chokepoint, along with the machinery above it, is deleted rather than refined.
 
 
-def go_build_argument_names_a_function(argument, local_names):
+STEP_FUNCTION_NAME = re.compile(r'step[A-Z]\w*')
+
+
+def go_bound_step_names(bound_names):
+    """The step<Title> names among a Test body's bindings: the chokepoint's whole input."""
+    return sorted(name for name in bound_names if STEP_FUNCTION_NAME.fullmatch(name))
+
+
+def go_build_argument_names_a_function(argument, bound_names):
     """Return whether a build argument says, on its own, which function the run builds with.
 
     A package-level identifier says it, and so does a function literal, which says it is
-    anonymous and therefore no step's. Anything else — a local, a struct field, an index, a
-    call, a qualified name — is an expression the gate would have to evaluate to know what the
-    run builds with, and this is brace matching over scrubbed source, not a Go compiler.
+    anonymous and therefore no step's. Anything else — a name the Test body binds itself, a
+    struct field, an index, a call, a qualified name — is an expression the gate would have to
+    evaluate to know what the run builds with, and this is brace matching over scrubbed
+    source, not a Go compiler.
     """
     if re.fullmatch(r'[A-Za-z_]\w*', argument):
-        return argument not in local_names
+        return argument not in bound_names
     return re.match(r'func\s*\(', argument) is not None
+
+
+UNREADABLE_ARGUMENT = ("write the run's arguments out one by one, with the build argument a "
+                       "literal step<Title> identifier so a step can claim the run")
+UNREADABLE_GUARD = ("the gate cannot read the condition that guards it, so it cannot say "
+                    "whether the run executes; write the run where nothing it cannot read "
+                    "guards it")
+UNREADABLE_OUTSIDE_TEST = ("the run is not inside a Go Test function, so the gate cannot say "
+                           "which Test reaches it; register the step from a Test body")
+
+
+def unreadable_local_step_reason(names):
+    """Why a Test body that binds a step<Title> name of its own makes its runs unreadable."""
+    return ("this Test body binds %s itself, so a step<Title> build argument written here may "
+            "be that local rather than the step function of the same name; rename the local so "
+            "no step<Title> name is bound in a Test body that registers a run"
+            % ', '.join(names))
 
 
 def registered_step_functions(src):
@@ -766,44 +806,67 @@ def registered_step_functions(src):
     gate then reports the steps such a run registers as registered nowhere, which is false.
     Only the build argument is judged; the gate and assertion arguments are not steps.
 
-    A run counts as unreadable in three ways, and they are one category because they leave the
-    gate in one state — it cannot say which function the run builds with. The argument list may
-    never close; it may be shorter than the build slot, which is what a run written as one
-    multi-value call parses to, the arguments forwarded from a helper rather than written out;
-    or the build argument may be an expression, a local or a table entry rather than a name.
-    Each compiles, so silently skipping any of them would let a build argument escape the
-    step<Title> check. The label carries the whole call where no argument reached the slot, and
-    the argument itself where one did.
+    A run is unreadable in five ways, and they are one category because they leave the gate in
+    one state — it cannot say which function the run builds with. The Test body may bind a
+    step<Title> name itself, which is the chokepoint above and covers every scope question at
+    once. A block the gate cannot read may guard the run. The argument list may never close; it
+    may be shorter than the build slot, which is what a run written as one multi-value call
+    parses to, the arguments forwarded from a helper rather than written out; or the build
+    argument may be an expression, a bound name or a table entry rather than a name. Each
+    compiles, so silently skipping any of them would let a build argument escape the
+    step<Title> check. Each unreadable run carries the label of the thing to look at and the
+    reason the gate stopped there. The label carries the whole call where no argument reached
+    the slot, and the argument itself where one did.
+
+    A run outside every Test body is reported the same way, because whether a Test reaches the
+    helper holding it is a call-graph question this gate does not ask.
     """
     registered = set()
     misnamed = set()
     unreadable = set()
-    for _, body in go_func_bodies(src, r'Test[A-Z]\w*'):
+    test_spans = []
+    for _, body_start, body_end in go_func_body_spans(src, r'Test[A-Z]\w*'):
+        test_spans.append((body_start, body_end))
+        body = src[body_start:body_end]
         brace_pairs = go_brace_pairs(body)
-        local_bindings = go_local_bindings(body, brace_pairs)
+        bound_names = go_bound_names(body)
+        bound_step_names = go_bound_step_names(bound_names)
         for pattern, build_arg in PROOF_RUN_CALLS:
             for m in re.finditer(pattern, body):
-                if not go_call_is_reachable(body, m.start(), brace_pairs):
+                reachable = go_call_reachability(body, m.start(), brace_pairs)
+                if reachable is False:
                     continue
-                # The run's own start, so a binding counts only where it is in scope for
-                # the whole call, and not one written inside the call's own arguments.
-                local_names = go_local_names_at(local_bindings, m.start())
                 open_paren = m.end() - 1
                 close_paren = matching_delimiter(body, open_paren)
+                call = (body[m.start():] if close_paren is None
+                        else body[m.start():close_paren + 1])
+                if reachable is None:
+                    unreadable.add((go_argument_label(call), UNREADABLE_GUARD))
+                    continue
                 if close_paren is None:
-                    unreadable.add(go_argument_label(body[m.start():]))
+                    unreadable.add((go_argument_label(call), UNREADABLE_ARGUMENT))
                     continue
                 args = split_go_args(body[open_paren + 1:close_paren])
                 if len(args) <= build_arg:
-                    unreadable.add(go_argument_label(body[m.start():close_paren + 1]))
+                    unreadable.add((go_argument_label(call), UNREADABLE_ARGUMENT))
                     continue
                 argument = args[build_arg]
-                if argument not in local_names and re.fullmatch(r'step[A-Z]\w*', argument):
+                if bound_step_names:
+                    unreadable.add((go_argument_label(argument),
+                                    unreadable_local_step_reason(bound_step_names)))
+                elif STEP_FUNCTION_NAME.fullmatch(argument):
                     registered.add(argument)
-                elif go_build_argument_names_a_function(argument, local_names):
+                elif go_build_argument_names_a_function(argument, bound_names):
                     misnamed.add(go_argument_label(argument))
                 else:
-                    unreadable.add(go_argument_label(argument))
+                    unreadable.add((go_argument_label(argument), UNREADABLE_ARGUMENT))
+    for pattern, _ in PROOF_RUN_CALLS:
+        for m in re.finditer(pattern, src):
+            if any(start <= m.start() < end for start, end in test_spans):
+                continue
+            close_paren = matching_delimiter(src, m.end() - 1)
+            call = src[m.start():] if close_paren is None else src[m.start():close_paren + 1]
+            unreadable.add((go_argument_label(call), UNREADABLE_OUTSIDE_TEST))
     return registered, sorted(misnamed), sorted(unreadable)
 
 
@@ -825,9 +888,11 @@ def proof_functions(proof_dir):
 def proof_registrations(proof_dir):
     """Return the registrations a proof directory makes, as three sets.
 
-    They are the step functions registered from a Go Test, the misnamed builds, and the
-    unreadable runs, the last two as (file, label) pairs. A label carries its file, because
-    the argument or the call alone does not say where to go and fix it.
+    They are the step functions registered from a Go Test, the misnamed builds as (file,
+    label) pairs, and the unreadable runs as (file, label, reason) triples. A label carries its
+    file, because the argument or the call alone does not say where to go and fix it, and an
+    unreadable run carries its reason, because the five ways a run can be unreadable are fixed
+    in five different places.
     """
     found = set()
     misnamed = set()
@@ -842,7 +907,7 @@ def proof_registrations(proof_dir):
         registered, other, unread = registered_step_functions(src)
         found.update(registered)
         misnamed.update((path, argument) for argument in other)
-        unreadable.update((path, label) for label in unread)
+        unreadable.update((path, label, reason) for label, reason in unread)
     return found, sorted(misnamed), sorted(unreadable)
 
 
@@ -913,11 +978,9 @@ def main(argv):
         problems.append("  %s registers %s as a proof run's build argument, but that argument "
                         "must be a step<Title> function so a step can claim it"
                         % (path, argument))
-    for path, label in unreadable_runs:
-        problems.append("  %s does not show the gate which function a proof run builds with: "
-                        "%s; write the run's arguments out one by one, with the build argument "
-                        "a literal step<Title> identifier so a step can claim the run"
-                        % (path, label))
+    for path, label, reason in unreadable_runs:
+        problems.append("  %s has a proof run the gate cannot read as a registration: %s; %s"
+                        % (path, label, reason))
 
     # 3. API calls are real
     local = PYTHON_METHODS | defined_names(FRAMEWORK) | contract_names(gear)

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -545,6 +545,65 @@ def go_argument_label(argument):
     return label
 
 
+def go_statement_ends_at_line(text):
+    """Whether Go would end a statement at the end of this line.
+
+    Go inserts the semicolon itself, and only when the line's last token can end a statement:
+    an identifier, a literal, a closing bracket, or ++/--. A line ending in `=`, a comma or an
+    operator continues into the next one, which is what keeps a multi-line declaration from
+    being read as several.
+    """
+    stripped = text.rstrip()
+    if not stripped:
+        return True
+    return re.search(r'(?:\w|[)\]}\'"]|\+\+|--)$', stripped) is not None
+
+
+def go_var_specs(body, start):
+    """The declaration specs of the var declaration at start, as written.
+
+    One spec for a single `var` declaration, and one per declaration for a parenthesised
+    block. Specs are cut at the block's own nesting depth, so a composite literal or a call in
+    an initializer cannot split one, and only where Go would end the statement, so a wrapped
+    initializer cannot either.
+    """
+    rest = body[start:]
+    offset = len(rest) - len(rest.lstrip())
+    if rest[offset:offset + 1] != '(':
+        return [rest]
+    closing = matching_delimiter(body, start + offset)
+    if closing is None:
+        return []
+    specs = []
+    current = ''
+    depth = 0
+    for ch in body[start + offset + 1:closing]:
+        if ch in '([{':
+            depth += 1
+        elif ch in ')]}':
+            depth -= 1
+        if depth == 0 and (ch == ';' or (ch == '\n' and go_statement_ends_at_line(current))):
+            specs.append(current)
+            current = ''
+            continue
+        current += ch
+    specs.append(current)
+    return specs
+
+
+def go_declared_names(spec):
+    """The names one var declaration binds: the identifier list before the type and any `=`.
+
+    Only the left-hand side, because a declaration's initializer may name a real step function,
+    and treating that name as a local would make a literal registration of it elsewhere in the
+    same function look unreadable.
+    """
+    match = re.match(r'\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)', spec)
+    if match is None:
+        return []
+    return re.findall(r'[A-Za-z_]\w*', match.group(1))
+
+
 def go_local_bindings(body):
     """Every name a Go function body binds with := or var, as far as those two forms show.
 
@@ -552,13 +611,16 @@ def go_local_bindings(body):
     the gate cannot say which function the run builds with. Telling the two apart matters:
     calling a loop variable a misnamed build function sends a drafter to rename the wrong
     thing. A stray keyword swept up by the scan is harmless, because no build argument is
-    written as one.
+    written as one. Every name a var declaration binds counts, including the ones after a comma
+    and the ones inside a parenthesised block, or a run on a local declared in either shape
+    would be read as a registration of a step function by that name.
     """
     names = set()
     for match in re.finditer(r'([^\n;{}]*?):=', body):
         names.update(re.findall(r'[A-Za-z_]\w*', match.group(1)))
-    for match in re.finditer(r'\bvar\s+([A-Za-z_]\w*)', body):
-        names.add(match.group(1))
+    for match in re.finditer(r'\bvar\b', body):
+        for spec in go_var_specs(body, match.end()):
+            names.update(go_declared_names(spec))
     return names
 
 

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -48,6 +48,7 @@ import os
 import re
 import subprocess
 import sys
+import unicodedata
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
@@ -360,6 +361,51 @@ def go_literal_end(src, start):
             return index + 1, True
         index += 1
     return len(src), False
+
+
+# Which build constraints this gate honours, and which it does not.
+#
+# A `//go:build` line above the package clause can keep `go build` and `go test` from compiling
+# a file at all, and a file Go never compiles registers nothing. Only the two conventional
+# never-build markers are honoured — `//go:build ignore` and `//go:build never` — because they
+# are the whole realistic case here: a proof file parked out of the build while it is being
+# written or kept for reference. Both are ordinary tag names Go has no meaning for, so neither
+# is satisfied unless someone passes `-tags`, and `proof/run.sh` passes none.
+#
+# NOT honoured, and read as if the file compiled: every other constraint. A tag expression
+# (`//go:build linux && cgo`), a negation (`//go:build !windows`), a GOOS or GOARCH name, an
+# implicit `_linux.go` or `_amd64.go` file-name constraint, and a bare legacy `// +build` line
+# all leave the file read. Deciding the first four needs the tag set, the target platform and a
+# release-tag list, which is a build-context evaluator, and a gate that matches braces rather
+# than compiling Go should not carry one. The legacy line costs nothing: gofmt writes the
+# matching `//go:build` line above it, so a committed file that never builds carries the form
+# this reads. The residue is a false pass of the same kind this rule closes, so a proof that
+# parks a run behind a platform constraint is still counted as registering it; `//go:build
+# never` is what to write when a file must not count.
+GO_NEVER_BUILT_CONSTRAINTS = frozenset(('ignore', 'never'))
+
+GO_BUILD_CONSTRAINT = re.compile(r'(?m)^//go:build[ \t]+(.*?)[ \t]*$')
+
+
+def go_build_constraint(src):
+    """The expression on the file's `//go:build` line, or None when it has none.
+
+    The line is a constraint only above the package clause, so nothing below it is read: a
+    `//go:build` written inside a function is a comment like any other.
+    """
+    package = re.search(r'(?m)^package\b', src)
+    head = src if package is None else src[:package.start()]
+    match = GO_BUILD_CONSTRAINT.search(head)
+    return None if match is None else match.group(1).strip()
+
+
+def go_file_is_never_built(src):
+    """Whether a build constraint keeps Go from ever compiling this file.
+
+    Read from the raw source, before `strip_go_comments_and_literals` blanks the line that
+    carries it. See the note above for which constraints this answers and which it does not.
+    """
+    return go_build_constraint(src) in GO_NEVER_BUILT_CONSTRAINTS
 
 
 def strip_go_comments_and_literals(src):
@@ -953,23 +999,61 @@ def go_func_literal_body_start(body, open_paren):
     return index if body[index:index + 1] == '{' else None
 
 
+# The prefixes an element type can carry in front of its own keyword. `[]*func(...)`,
+# `map[string]chan func(...)` and `[]<-chan func(...)` are the bracketed type whose element is
+# a func TYPE, written with `*`, `chan` or `<-chan` standing where the `]` would otherwise be.
+# Anchored at the end so it reads what stands just before a keyword. `...` is not in the list:
+# Go writes it only in a parameter list, where no `]` closing a bracketed type can stand in
+# front of it, so reading it would decide nothing.
+#
+# `chan` may be spaced off what follows it and needs a boundary in front of it, so a name
+# ending in those four letters is not read as the keyword. `*` may NOT: a pointer type is
+# written against its element and a product is written with spaces around its operator, which
+# is what separates `[]*func(arg stepType){}` from `m[0] * func(arg stepType) int { ... }(0)`,
+# an invoked literal whose parameters bind. Both spellings are gofmt's, so the space is a fact
+# about committed Go rather than a guess. A pointer element type spaced off its own type reads
+# as a literal here and binds a name too many, which is the direction that only ever makes a
+# run unreadable.
+GO_TYPE_PREFIX_BEFORE = re.compile(r'(?:\*|(?:<-[ \t]*)?(?<!\w)chan[ \t]*)\Z')
+
+
+def go_type_prefix_start(body, index):
+    """Where the run of type prefixes standing just before index begins.
+
+    index itself when none stands there. Only spaces and tabs are crossed, never a line break,
+    for the reason `go_element_type_bracket_before` gives.
+    """
+    while True:
+        match = GO_TYPE_PREFIX_BEFORE.search(body, 0, index)
+        if match is None:
+            return index
+        index = match.start()
+
+
 def go_element_type_bracket_before(body, keyword):
     """Whether the `func` keyword at keyword is the element type of a bracketed type.
 
     `[]func(arg stepType)`, `[2]func(arg stepType)` and `map[string]func(arg stepType)` all
     write a func TYPE, and all three announce it the same way: with the `]` that closes their
-    brackets standing immediately before the `func`. Go writes no expression that puts a `]`
-    there, so the character decides it, and it is the only character that can — a func literal
-    in expression position follows an operator, a delimiter, a keyword, or nothing.
+    brackets standing before the `func`. Go writes no expression that puts a `]` there, so the
+    character decides it, and it is the only character that can — a func literal in expression
+    position follows an operator, a delimiter, a keyword, or nothing.
+
+    The `]` does not have to stand next to the keyword. `map[string]chan func(arg stepType)`
+    and `[]*func(arg stepType)` are the same func TYPE with a prefix in between, so the
+    character before the keyword is `n` or `*` there and a test that read only that character
+    reported both as literals. The prefixes are walked over first, which is what makes this a
+    test for "a func keyword standing in type text" rather than for one punctuation mark. See
+    `GO_TYPE_PREFIX_BEFORE` for which prefixes are read and how a product's `*` stays out.
 
     Only spaces and tabs are crossed looking back, never a line break. A statement ending in
     `]` on the line above says nothing about the `func` opening the next one, and gofmt writes
     the bracketed type and its element type together on one line.
     """
-    index = keyword - 1
-    while index >= 0 and body[index] in ' \t':
+    index = go_type_prefix_start(body, keyword)
+    while index > 0 and body[index - 1] in ' \t':
         index -= 1
-    return index >= 0 and body[index] == ']'
+    return index > 0 and body[index - 1] == ']'
 
 
 def go_func_literal_parameter_lists(body):
@@ -990,6 +1074,14 @@ def go_func_literal_parameter_lists(body):
     span in hand before the matches it covers. Case 2 is decided by the bracket that precedes
     the keyword.
 
+    An element type is type text all the way down, so case 2 records the span it covers
+    instead of skipping one keyword and reading on. `table := []func() func(arg stepType){}`
+    writes the same func TYPE twice, and skipping only the outer one left the inner parameter
+    list standing in front of the composite literal's value brace, which is exactly what a
+    literal looks like locally: `arg` came out bound, and a run built with a step function of
+    that name was then reported unreadable. `go_type_end` reads the whole type from the
+    keyword, and every match inside it is type text for the same reason case 1's span is.
+
     What this does NOT decide is scope. A func literal nested in another one is a literal, and
     its parameters are collected, because the chokepoint below asks only whether a name is
     bound somewhere in the body. That conservative reading is the design, not an oversight.
@@ -1000,6 +1092,9 @@ def go_func_literal_parameter_lists(body):
         if any(start <= match.start() < end for start, end in type_spans):
             continue
         if go_element_type_bracket_before(body, match.start()):
+            type_end = go_type_end(body, match.start())
+            if type_end is not None:
+                type_spans.append((match.start(), type_end))
             continue
         open_paren = match.end() - 1
         brace = go_func_literal_body_start(body, open_paren)
@@ -1360,10 +1455,31 @@ STEP_FUNCTION_NAME = re.compile(r'step[A-Z]\w*')
 # Which names `go test` runs, written as Go's own rule rather than as a convention: `Test`
 # followed by a rune that is not a lower-case letter, and `Test` on its own. `Test_Profile` and
 # `Test1` are tests, `Testing` is not, and `go vet` refuses a `Testing(t *testing.T)` as a
-# malformed test name, so the two agree on the whole space. Reading only `Test[A-Z]\w*` left a
-# run in a `Test_Profile` or a `Test1` body reported as 'not inside a Go Test function', which
-# names the wrong thing to fix: the Test was there and the gate was not looking for it.
-GO_TEST_FUNCTION_NAME = r'Test(?:[^a-z]\w*)?'
+# malformed test name. Reading only `Test[A-Z]\w*` left a run in a `Test_Profile` or a `Test1`
+# body reported as 'not inside a Go Test function', which names the wrong thing to fix: the
+# Test was there and the gate was not looking for it.
+#
+# The pattern collects candidates and `go_name_is_a_go_test` decides them, because this name is
+# interpolated into a larger pattern and Python writes no Unicode category class. `[^a-z]` was
+# the ASCII reading of the rule and accepted `Testé`, which `go vet` refuses with the same
+# malformed-name error it gives `Testing`.
+GO_TEST_NAME_PREFIX = 'Test'
+
+GO_TEST_FUNCTION_NAME = GO_TEST_NAME_PREFIX + r'\w*'
+
+
+def go_name_is_a_go_test(name):
+    """Whether `go test` runs a function of this name, by Go's own rule.
+
+    `cmd/go/internal/load.isTest` takes the first rune after the prefix and answers
+    `!unicode.IsLower(rune)`, with the bare prefix a test. Go's `unicode.IsLower` is category
+    Ll and nothing else, so the category is read here rather than `str.islower()`, which also
+    answers true for Other_Lowercase runes such as U+02B0. That difference would only reject
+    names Go runs — the safe direction — but the rule is cheap to write exactly, and a gate
+    that says it matches Go should match it.
+    """
+    rest = name[len(GO_TEST_NAME_PREFIX):]
+    return not rest or unicodedata.category(rest[0]) != 'Ll'
 
 
 def go_bound_step_names(bound_names):
@@ -1432,13 +1548,17 @@ def registered_step_functions(src):
     the slot, and the argument itself where one did.
 
     A run outside every Test body is reported the same way, because whether a Test reaches the
-    helper holding it is a call-graph question this gate does not ask.
+    helper holding it is a call-graph question this gate does not ask. A function whose name
+    only looks like a test's is outside every Test body too: `go test` never runs it, so a run
+    written in one registers nothing.
     """
     registered = set()
     misnamed = set()
     unreadable = set()
     test_spans = []
-    for _, body_start, body_end in go_func_body_spans(src, GO_TEST_FUNCTION_NAME):
+    for name, body_start, body_end in go_func_body_spans(src, GO_TEST_FUNCTION_NAME):
+        if not go_name_is_a_go_test(name):
+            continue
         test_spans.append((body_start, body_end))
         body = src[body_start:body_end]
         brace_pairs = go_brace_pairs(body)
@@ -1510,6 +1630,16 @@ def proof_registrations(proof_dir):
     file, because the argument or the call alone does not say where to go and fix it, and an
     unreadable run carries its reason, because the six ways a run can be unreadable are fixed
     in six different places.
+
+    A file a build constraint keeps out of the build is skipped whole, because `go test` never
+    compiles it and a run it holds never executes. That is read from the raw file, ahead of the
+    scrubber that blanks the constraint along with every other comment.
+
+    `proof_functions` reads the same directory without that skip, so a step function DEFINED in
+    a never-built file is still collected. Both halves of the disagreement that leaves are
+    loud: the step list claims a function whose registration is now missing, or no step claims
+    a function nothing registers. A false failure naming a real file is the safe side of a rule
+    this narrow, and it is the reading a compiling proof never reaches.
     """
     found = set()
     misnamed = set()
@@ -1520,8 +1650,11 @@ def proof_registrations(proof_dir):
         if not entry.endswith('_test.go'):
             continue
         path = os.path.join(proof_dir, entry)
-        src = strip_go_comments_and_literals(read(path))
-        registered, other, unread = registered_step_functions(src)
+        text = read(path)
+        if go_file_is_never_built(text):
+            continue
+        registered, other, unread = registered_step_functions(
+            strip_go_comments_and_literals(text))
         found.update(registered)
         misnamed.update((path, argument) for argument in other)
         unreadable.update((path, label, reason) for label, reason in unread)

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -892,33 +892,98 @@ def go_type_end(text, index):
     return index
 
 
-def go_func_literal_has_body(body, open_paren):
-    """Whether the `func` whose parameter list opens at open_paren is a literal with a body.
+def go_func_literal_body_start(body, open_paren):
+    """The index of the brace opening the body of the func whose list opens at open_paren.
 
-    A func TYPE binds nothing. `var handle func(arg stepType)`, `type handler func(arg
-    stepType)`, a func-typed struct field and a func type nested in another literal's
-    parameter list all write a parameter list that no body can read, so reading names out of
-    one collects identifiers that nothing in the file binds.
+    None when no brace follows the signature, which is what a func TYPE writes. A type binds
+    nothing. `var handle func(arg stepType)`, `type handler func(arg stepType)`, a func-typed
+    struct field and a func type nested in another literal's parameter list all write a
+    parameter list that no body can read, so reading names out of one collects identifiers
+    that nothing in the file binds.
 
     Requiring a body drops exactly those and excludes nothing that binds, because every func
     literal in Go has a body. What stands between the parameter list and that body is either
     nothing, a parenthesised result list, or one unparenthesised result type.
+
+    This test is local, so it can ask only whether a brace FOLLOWS the signature, never whose
+    brace it is. A func type written inside other type text is followed by a brace that opens
+    something else — the body of the literal whose result the type is, or a composite
+    literal's value — and this test accepts it. Whose brace it is depends on the text around
+    the match, so it is decided by the scan in `go_func_literal_parameter_lists`, which is
+    what callers wanting literals only must use.
     """
     closing = matching_delimiter(body, open_paren)
     if closing is None:
-        return False
+        return None
     index = go_skip_line_space(body, closing + 1)
     if body[index:index + 1] == '(':
         results = matching_delimiter(body, index)
         if results is None:
-            return False
+            return None
         index = go_skip_line_space(body, results + 1)
     elif body[index:index + 1] not in ('{', ''):
         index = go_type_end(body, index)
         if index is None:
-            return False
+            return None
         index = go_skip_line_space(body, index)
-    return body[index:index + 1] == '{'
+    return index if body[index:index + 1] == '{' else None
+
+
+def go_element_type_bracket_before(body, keyword):
+    """Whether the `func` keyword at keyword is the element type of a bracketed type.
+
+    `[]func(arg stepType)`, `[2]func(arg stepType)` and `map[string]func(arg stepType)` all
+    write a func TYPE, and all three announce it the same way: with the `]` that closes their
+    brackets standing immediately before the `func`. Go writes no expression that puts a `]`
+    there, so the character decides it, and it is the only character that can — a func literal
+    in expression position follows an operator, a delimiter, a keyword, or nothing.
+
+    Only spaces and tabs are crossed looking back, never a line break. A statement ending in
+    `]` on the line above says nothing about the `func` opening the next one, and gofmt writes
+    the bracketed type and its element type together on one line.
+    """
+    index = keyword - 1
+    while index >= 0 and body[index] in ' \t':
+        index -= 1
+    return index >= 0 and body[index] == ']'
+
+
+def go_func_literal_parameter_lists(body):
+    """Every func LITERAL's parameter list in body, as open-paren indexes in source order.
+
+    A `func(` match is a literal only when it opens one. The same characters write a func TYPE
+    inside larger type text, where the brace `go_func_literal_body_start` finds belongs to
+    something else, and a type binds nothing anywhere in the program. Two shapes reach it:
+
+      1. A result type. In `factory := func() func(arg stepType) {`, the returned type's own
+         parameter list is followed by the OUTER literal's body brace.
+      2. A bracketed element type. In `table := []func(arg stepType){}`, the parameter list is
+         followed by the composite literal's value brace.
+
+    Neither is decidable from the brace, and both are decidable from the scan. A literal's
+    result type runs from its parameter list to its body brace, so every match inside that
+    span is type text, and the scan runs in source order, which puts the enclosing literal's
+    span in hand before the matches it covers. Case 2 is decided by the bracket that precedes
+    the keyword.
+
+    What this does NOT decide is scope. A func literal nested in another one is a literal, and
+    its parameters are collected, because the chokepoint below asks only whether a name is
+    bound somewhere in the body. That conservative reading is the design, not an oversight.
+    """
+    open_parens = []
+    type_spans = []
+    for match in re.finditer(r'\bfunc\s*\(', body):
+        if any(start <= match.start() < end for start, end in type_spans):
+            continue
+        if go_element_type_bracket_before(body, match.start()):
+            continue
+        open_paren = match.end() - 1
+        brace = go_func_literal_body_start(body, open_paren)
+        if brace is None:
+            continue
+        open_parens.append(open_paren)
+        type_spans.append((matching_delimiter(body, open_paren) + 1, brace))
+    return open_parens
 
 
 def go_signature_groups(text):
@@ -1051,10 +1116,8 @@ def go_bound_names(body):
     for match in re.finditer(r'\bvar\b', body):
         for spec in go_var_specs(body, match.end()):
             names.update(go_declared_names(spec))
-    for match in re.finditer(r'\bfunc\s*\(', body):
-        open_paren = match.end() - 1
-        if go_func_literal_has_body(body, open_paren):
-            names.update(go_signature_names(body, open_paren))
+    for open_paren in go_func_literal_parameter_lists(body):
+        names.update(go_signature_names(body, open_paren))
     return names
 
 

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -341,8 +341,41 @@ def proof_path_is_tracked_or_committed(path):
     return committed.returncode == 0
 
 
+def go_literal_end(src, start):
+    """Where the string, rune or raw literal at start ends, and whether it is terminated.
+
+    The end is one past the closing delimiter of a terminated literal, and the end of the
+    source for one the file never closes.
+    """
+    quote = src[start]
+    if quote == '`':
+        closing = src.find('`', start + 1)
+        return (len(src), False) if closing == -1 else (closing + 1, True)
+    index = start + 1
+    while index < len(src):
+        if src[index] == '\\':
+            index += 2
+            continue
+        if src[index] == quote:
+            return index + 1, True
+        index += 1
+    return len(src), False
+
+
 def strip_go_comments_and_literals(src):
-    """Blank Go comments and literals so proof registration is read from code only."""
+    """Blank Go comments and literals so proof registration is read from code only.
+
+    A literal's own text goes and its CLOSING delimiter stays, so what is left where a literal
+    stood is a token that can end a statement. Blanking the delimiter too left `label = "one"`
+    reading as `label =`, a line Go's semicolon insertion continues into the next one, and a
+    `var ( ... )` block written over several lines was then read as one declaration instead of
+    several: only the first spec's names came out as bound, and a `step<Title>` local declared
+    under a string-initialised one was never seen by the chokepoint.
+
+    The closing delimiter is the one to keep, because it is the one a statement can end on. A
+    raw string's opening backtick can stand on a line the literal itself continues past, and a
+    line break inside a raw string ends no statement in Go.
+    """
     out = list(src)
     i = 0
     while i < len(src):
@@ -362,26 +395,9 @@ def strip_go_comments_and_literals(src):
                     out[k] = ' '
             i = j
             continue
-        if src[i] in ('"', "'"):
-            quote = src[i]
-            j = i + 1
-            while j < len(src):
-                if src[j] == '\\':
-                    j += 2
-                    continue
-                if src[j] == quote:
-                    j += 1
-                    break
-                j += 1
-            for k in range(i, min(j, len(src))):
-                if out[k] != '\n':
-                    out[k] = ' '
-            i = j
-            continue
-        if src[i] == '`':
-            j = src.find('`', i + 1)
-            j = len(src) if j == -1 else j + 1
-            for k in range(i, j):
+        if src[i] in ('"', "'", '`'):
+            j, terminated = go_literal_end(src, i)
+            for k in range(i, j - 1 if terminated else j):
                 if out[k] != '\n':
                     out[k] = ' '
             i = j
@@ -643,6 +659,9 @@ def go_block_condition(src, opening):
     enclosure holds runs when the statement around it does. Reading those enclosures as guards
     is how a proof that registers its steps from a table used to look as though no Test
     registered anything.
+
+    Whether the statement around a func literal ever RUNS that literal is a separate question
+    this does not answer; `go_unreached_literal_spans` does, on the reached-literal axis.
     """
     header = go_block_header(src, opening)
     if not go_header_is_guard(header):
@@ -686,7 +705,8 @@ def go_call_reachability(src, pos, brace_pairs):
 
     True when nothing the gate reads keeps it from running, False when a known-false
     condition or an unconditional early return does, and None when a block encloses it whose
-    condition the gate cannot read.
+    condition the gate cannot read. A func literal that never runs keeps a run off the test
+    path too, and that is read separately, by `go_unreached_literal_spans`.
 
     None is not False. A run the gate cannot decide about is one it cannot report on, so the
     caller reads it as unreadable rather than dropping it. Dropping it was worse than saying
@@ -722,11 +742,15 @@ def go_statement_ends_at_line(text):
     an identifier, a literal, a closing bracket, or ++/--. A line ending in `=`, a comma or an
     operator continues into the next one, which is what keeps a multi-line declaration from
     being read as several.
+
+    A literal reaches this rule as its closing delimiter alone, which is what
+    `strip_go_comments_and_literals` leaves standing, so the backtick of a raw string ends a
+    statement here exactly as a quote does.
     """
     stripped = text.rstrip()
     if not stripped:
         return True
-    return re.search(r'(?:\w|[)\]}\'"]|\+\+|--)$', stripped) is not None
+    return re.search(r'(?:\w|[)\]}\'"`]|\+\+|--)$', stripped) is not None
 
 
 def go_var_specs(body, start):
@@ -986,6 +1010,78 @@ def go_func_literal_parameter_lists(body):
     return open_parens
 
 
+def go_func_literal_bodies(body):
+    """(keyword, opening brace, closing brace) for every func LITERAL written in body.
+
+    The keyword is the `func` of the literal itself, which is the last one before its
+    parameter list, because only whitespace can stand between the two.
+    """
+    bodies = []
+    for open_paren in go_func_literal_parameter_lists(body):
+        opening = go_func_literal_body_start(body, open_paren)
+        closing = matching_delimiter(body, opening)
+        if closing is None:
+            continue
+        bodies.append((body.rfind('func', 0, open_paren), opening, closing))
+    return bodies
+
+
+ASSIGNMENT_END = re.compile(r'(?<![=!<>])=\s*$')
+
+
+def go_func_literal_bound_names(body, keyword):
+    """The names the func literal at keyword is assigned to, or None when it is assigned none.
+
+    The literal's own statement is read back to its start, so what stands in front of the
+    keyword says which POSITION the literal is written in. A statement head ending in an `=`
+    that is not part of a comparison is an assignment or a declaration, and the identifier list
+    at its start is what the literal is bound to. Every other head — an argument list, a
+    `return`, a `go` or `defer`, a composite literal's element or field, a statement of its
+    own — puts the literal somewhere it is not stored under a name.
+    """
+    head = body[go_statement_start(body, keyword):keyword]
+    assignment = ASSIGNMENT_END.search(head)
+    if assignment is None:
+        return None
+    left = re.sub(r'^\s*var\b', '', head[:assignment.start()])
+    match = re.match(r'\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)', left)
+    return [] if match is None else re.findall(r'[A-Za-z_]\w*', match.group(1))
+
+
+def go_literal_is_invoked_where_it_stands(body, closing):
+    """Whether the func literal whose body closes at `closing` is called on the spot.
+
+    `func() { ... }()` is the whole shape, and `go` and `defer` write it too, because Go takes
+    a call after either keyword and not a bare literal.
+    """
+    index = go_skip_line_space(body, closing + 1)
+    return body[index:index + 1] == '('
+
+
+def go_name_is_called(body, name):
+    """Whether `name` stands in call position anywhere in body."""
+    return re.search(r'\b%s\s*\(' % re.escape(name), body) is not None
+
+
+def go_unreached_literal_spans(body):
+    """The bodies of func literals this gate cannot say run, as (opening, closing) spans.
+
+    See THE REACHED-LITERAL AXIS below for what the two positions are and why the second is
+    reported rather than counted.
+    """
+    spans = []
+    for keyword, opening, closing in go_func_literal_bodies(body):
+        if go_literal_is_invoked_where_it_stands(body, closing):
+            continue
+        names = go_func_literal_bound_names(body, keyword)
+        if names is None:
+            continue
+        if any(go_name_is_called(body, name) for name in names):
+            continue
+        spans.append((opening, closing))
+    return spans
+
+
 def go_signature_groups(text):
     """One parameter or result list, split into groups at its own top-level commas.
 
@@ -1184,9 +1280,10 @@ def go_bound_names(body):
 #
 # Go's grammar closes this axis, not this repo's conventions, which is why it can be listed
 # once. Only the if / else if / else family skips its own block on a condition. A `for`, a
-# `switch`, a `select`, a func literal (invoked, deferred, started with `go`, or handed to
-# `t.Run`), a plain block, a labelled statement and a composite literal all enclose what is
-# written inside them, and what an enclosure holds runs when the statement around it runs. So
+# `switch`, a `select`, a func literal, a plain block, a labelled statement and a composite
+# literal all enclose what is written inside them, and what an enclosure holds runs when the
+# statement around it runs. Whether the statement around a func literal runs the literal is a
+# separate question, and THE REACHED-LITERAL AXIS below is where it is answered. So
 # the walk reads the header back to the statement start and dispatches on the keyword standing
 # there: the enclosure verdict is what that keyword says, rather than what an unread header
 # happened to fall through to. Reading only the last line before the brace was the earlier
@@ -1214,9 +1311,59 @@ def go_bound_names(body):
 #      Go, the scan stops at the line break, and the block then reads as an enclosure. gofmt
 #      rewrites it to one line, so no committed proof can hold the shape; the test table pins
 #      both the misreading and the rewrite rather than leaving the gap unwritten.
+#
+# THE REACHED-LITERAL AXIS: DOES THE FUNC LITERAL HOLDING THE RUN EVER RUN
+#
+# A func literal encloses what is written in it, so the guard axis says a run inside one runs
+# when the statement around the literal runs. That is the right reading of the brace and the
+# wrong reading of the literal: `unused := func() { proofkit.Run(t, cases, stepOne) }` writes a
+# statement that runs and a run that never does, and counting stepOne registered there is a
+# silent false pass in the same shape the chokepoint above exists to close.
+#
+# The POSITION the literal is written in settles it, and reading a position is what this module
+# can do. `go_unreached_literal_spans` splits the two:
+#
+#   * Reached. A literal invoked where it stands — `func() { ... }()`, and the `go` and `defer`
+#     forms of the same shape, because Go takes a call after either keyword. A literal in
+#     argument position, `t.Run("name", func(t *testing.T) { ... })`, which the test framework
+#     calls. A literal stored under a name that stands in call position somewhere in the same
+#     Test body. Anything else that is not an assignment: a composite literal's element, a
+#     struct field, a `return` operand.
+#   * Unreached. A literal stored under a name that never stands in call position in that body.
+#     A run inside one is reported unreadable rather than counted.
+#
+# Reporting EVERY func-literal enclosure unreadable was the other candidate and it is refused
+# here in writing, because it takes the `t.Run` subtest with it — the pattern this whole file
+# was rewritten to stop reporting as unregistered. An audit of that version failed 38 of 61
+# cases across 11 tests, two of them written for the subtest pattern on purpose.
+#
+# WHAT THIS AXIS GIVES UP
+#
+#   1. Where the call is. The name standing in call position may itself sit in dead code or in
+#      another unreached literal, and the literal is read as reached anyway. Following that is
+#      the call-graph question this gate does not ask, and the same limit is already written
+#      down for a run in a helper. What the check does buy is the shape a drafter actually
+#      writes: a literal built and then called in the same Test body.
+#   2. A literal that escapes under a name. `handlers["x"] = func() { ... }` and a literal
+#      returned or passed on after being stored are read as unreached, because no call on that
+#      name stands in the body. That is a false failure, it is loud, and a proof pays it only
+#      by registering a run from a closure it never calls itself.
+#   3. A literal that is not assigned anywhere. A composite literal's element and a struct
+#      field hold a run the value they belong to may never call, and this axis reads them as
+#      reached, because the position it reads is the assignment. The guard axis pins those
+#      three shapes as enclosures, so moving them is a decision about that table and not a
+#      refinement of this one.
 
 
 STEP_FUNCTION_NAME = re.compile(r'step[A-Z]\w*')
+
+# Which names `go test` runs, written as Go's own rule rather than as a convention: `Test`
+# followed by a rune that is not a lower-case letter, and `Test` on its own. `Test_Profile` and
+# `Test1` are tests, `Testing` is not, and `go vet` refuses a `Testing(t *testing.T)` as a
+# malformed test name, so the two agree on the whole space. Reading only `Test[A-Z]\w*` left a
+# run in a `Test_Profile` or a `Test1` body reported as 'not inside a Go Test function', which
+# names the wrong thing to fix: the Test was there and the gate was not looking for it.
+GO_TEST_FUNCTION_NAME = r'Test(?:[^a-z]\w*)?'
 
 
 def go_bound_step_names(bound_names):
@@ -1245,6 +1392,10 @@ UNREADABLE_GUARD = ("the gate cannot read the condition that guards it, so it ca
                     "guards it")
 UNREADABLE_OUTSIDE_TEST = ("the run is not inside a Go Test function, so the gate cannot say "
                            "which Test reaches it; register the step from a Test body")
+UNREADABLE_CLOSURE = ("the run is inside a func literal that is stored under a name and never "
+                      "called, so the gate cannot say whether the Test reaches it; hand the "
+                      "literal to t.Run, invoke it where it stands, or call the name it is "
+                      "stored under in the same Test body")
 
 
 def unreadable_local_step_reason(names):
@@ -1266,13 +1417,15 @@ def registered_step_functions(src):
     gate then reports the steps such a run registers as registered nowhere, which is false.
     Only the build argument is judged; the gate and assertion arguments are not steps.
 
-    A run is unreadable in five ways, and they are one category because they leave the gate in
-    one state — it cannot say which function the run builds with. The Test body may bind a
-    step<Title> name itself, which is the chokepoint above and covers every scope question at
-    once. A block the gate cannot read may guard the run. The argument list may never close; it
-    may be shorter than the build slot, which is what a run written as one multi-value call
-    parses to, the arguments forwarded from a helper rather than written out; or the build
-    argument may be an expression, a bound name or a table entry rather than a name. Each
+    A run is unreadable in six ways, and they are one category because they leave the gate in
+    one state — it cannot say which function the run builds with, or whether the Test runs it
+    at all. The Test body may bind a step<Title> name itself, which is the chokepoint above and
+    covers every scope question at once. A block the gate cannot read may guard the run. A func
+    literal that is stored under a name and never called may hold it, which is the
+    reached-literal axis above. The argument list may never close; it may be shorter than the
+    build slot, which is what a run written as one multi-value call parses to, the arguments
+    forwarded from a helper rather than written out; or the build argument may be an
+    expression, a bound name or a table entry rather than a name. Each
     compiles, so silently skipping any of them would let a build argument escape the
     step<Title> check. Each unreadable run carries the label of the thing to look at and the
     reason the gate stopped there. The label carries the whole call where no argument reached
@@ -1285,12 +1438,13 @@ def registered_step_functions(src):
     misnamed = set()
     unreadable = set()
     test_spans = []
-    for _, body_start, body_end in go_func_body_spans(src, r'Test[A-Z]\w*'):
+    for _, body_start, body_end in go_func_body_spans(src, GO_TEST_FUNCTION_NAME):
         test_spans.append((body_start, body_end))
         body = src[body_start:body_end]
         brace_pairs = go_brace_pairs(body)
         bound_names = go_bound_names(body)
         bound_step_names = go_bound_step_names(bound_names)
+        unreached_literals = go_unreached_literal_spans(body)
         for pattern, build_arg in PROOF_RUN_CALLS:
             for m in re.finditer(pattern, body):
                 reachable = go_call_reachability(body, m.start(), brace_pairs)
@@ -1300,6 +1454,9 @@ def registered_step_functions(src):
                 close_paren = matching_delimiter(body, open_paren)
                 call = (body[m.start():] if close_paren is None
                         else body[m.start():close_paren + 1])
+                if any(start < m.start() < end for start, end in unreached_literals):
+                    unreadable.add((go_argument_label(call), UNREADABLE_CLOSURE))
+                    continue
                 if reachable is None:
                     unreadable.add((go_argument_label(call), UNREADABLE_GUARD))
                     continue
@@ -1351,8 +1508,8 @@ def proof_registrations(proof_dir):
     They are the step functions registered from a Go Test, the misnamed builds as (file,
     label) pairs, and the unreadable runs as (file, label, reason) triples. A label carries its
     file, because the argument or the call alone does not say where to go and fix it, and an
-    unreadable run carries its reason, because the five ways a run can be unreadable are fixed
-    in five different places.
+    unreadable run carries its reason, because the six ways a run can be unreadable are fixed
+    in six different places.
     """
     found = set()
     misnamed = set()

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -645,15 +645,37 @@ def go_enclosing_block_close(body, brace_pairs, pos):
     return close
 
 
+def go_group_closes_the_statement(body, closing):
+    """Whether nothing but whitespace follows a brace group's close before the statement ends.
+
+    A statement ends at a newline, at a `;`, or at the `}` of the block it sits in, so a group
+    that reaches one of those with only whitespace in between is the last thing the statement
+    writes.
+    """
+    for ch in body[closing + 1:]:
+        if ch in '\n;}':
+            return True
+        if not ch.isspace():
+            return False
+    return True
+
+
 def go_header_block_close(body, brace_pairs, pos):
     """Where the block a statement header introduces closes, or None when none follows.
 
     A `for` or `if` header is written in the enclosing block, but what it binds is scoped to
-    the block that header opens, so that block is what bounds it. The scan skips balanced
-    groups, and takes the first brace at the header's own depth that follows whitespace: gofmt
-    writes a space before a block's opening brace and none before a composite literal's, which
-    is what tells the block in `for _, build := range []proofkit.Build{stepOne} {` from the
-    literal in the same header.
+    the block that header opens, so that block is what bounds it. The scan skips every balanced
+    brace group from the binding onward and takes the group, at the header's own paren and
+    bracket depth, whose close is the last thing on the statement. The block a header opens is
+    always in that position, and nothing else in the header is: whatever a header writes before
+    the block — a composite literal, a struct or interface type, a function literal — is
+    followed by the block itself, or by the call parentheses, the `;` or the operand that
+    carries the header on.
+
+    The rule has to be positional. Brace matching cannot see where the range expression ends,
+    and it cannot read the spacing either: gofmt leaves a space before a multi-line
+    `[]struct {` or a function literal's own brace just as it does before a block's, so the
+    character in front of a brace says nothing about which kind it opens.
     """
     depth = 0
     while pos < len(body):
@@ -667,9 +689,10 @@ def go_header_block_close(body, brace_pairs, pos):
         elif ch == '{':
             if pos not in brace_pairs:
                 return None
-            if depth == 0 and pos > 0 and body[pos - 1].isspace():
-                return brace_pairs[pos]
-            pos = brace_pairs[pos]
+            closing = brace_pairs[pos]
+            if depth == 0 and go_group_closes_the_statement(body, closing):
+                return closing
+            pos = closing
         pos += 1
     return None
 

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -480,37 +480,181 @@ def go_brace_depth(src, pos):
     return sum(char == '{' for char in src[:pos]) - sum(char == '}' for char in src[:pos])
 
 
+def go_open_delimiter(src, closing):
+    """Return the index of the delimiter that src[closing] closes, or None."""
+    pairs = {')': '(', ']': '[', '}': '{'}
+    stack = [src[closing]]
+    for index in range(closing - 1, -1, -1):
+        char = src[index]
+        if char in pairs:
+            stack.append(char)
+        elif char in '([{':
+            if pairs[stack[-1]] != char:
+                return None
+            stack.pop()
+            if not stack:
+                return index
+    return None
+
+
+def go_statement_start(src, opening):
+    """Where the statement whose block opens at `opening` begins.
+
+    The scan walks back from the brace over whole bracket groups, so a condition wrapped
+    across lines, and an arm the chain has already closed, are stepped over rather than
+    ending it. It stops at the first statement boundary: the unmatched `{`, `(` or `[` of the
+    construct this statement sits inside, or a newline where Go's own semicolon insertion
+    would end the line. See THE GUARD AXIS below for what this reading can and cannot reach.
+    """
+    index = opening
+    while index > 0:
+        char = src[index - 1]
+        if char in ')]}':
+            start = go_open_delimiter(src, index - 1)
+            if start is None:
+                return index
+            index = start
+            continue
+        if char in '([{':
+            return index
+        if char == '\n':
+            if go_statement_ends_at_line(src[:index - 1]):
+                return index
+            index -= 1
+            continue
+        index -= 1
+    return 0
+
+
 def go_block_header(src, opening):
-    """The text before a block's opening brace, on one line."""
-    line_start = src.rfind('\n', 0, opening) + 1
-    return re.sub(r'\s+', ' ', src[line_start:opening]).strip()
+    """The whole header of the block opening at `opening`, on one line.
+
+    It runs from the statement start, so it carries the construct's keyword whatever the lines
+    between look like: an `if` whose condition wraps, an init statement, and for an `else` arm
+    the whole chain it hangs off, up to but not including its own brace.
+    """
+    return re.sub(r'\s+', ' ', src[go_statement_start(src, opening):opening]).strip()
 
 
-def go_if_condition(header):
-    """The condition an if block header states, or None when the header is not an if."""
-    match = re.search(r'\bif\s+(.+)$', header)
-    if not match:
-        return None
-    return match.group(1).strip()
+GUARD_HEADER = re.compile(r'^(?:[A-Za-z_]\w*\s*:\s+)*(if|else)\b')
+ARM_KEYWORD = re.compile(r'\s*(else if|if|else)\b')
+
+
+def go_header_is_guard(header):
+    """Whether a header opens an arm of an if chain rather than an enclosure.
+
+    Go gives only the if / else if / else family the power to skip its own block on a
+    condition. Every other brace a walk crosses — `for`, `switch`, `select`, a func literal, a
+    plain block, a composite literal, a labelled statement — encloses what is written inside
+    it. So the keyword the header opens with settles this, and a header read back to the
+    statement start always has that keyword in it.
+    """
+    return GUARD_HEADER.match(header) is not None
+
+
+def go_arm_condition(header, start):
+    """One arm's condition text from start, with the position after that arm's body.
+
+    A `{` at the header's own depth ends the condition only when an `else` follows the group
+    it opens, which is what a closed arm looks like from here. Any other group at that depth
+    is a composite literal inside an init statement or a condition, so the scan steps over it
+    and keeps reading.
+    """
+    index = start
+    depth = 0
+    while index < len(header):
+        char = header[index]
+        if char in '([':
+            depth += 1
+        elif char in ')]':
+            depth -= 1
+        elif char == '{' and depth == 0:
+            closing = matching_delimiter(header, index)
+            if closing is None:
+                break
+            if re.match(r'\s*else\b', header[closing + 1:]):
+                return header[start:index].strip(), closing + 1
+            index = closing
+        index += 1
+    return header[start:].strip(), len(header)
+
+
+def go_guard_arms(header):
+    """The conditions an if chain header states: the arms it falls through, and its own.
+
+    Go writes a whole if / else if / else chain as one statement, so the header of any arm
+    starts at the chain's `if` and carries every arm before it. The arm this header opens is
+    the last one, and its own condition is None when it is a bare `else`.
+    """
+    text = header[GUARD_HEADER.match(header).start(1):]
+    preceding = []
+    own = None
+    position = 0
+    while position < len(text):
+        keyword = ARM_KEYWORD.match(text, position)
+        if keyword is None:
+            break
+        position = keyword.end()
+        if keyword.group(1) == 'else':
+            own = None
+            break
+        condition, position = go_arm_condition(text, position)
+        own = condition
+        if position >= len(text):
+            break
+        preceding.append(condition)
+        own = None
+    return preceding, own
+
+
+def go_condition_value(condition):
+    """True, False or None for one arm's condition: taken, never taken, or unreadable.
+
+    The init statement an `if` may carry decides nothing, so only the expression after the
+    last `;` at the condition's own depth is read. Three forms are known; anything else,
+    a compound of literals included, is a condition this gate would have to evaluate, and it
+    says it cannot read it rather than guessing.
+    """
+    if condition is None:
+        return True
+    depth = 0
+    cut = -1
+    for index, char in enumerate(condition):
+        if char in '([{':
+            depth += 1
+        elif char in ')]}':
+            depth -= 1
+        elif char == ';' and depth == 0:
+            cut = index
+    expression = condition[cut + 1:].strip()
+    if expression == 'false':
+        return False
+    if expression in ('true', 't != nil'):
+        return True
+    return None
 
 
 def go_block_condition(src, opening):
     """Return the known reachability of a block, or None when it is unknown.
 
-    Only an `if` decides whether its block runs. A `for` loop, the closure a `t.Run` subtest
-    takes, a `switch` and every other brace the walk crosses on its way to a run enclose that
-    run rather than guard it, so a run inside one still executes on the test path. Reading
-    those enclosures as guards is how a proof that registers its steps from a table used to
-    look as though no Test registered anything.
+    An arm of an if chain runs when no arm before it was taken and its own condition holds, so
+    a bare `else` inherits the readability of the chain it closes: it is unreadable whenever
+    any condition before it is. Every other brace encloses rather than guards, and what an
+    enclosure holds runs when the statement around it does. Reading those enclosures as guards
+    is how a proof that registers its steps from a table used to look as though no Test
+    registered anything.
     """
-    condition = go_if_condition(go_block_header(src, opening))
-    if condition is None:
+    header = go_block_header(src, opening)
+    if not go_header_is_guard(header):
         return True
-    if condition == 'false':
+    preceding, own = go_guard_arms(header)
+    values = [go_condition_value(condition) for condition in preceding]
+    own_value = go_condition_value(own)
+    if own_value is False or any(value is True for value in values):
         return False
-    if condition in ('true', 't != nil'):
-        return True
-    return None
+    if any(value is None for value in values):
+        return None
+    return own_value
 
 
 def go_top_level_return_before(src, pos):
@@ -526,9 +670,9 @@ def go_early_return_before(src, pos, brace_pairs):
     for opening, closing in brace_pairs.items():
         if closing >= pos or go_brace_depth(src, opening) != 0:
             continue
-        # Only an if can return early on a known-true condition. A loop or a closure whose
+        # Only an if arm can return early on a known-true condition. A loop or a closure whose
         # whole body is a return says nothing about what follows it.
-        if go_if_condition(go_block_header(src, opening)) is None:
+        if not go_header_is_guard(go_block_header(src, opening)):
             continue
         if go_block_condition(src, opening) is not True:
             continue
@@ -754,6 +898,47 @@ def go_bound_names(body):
 # makes this Python gate depend on the Go toolchain being present to run at all, which is a
 # structural change beyond the scope this decision was taken in. Take it up and this whole
 # chokepoint, along with the machinery above it, is deleted rather than refined.
+#
+# THE GUARD AXIS: IS A BRACE A GUARD OR AN ENCLOSURE
+#
+# The map above crossed binding constructs with header shapes to decide which NAMES a body
+# binds. This is the other question the walk asks of a brace it crosses on its way to a run:
+# does that brace guard the run, and if it does, can its condition be read. The two axes are
+# independent, and the chokepoint answers only the first, so this one is answered here, by
+# `go_block_header` and `go_block_condition`.
+#
+# Go's grammar closes this axis, not this repo's conventions, which is why it can be listed
+# once. Only the if / else if / else family skips its own block on a condition. A `for`, a
+# `switch`, a `select`, a func literal (invoked, deferred, started with `go`, or handed to
+# `t.Run`), a plain block, a labelled statement and a composite literal all enclose what is
+# written inside them, and what an enclosure holds runs when the statement around it runs. So
+# the walk reads the header back to the statement start and dispatches on the keyword standing
+# there: the enclosure verdict is what that keyword says, rather than what an unread header
+# happened to fall through to. Reading only the last line before the brace was the earlier
+# rule, and it left a wrapped `if` header as `)`, which matched no condition and made the guard
+# read as an enclosure — the same guard passing when written over three lines and failing when
+# written on one.
+#
+# An `else` arm carries its whole chain in its header, because Go writes a chain as one
+# statement. It runs when every condition before it was false, so it inherits their
+# readability: the `else` closing an unreadable `if` is unreadable itself, and a run inside it
+# is reported rather than counted.
+#
+# WHAT THIS AXIS STILL CANNOT READ
+#
+#   1. A condition that is not one of three literal forms. `false` is dead, `true` and
+#      `t != nil` are live, and everything else — a call, a variable, a comparison, and a
+#      compound of literals such as `false || false` — is unreadable. That is item 3 of the
+#      list above reached from the other side. The compound is decidable and is still refused,
+#      because deciding it means evaluating Go, and this axis reads keywords.
+#   2. A statement boundary gofmt does not write. The scan ends a statement where Go's own
+#      semicolon insertion ends a line, so two statements written on one line with a `;`
+#      between them would be read as a single header. gofmt splits them, and no proof here
+#      writes them.
+#   3. An `if` left alone on its line with its condition starting the next one. That is legal
+#      Go, the scan stops at the line break, and the block then reads as an enclosure. gofmt
+#      rewrites it to one line, so no committed proof can hold the shape; the test table pins
+#      both the misreading and the rewrite rather than leaving the gap unwritten.
 
 
 STEP_FUNCTION_NAME = re.compile(r'step[A-Z]\w*')

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -834,6 +834,26 @@ def go_bound_names(body):
 
     No position is recorded, because the chokepoint below asks only whether a name is bound
     somewhere in the body, never where.
+
+    `const` and `type` are deliberately NOT read, and that is a claim you can falsify rather
+    than a gap. Neither can occupy a build slot: every `PROOF_RUN_CALLS` entry points at slot
+    2, which is `proofkit.Build` or `proofkit3d.Build`, both func types. Go restricts constants
+    to boolean, rune, integer, float, complex and string, so `const stepOne proofkit.Build =
+    nil` is rejected as `invalid constant type`, and `const stepOne = 0` passed to a run is
+    rejected as `cannot use stepOne (untyped int constant 0) as proofkit.Build value`. A type
+    name is never an expression, so `type stepOne struct{}`, a `type stepOne = proofkit.Build`
+    alias and a func-typed declaration are all rejected as `stepOne (type) is not an
+    expression`. Checked against the real packages with go1.26.1.
+
+    Reading them would therefore add false failures and no soundness: the only step-named
+    `const` or `type` declarations that COMPILE are ones a run does not resolve against —
+    declared after the run, or in a sibling block — and in each the run's argument really is
+    the package-level step function, so counting it registered is the correct answer. The one
+    shape where such a name reaches a run's argument text is a conversion,
+    `stepOne(buildX)`, and that is already unreadable because it is not a bare identifier.
+
+    To falsify this, exhibit a `const` or `type` declaration that COMPILES as a build argument
+    and shadows a package-level step function. `go vet` deciding it is the whole test.
     """
     names = set()
     for match in re.finditer(r':=', body):

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -785,8 +785,9 @@ def go_short_declaration_names(body, assign):
     last token can end a statement stops the scan, which is the same rule Go's own semicolon
     insertion uses.
 
-    A keyword swept up in front of the list — `for`, `if`, `case` — costs nothing, because no
-    build argument is written as one.
+    A keyword swept up in front of the list — `for`, `if`, `case` — costs nothing, because
+    these names are judged against `step<Title>` at the chokepoint and no Go keyword can match
+    it. What a name here costs is measured on that path, not on the build-argument path.
     """
     start = assign
     while start > 0:
@@ -803,24 +804,213 @@ def go_short_declaration_names(body, assign):
     return re.findall(r'[A-Za-z_]\w*', body[start:assign])
 
 
-def go_signature_names(body, open_paren):
-    """The identifiers a func literal's parameter list, and its named result list, write.
+# A type keyword can lead a parameter group without any name standing in front of it, so a
+# group starting with one of these is a bare type: `chan int`, `map[string]int`, `struct {`,
+# `interface {`, `func(`. Only `chan` and the two brace forms can hold whitespace at the
+# group's own top level, which is why the keyword has to be recognised rather than the space.
+GO_TYPE_KEYWORDS = frozenset(('chan', 'map', 'struct', 'interface', 'func'))
 
-    Both lists bind names in the literal's body, and both are read whole rather than split
-    into name and type: a type name swept up alongside a parameter name costs nothing, because
-    no build argument is written as a type.
+GO_GROUP_HEAD = re.compile(r'\s*([A-Za-z_]\w*)(\s+(?=\S))?', re.S)
+
+
+def go_skip_line_space(text, index):
+    """The index of the first character at or after index that is not a space or a tab.
+
+    Newlines are not crossed. Go ends a statement at a line break whose last token can end
+    one, so a `func` signature and the brace opening its body stand on one line, and a `{` on
+    the next line opens a plain block after a func TYPE instead.
+    """
+    while index < len(text) and text[index] in ' \t':
+        index += 1
+    return index
+
+
+def go_type_end(text, index):
+    """The index just past the type written at index, or None if no type is written there.
+
+    Only enough of Go's type grammar to walk over one result type: the prefixes `*`, `[]`,
+    `[N]`, `<-` and `...`, the four keyword forms, and a plain or qualified name with an
+    optional generic instantiation. It exists to find the brace after a func literal's single
+    unparenthesised result, `func(arg stepType) error {`, which is a literal whose parameters
+    bind and which a bare "is the next character a brace" test would drop.
+    """
+    while True:
+        index = go_skip_line_space(text, index)
+        if text.startswith('...', index) or text.startswith('<-', index):
+            index += 3 if text.startswith('...', index) else 2
+            continue
+        if text[index:index + 1] == '*':
+            index += 1
+            continue
+        if text[index:index + 1] == '[':
+            closing = matching_delimiter(text, index)
+            if closing is None:
+                return None
+            index = closing + 1
+            continue
+        break
+    word = re.match(r'[A-Za-z_]\w*', text[index:])
+    if word is None:
+        return None
+    index += word.end()
+    if word.group() == 'chan':
+        return go_type_end(text, index)
+    if word.group() == 'map':
+        index = go_skip_line_space(text, index)
+        if text[index:index + 1] != '[':
+            return None
+        closing = matching_delimiter(text, index)
+        return None if closing is None else go_type_end(text, closing + 1)
+    if word.group() in ('struct', 'interface'):
+        index = go_skip_line_space(text, index)
+        if text[index:index + 1] != '{':
+            return None
+        closing = matching_delimiter(text, index)
+        return None if closing is None else closing + 1
+    if word.group() == 'func':
+        index = go_skip_line_space(text, index)
+        if text[index:index + 1] != '(':
+            return None
+        closing = matching_delimiter(text, index)
+        if closing is None:
+            return None
+        after = go_skip_line_space(text, closing + 1)
+        if text[after:after + 1] == '(':
+            results = matching_delimiter(text, after)
+            return closing + 1 if results is None else results + 1
+        # A func type's own result is optional, and what follows may be the brace of the body
+        # this whole type is the result of, so an unreadable one ends the type here.
+        return go_type_end(text, after) or closing + 1
+    qualified = re.match(r'\s*\.\s*[A-Za-z_]\w*', text[index:])
+    if qualified is not None:
+        index += qualified.end()
+    if text[index:index + 1] == '[':
+        closing = matching_delimiter(text, index)
+        if closing is None:
+            return None
+        index = closing + 1
+    return index
+
+
+def go_func_literal_has_body(body, open_paren):
+    """Whether the `func` whose parameter list opens at open_paren is a literal with a body.
+
+    A func TYPE binds nothing. `var handle func(arg stepType)`, `type handler func(arg
+    stepType)`, a func-typed struct field and a func type nested in another literal's
+    parameter list all write a parameter list that no body can read, so reading names out of
+    one collects identifiers that nothing in the file binds.
+
+    Requiring a body drops exactly those and excludes nothing that binds, because every func
+    literal in Go has a body. What stands between the parameter list and that body is either
+    nothing, a parenthesised result list, or one unparenthesised result type.
+    """
+    closing = matching_delimiter(body, open_paren)
+    if closing is None:
+        return False
+    index = go_skip_line_space(body, closing + 1)
+    if body[index:index + 1] == '(':
+        results = matching_delimiter(body, index)
+        if results is None:
+            return False
+        index = go_skip_line_space(body, results + 1)
+    elif body[index:index + 1] not in ('{', ''):
+        index = go_type_end(body, index)
+        if index is None:
+            return False
+        index = go_skip_line_space(body, index)
+    return body[index:index + 1] == '{'
+
+
+def go_signature_groups(text):
+    """One parameter or result list, split into groups at its own top-level commas.
+
+    A comma inside brackets, parentheses or braces belongs to a type — `pair[A, B]`, a nested
+    `func(a, b int)`, a `struct{ x, y int }` field — and separates nothing at this level, so
+    the split tracks nesting depth instead of splitting the text plainly. Groups holding only
+    whitespace are dropped, which is what a list gofmt wrapped over several lines writes after
+    its trailing comma.
+    """
+    groups = []
+    current = ''
+    depth = 0
+    for ch in text:
+        if ch in '([{':
+            depth += 1
+        elif ch in ')]}':
+            depth -= 1
+        elif ch == ',' and depth == 0:
+            groups.append(current)
+            current = ''
+            continue
+        current += ch
+    groups.append(current)
+    return [group for group in groups if group.strip()]
+
+
+def go_group_head(group):
+    """The identifier leading this group, and whether type text follows it.
+
+    Only the LEADING identifier can be a name. Everything from the first type token on is type
+    text and is skipped whole, which is what keeps `arg` and `stepType` out of
+    `func(cb func(arg stepType))` and a field name out of `func(cfg struct{ stepField int })`.
+
+    Whitespace is what separates a name from its type. `pair[stepType]` and `testing.T` open
+    with an identifier too, and gofmt writes no space before the bracket or dot continuing
+    one, so an identifier running straight into either is the head of a type and not a name.
+    A group opening with a type keyword is a bare type whatever follows it.
+    """
+    match = GO_GROUP_HEAD.match(group)
+    if match is None or match.group(1) in GO_TYPE_KEYWORDS:
+        return None, False
+    if match.group(2) is not None:
+        return match.group(1), True
+    if group[match.end():].strip():
+        return None, False
+    return match.group(1), False
+
+
+def go_parameter_names(text):
+    """The names one parameter or result list binds, and none if the list is unnamed.
+
+    Named and unnamed cannot be told apart one group at a time. `(stepType, error)` and
+    `(a, b int)` both hold groups of a single identifier, and only the list as a whole
+    separates them: Go forbids mixing the two forms, so ONE group carrying a name and then a
+    type puts the whole list in named form, and every group's leading identifier is a name.
+    Deciding per group instead reads the type in `func(stepType)` as a name, or loses `a` in
+    `func(a, b stepType)`.
+    """
+    heads = [go_group_head(group) for group in go_signature_groups(text)]
+    if not any(carries_type for _, carries_type in heads):
+        return []
+    return [name for name, _ in heads if name is not None]
+
+
+def go_signature_names(body, open_paren):
+    """The names a func literal's parameter list, and its named result list, bind.
+
+    Names only, never the types standing beside them. These names reach `go_bound_step_names`,
+    which keeps everything matching `step<Title>`, so a type name swept up here is read as a
+    binding: a package-level `type stepResult struct{}` named in a parameter's type would make
+    every run in the body unreadable, suppress the whole proof directory's registration
+    verdict, and tell the drafter to rename a local that was never written. That is the
+    chokepoint path. Reading the lists whole was justified by the build-argument path, where a
+    type name really does cost nothing, and the two paths are not the same one.
+
+    Each list is read on its own, because each carries its own named-or-unnamed form. The
+    result list is read only when it is parenthesised, since an unparenthesised single result
+    is a bare type and binds nothing.
     """
     closing = matching_delimiter(body, open_paren)
     if closing is None:
         return []
-    text = body[open_paren + 1:closing]
+    names = go_parameter_names(body[open_paren + 1:closing])
     rest = body[closing + 1:]
     offset = len(rest) - len(rest.lstrip())
     if rest[offset:offset + 1] == '(':
         results = matching_delimiter(body, closing + 1 + offset)
         if results is not None:
-            text += ',' + body[closing + offset + 2:results]
-    return re.findall(r'[A-Za-z_]\w*', text)
+            names += go_parameter_names(body[closing + offset + 2:results])
+    return names
 
 
 def go_bound_names(body):
@@ -862,7 +1052,9 @@ def go_bound_names(body):
         for spec in go_var_specs(body, match.end()):
             names.update(go_declared_names(spec))
     for match in re.finditer(r'\bfunc\s*\(', body):
-        names.update(go_signature_names(body, match.end() - 1))
+        open_paren = match.end() - 1
+        if go_func_literal_has_body(body, open_paren):
+            names.update(go_signature_names(body, open_paren))
     return names
 
 

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -11,12 +11,14 @@ Four checks gate, and one is reported:
   1. CITATIONS RESOLVE. Every step has a nonempty `**From:**` line naming real files and line
      ranges that exist.
   2. STEPS AND PROOF AGREE. Every `[GO]` step names the proof function that realises it, every
-     proof function is claimed by a step, and every proof run's build argument is a `step<Title>`
-     function so a step can claim it. Drift in either direction means one artifact moved without
-     the other, and a build function under any other name is a proof no step can reach. A run
-     whose arguments this checker cannot read to the build slot — one written as a single
-     multi-value call, say — is reported for the same reason: an unread build argument is an
-     unchecked one.
+     proof function is claimed by a step, and every proof run's build argument is a literal
+     `step<Title>` identifier so a step can claim it. Drift in either direction means one
+     artifact moved without the other, and a build function under any other name is a proof no
+     step can reach. The argument has to be written out, not forwarded with the rest of the
+     argument list and not reached through a table or a variable, because the gate reads Go by
+     matching braces rather than by compiling it: a run it cannot read to a function name is
+     reported as unreadable, and it then says nothing about which steps are registered, rather
+     than calling a registered step unregistered.
   3. API CALLS ARE REAL. Every Fusion call the step list names exists in the API database the
      `fusion` plugin ships. Catches a spec that names a method Fusion does not have.
   4. INPUTS HAVE NOT DRIFTED. The provenance table contains and matches the existing instructions,
@@ -465,14 +467,32 @@ def go_brace_depth(src, pos):
     return sum(char == '{' for char in src[:pos]) - sum(char == '}' for char in src[:pos])
 
 
-def go_block_condition(src, opening):
-    """Return the known reachability of an if block, or None when it is unknown."""
+def go_block_header(src, opening):
+    """The text before a block's opening brace, on one line."""
     line_start = src.rfind('\n', 0, opening) + 1
-    header = src[line_start:opening].strip()
-    match = re.match(r'if\s+(.+)$', header)
+    return re.sub(r'\s+', ' ', src[line_start:opening]).strip()
+
+
+def go_if_condition(header):
+    """The condition an if block header states, or None when the header is not an if."""
+    match = re.search(r'\bif\s+(.+)$', header)
     if not match:
-        return False
-    condition = re.sub(r'\s+', ' ', match.group(1)).strip()
+        return None
+    return match.group(1).strip()
+
+
+def go_block_condition(src, opening):
+    """Return the known reachability of a block, or None when it is unknown.
+
+    Only an `if` decides whether its block runs. A `for` loop, the closure a `t.Run` subtest
+    takes, a `switch` and every other brace the walk crosses on its way to a run enclose that
+    run rather than guard it, so a run inside one still executes on the test path. Reading
+    those enclosures as guards is how a proof that registers its steps from a table used to
+    look as though no Test registered anything.
+    """
+    condition = go_if_condition(go_block_header(src, opening))
+    if condition is None:
+        return True
     if condition == 'false':
         return False
     if condition in ('true', 't != nil'):
@@ -492,6 +512,10 @@ def go_early_return_before(src, pos, brace_pairs):
     """Return whether a known-true top-level if-return precedes pos."""
     for opening, closing in brace_pairs.items():
         if closing >= pos or go_brace_depth(src, opening) != 0:
+            continue
+        # Only an if can return early on a known-true condition. A loop or a closure whose
+        # whole body is a return says nothing about what follows it.
+        if go_if_condition(go_block_header(src, opening)) is None:
             continue
         if go_block_condition(src, opening) is not True:
             continue
@@ -521,27 +545,62 @@ def go_argument_label(argument):
     return label
 
 
+def go_local_bindings(body):
+    """Every name a Go function body binds with := or var, as far as those two forms show.
+
+    A build argument that is one of these is a local holding a build, not the name of one, so
+    the gate cannot say which function the run builds with. Telling the two apart matters:
+    calling a loop variable a misnamed build function sends a drafter to rename the wrong
+    thing. A stray keyword swept up by the scan is harmless, because no build argument is
+    written as one.
+    """
+    names = set()
+    for match in re.finditer(r'([^\n;{}]*?):=', body):
+        names.update(re.findall(r'[A-Za-z_]\w*', match.group(1)))
+    for match in re.finditer(r'\bvar\s+([A-Za-z_]\w*)', body):
+        names.add(match.group(1))
+    return names
+
+
+def go_build_argument_names_a_function(argument, local_names):
+    """Return whether a build argument says, on its own, which function the run builds with.
+
+    A package-level identifier says it, and so does a function literal, which says it is
+    anonymous and therefore no step's. Anything else — a local, a struct field, an index, a
+    call, a qualified name — is an expression the gate would have to evaluate to know what the
+    run builds with, and this is brace matching over scrubbed source, not a Go compiler.
+    """
+    if re.fullmatch(r'[A-Za-z_]\w*', argument):
+        return argument not in local_names
+    return re.match(r'func\s*\(', argument) is not None
+
+
 def registered_step_functions(src):
-    """Return (step functions, other build arguments, unreadable runs) for reachable runs.
+    """Return (step functions, misnamed builds, unreadable runs) for reachable proofkit runs.
 
-    The first two come out of the same parse of the same run, because they are the same fact
-    read two ways: a run's build argument either is a step function or is a build the step
-    list has no name for. Dropping the second half is how a proof registered under a name
-    like buildSolid used to escape every check — no step could claim it, and nothing looked
-    for it. Only the build argument is judged; the gate and assertion arguments are not steps.
+    All three come out of the same parse of the same run, because they are the same fact read
+    three ways: a run's build argument is a step function, or is a build the step list has no
+    name for, or is something this parse cannot read to a function name at all. Dropping the
+    second is how a proof registered under a name like buildSolid used to escape every check —
+    no step could claim it, and nothing looked for it. Dropping the third is worse, because the
+    gate then reports the steps such a run registers as registered nowhere, which is false.
+    Only the build argument is judged; the gate and assertion arguments are not steps.
 
-    The third is every reachable run whose argument list this parse could not read to the
-    build slot: an unterminated call, or an argument list shorter than that slot, which is
-    what a run written as one multi-value call — the build argument forwarded from a helper
-    rather than written out — parses to. Such a run compiles, so silently skipping it would
-    let its build argument escape the same check. It is reported instead, and the fix is to
-    write the run's arguments out one by one.
+    A run counts as unreadable in three ways, and they are one category because they leave the
+    gate in one state — it cannot say which function the run builds with. The argument list may
+    never close; it may be shorter than the build slot, which is what a run written as one
+    multi-value call parses to, the arguments forwarded from a helper rather than written out;
+    or the build argument may be an expression, a local or a table entry rather than a name.
+    Each compiles, so silently skipping any of them would let a build argument escape the
+    step<Title> check. The label carries the whole call where no argument reached the slot, and
+    the argument itself where one did.
     """
     registered = set()
-    other = set()
+    misnamed = set()
     unreadable = set()
     for _, body in go_func_bodies(src, r'Test[A-Z]\w*'):
         brace_pairs = go_brace_pairs(body)
+        local_names = go_local_bindings(body)
         for pattern, build_arg in PROOF_RUN_CALLS:
             for m in re.finditer(pattern, body):
                 if not go_call_is_reachable(body, m.start(), brace_pairs):
@@ -555,11 +614,14 @@ def registered_step_functions(src):
                 if len(args) <= build_arg:
                     unreadable.add(go_argument_label(body[m.start():close_paren + 1]))
                     continue
-                if re.fullmatch(r'step[A-Z]\w*', args[build_arg]):
-                    registered.add(args[build_arg])
+                argument = args[build_arg]
+                if argument not in local_names and re.fullmatch(r'step[A-Z]\w*', argument):
+                    registered.add(argument)
+                elif go_build_argument_names_a_function(argument, local_names):
+                    misnamed.add(go_argument_label(argument))
                 else:
-                    other.add(go_argument_label(args[build_arg]))
-    return registered, sorted(other), sorted(unreadable)
+                    unreadable.add(go_argument_label(argument))
+    return registered, sorted(misnamed), sorted(unreadable)
 
 
 def proof_functions(proof_dir):
@@ -578,10 +640,11 @@ def proof_functions(proof_dir):
 
 
 def proof_registrations(proof_dir):
-    """Return registrations, misnamed builds and unreadable runs, the last two file-anchored.
+    """Return the registrations a proof directory makes, as three sets.
 
-    Misnamed builds come back as (file, argument) and unreadable runs as (file, call), because
-    the name alone does not say where to go and fix it.
+    They are the step functions registered from a Go Test, the misnamed builds, and the
+    unreadable runs, the last two as (file, label) pairs. A label carries its file, because
+    the argument or the call alone does not say where to go and fix it.
     """
     found = set()
     misnamed = set()
@@ -596,7 +659,7 @@ def proof_registrations(proof_dir):
         registered, other, unread = registered_step_functions(src)
         found.update(registered)
         misnamed.update((path, argument) for argument in other)
-        unreadable.update((path, call) for call in unread)
+        unreadable.update((path, label) for label in unread)
     return found, sorted(misnamed), sorted(unreadable)
 
 
@@ -639,6 +702,11 @@ def main(argv):
     # 2. steps and proof agree
     functions = proof_functions(proof_dir)
     registered, misnamed_builds, unreadable_runs = proof_registrations(proof_dir)
+    # One run the gate cannot read leaves every registration in this proof unknown, because
+    # that run may be the one registering any of these step functions. Say the run is
+    # unreadable, and say nothing about who is registered — a false "no Go Test registers it"
+    # sends a drafter to fix a proof that is already doing the thing it is accused of skipping.
+    registration_is_known = not unreadable_runs
     claimed = set()
     for sid, tag, body in steps:
         named = set(re.findall(r'\b(step[A-Z]\w*)\b', body))
@@ -648,23 +716,25 @@ def main(argv):
             if fn not in functions:
                 problems.append("  %s names proof function %s, which %s/ does not define"
                                 % (sid, fn, proof_dir))
-            elif fn not in registered:
+            elif registration_is_known and fn not in registered:
                 problems.append("  %s names proof function %s, but no Go Test registers it "
                                 "in a proofkit run" % (sid, fn))
             claimed.add(fn)
     for fn in sorted(functions - claimed):
         problems.append("  proof function %s is not claimed by any step" % fn)
-    for fn in sorted(functions - registered):
-        problems.append("  proof function %s is defined but is not registered in any "
-                        "proofkit run inside a Go Test" % fn)
+    if registration_is_known:
+        for fn in sorted(functions - registered):
+            problems.append("  proof function %s is defined but is not registered in any "
+                            "proofkit run inside a Go Test" % fn)
     for path, argument in misnamed_builds:
         problems.append("  %s registers %s as a proof run's build argument, but that argument "
                         "must be a step<Title> function so a step can claim it"
                         % (path, argument))
-    for path, call in unreadable_runs:
-        problems.append("  %s runs %s, whose arguments could not be read, so its build argument "
-                        "cannot be checked; write the run's arguments out one by one"
-                        % (path, call))
+    for path, label in unreadable_runs:
+        problems.append("  %s does not show the gate which function a proof run builds with: "
+                        "%s; write the run's arguments out one by one, with the build argument "
+                        "a literal step<Title> identifier so a step can claim the run"
+                        % (path, label))
 
     # 3. API calls are real
     local = PYTHON_METHODS | defined_names(FRAMEWORK) | contract_names(gear)

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Regression tests for the compile-stage gate."""
+import collections
 import contextlib
 import importlib.util
 import io
 import os
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -14,6 +17,12 @@ COMPILE_CHECKER_PATH = Path(__file__).with_name('check_compile.py')
 COMPILE_MODULE_SPEC = importlib.util.spec_from_file_location('check_compile', COMPILE_CHECKER_PATH)
 COMPILE_CHECKER = importlib.util.module_from_spec(COMPILE_MODULE_SPEC)
 COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
+
+
+UNREADABLE_ARGUMENT = COMPILE_CHECKER.UNREADABLE_ARGUMENT
+UNREADABLE_GUARD = COMPILE_CHECKER.UNREADABLE_GUARD
+UNREADABLE_OUTSIDE_TEST = COMPILE_CHECKER.UNREADABLE_OUTSIDE_TEST
+LOCAL_STEP_PREFIX = 'this Test body binds stepOne'
 
 
 class CheckCompileTest(unittest.TestCase):
@@ -317,9 +326,9 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'proof/gear/proof_test.go does not show the gate which function a proof run builds '
-            'with: step.build; write the run\'s arguments out one by one, with the build '
-            'argument a literal step<Title> identifier so a step can claim the run', output)
+            'proof/gear/proof_test.go has a proof run the gate cannot read as a registration: '
+            'step.build; write the run\'s arguments out one by one, with the build argument a '
+            'literal step<Title> identifier so a step can claim the run', output)
 
     def test_table_registered_step_is_not_called_unregistered(self):
         proof_body = (
@@ -359,7 +368,7 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['step.build'])
+        self.assertEqual(unreadable, [('step.build', UNREADABLE_ARGUMENT)])
 
     def test_loop_variable_build_argument_is_unreadable_not_misnamed(self):
         src = (
@@ -373,7 +382,7 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['build'])
+        self.assertEqual(unreadable, [('build', UNREADABLE_ARGUMENT)])
 
     def test_comma_declared_local_build_argument_is_unreadable(self):
         src = (
@@ -387,7 +396,9 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['stepOne'])
+        self.assertEqual(len(unreadable), 1)
+        self.assertEqual(unreadable[0][0], 'stepOne')
+        self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
 
     def test_grouped_var_local_build_argument_is_unreadable(self):
         src = (
@@ -402,7 +413,9 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['stepOne'])
+        self.assertEqual(len(unreadable), 1)
+        self.assertEqual(unreadable[0][0], 'stepOne')
+        self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
 
     def test_grouped_var_initializer_does_not_hide_a_real_registration(self):
         src = (
@@ -440,70 +453,93 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(misnamed, [])
         self.assertEqual(unreadable, [])
 
-    # Go scopes a local from the end of its own spec to the end of the block that contains
-    # it, so only a declaration whose block encloses the run can hide what that run registers.
+    # `local` stands in for the declared name, so one template drives both directions: the
+    # name a proof must not use, and any other name.
     LOCAL_DECLARATIONS = (
-        'var stepOne proofkit.Build = buildA',
-        'stepOne := buildA',
+        'var local proofkit.Build = buildA',
+        'local := buildA',
     )
 
-    def test_local_that_does_not_enclose_the_run_leaves_it_registered(self):
-        shapes = {
-            'later in the same block': (
-                'func TestOne(t *testing.T) {\n'
-                '    proofkit.Run(t, spurCases(), stepOne)\n'
-                '    %s\n'
-                '    _ = stepOne\n'
-                '}\n'),
-            'earlier sibling block': (
-                'func TestOne(t *testing.T) {\n'
-                '    if true {\n'
-                '        %s\n'
-                '        _ = stepOne\n'
-                '    }\n'
-                '    proofkit.Run(t, spurCases(), stepOne)\n'
-                '}\n'),
-            'sibling blocks': (
-                'func TestOne(t *testing.T) {\n'
-                '    if true {\n'
-                '        %s\n'
-                '        _ = stepOne\n'
-                '    }\n'
-                '    if true {\n'
-                '        proofkit.Run(t, spurCases(), stepOne)\n'
-                '    }\n'
-                '}\n'),
-        }
+    LOCAL_SHAPES = {
+        'later in the same block': (
+            'func TestOne(t *testing.T) {\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '    %s\n'
+            '    _ = local\n'
+            '}\n'),
+        'earlier sibling block': (
+            'func TestOne(t *testing.T) {\n'
+            '    if true {\n'
+            '        %s\n'
+            '        _ = local\n'
+            '    }\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '}\n'),
+        'sibling blocks': (
+            'func TestOne(t *testing.T) {\n'
+            '    if true {\n'
+            '        %s\n'
+            '        _ = local\n'
+            '    }\n'
+            '    if true {\n'
+            '        proofkit.Run(t, spurCases(), stepOne)\n'
+            '    }\n'
+            '}\n'),
+    }
 
-        for shape, template in shapes.items():
+    def local_shapes(self, name):
+        for shape, template in self.LOCAL_SHAPES.items():
             for declaration in self.LOCAL_DECLARATIONS:
-                with self.subTest(shape=shape, declaration=declaration):
-                    src = template % declaration
+                yield shape, declaration, (template % declaration).replace('local', name)
 
-                    registered, misnamed, unreadable = (
-                        COMPILE_CHECKER.registered_step_functions(src))
+    # Go scopes a local from the end of its own spec to the end of the block containing it, so
+    # a real scope analysis would leave every run below registered. The chokepoint makes no
+    # scope decision, so it reports them unreadable instead. This is the precision option A
+    # gives up, written down as a test so a later reader meets it as a decision rather than as
+    # a surprise: the cost is a false failure, which is loud, and a proof pays it only by
+    # naming a local step<Title>.
+    def test_local_outside_the_run_is_given_up_as_unreadable(self):
+        for shape, declaration, src in self.local_shapes('stepOne'):
+            with self.subTest(shape=shape, declaration=declaration):
+                registered, misnamed, unreadable = (
+                    COMPILE_CHECKER.registered_step_functions(src))
 
-                    self.assertEqual(registered, {'stepOne'})
-                    self.assertEqual(misnamed, [])
-                    self.assertEqual(unreadable, [])
+                self.assertEqual(registered, set())
+                self.assertEqual(misnamed, [])
+                self.assertEqual(len(unreadable), 1)
+                self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
+
+    # The same shapes with the local under any other name still count the literal
+    # registration, which is what keeps the chokepoint from being a blanket refusal.
+    def test_local_under_another_name_leaves_the_run_registered(self):
+        for shape, declaration, src in self.local_shapes('localBuild'):
+            with self.subTest(shape=shape, declaration=declaration):
+                registered, misnamed, unreadable = (
+                    COMPILE_CHECKER.registered_step_functions(src))
+
+                self.assertEqual(registered, {'stepOne'})
+                self.assertEqual(misnamed, [])
+                self.assertEqual(unreadable, [])
 
     def test_local_in_an_enclosing_block_still_makes_the_run_unreadable(self):
         for declaration in self.LOCAL_DECLARATIONS:
             with self.subTest(declaration=declaration):
-                src = (
+                src = ((
                     'func TestOne(t *testing.T) {\n'
                     '    if true {\n'
                     '        %s\n'
                     '        proofkit.Run(t, spurCases(), stepOne)\n'
                     '    }\n'
-                    '}\n') % declaration
+                    '}\n') % declaration).replace('local', 'stepOne')
 
                 registered, misnamed, unreadable = (
                     COMPILE_CHECKER.registered_step_functions(src))
 
                 self.assertEqual(registered, set())
                 self.assertEqual(misnamed, [])
-                self.assertEqual(unreadable, ['stepOne'])
+                self.assertEqual(len(unreadable), 1)
+                self.assertEqual(unreadable[0][0], 'stepOne')
+                self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
 
     def test_loop_header_binding_covers_the_loop_body(self):
         src = (
@@ -517,13 +553,31 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['stepOne'])
+        self.assertEqual(len(unreadable), 1)
+        self.assertEqual(unreadable[0][0], 'stepOne')
+        self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
 
-    def test_loop_header_binding_ends_with_its_loop(self):
+    def test_loop_header_binding_reaches_past_its_loop(self):
         src = (
             'func TestOne(t *testing.T) {\n'
             '    for _, stepOne := range []proofkit.Build{buildA} {\n'
             '        _ = stepOne\n'
+            '    }\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, [])
+        self.assertEqual(len(unreadable), 1)
+        self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
+
+    def test_loop_header_binding_under_another_name_leaves_the_run_registered(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, localBuild := range []proofkit.Build{buildA} {\n'
+            '        _ = localBuild\n'
             '    }\n'
             '    proofkit.Run(t, spurCases(), stepOne)\n'
             '}\n')
@@ -568,9 +622,11 @@ class CheckCompileTest(unittest.TestCase):
 
                 self.assertEqual(registered, set())
                 self.assertEqual(misnamed, [])
-                self.assertEqual(unreadable, ['stepOne'])
+                self.assertEqual(len(unreadable), 1)
+                self.assertEqual(unreadable[0][0], 'stepOne')
+                self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
 
-    def test_loop_header_shapes_end_their_binding_with_the_loop(self):
+    def test_loop_header_shapes_reach_past_their_loop(self):
         for shape, header in self.HEADER_BLOCK_SHAPES.items():
             with self.subTest(shape=shape):
                 src = (
@@ -584,27 +640,29 @@ class CheckCompileTest(unittest.TestCase):
                 registered, misnamed, unreadable = (
                     COMPILE_CHECKER.registered_step_functions(src))
 
+                self.assertEqual(registered, set())
+                self.assertEqual(misnamed, [])
+                self.assertEqual(len(unreadable), 1)
+                self.assertTrue(unreadable[0][1].startswith(LOCAL_STEP_PREFIX))
+
+    # The same three headers with an ordinary loop variable still count the registration, so
+    # the header shapes that defeated three rounds of the old scope decision now cost nothing.
+    def test_loop_header_shapes_under_another_name_stay_registered(self):
+        for shape, header in self.HEADER_BLOCK_SHAPES.items():
+            with self.subTest(shape=shape):
+                src = (
+                    'func TestOne(t *testing.T) {\n'
+                    + header.replace('stepOne', 'localBuild')
+                    + '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+                    '\t}\n'
+                    '}\n')
+
+                registered, misnamed, unreadable = (
+                    COMPILE_CHECKER.registered_step_functions(src))
+
                 self.assertEqual(registered, {'stepOne'})
                 self.assertEqual(misnamed, [])
                 self.assertEqual(unreadable, [])
-
-    # An if header that carries an init clause states a condition the reachability walk cannot
-    # read, so a run inside such a block is skipped before its build argument is judged. The
-    # scope the header binding gets is therefore checked on the bindings themselves.
-    def test_if_header_binding_is_scoped_to_the_block_it_opens(self):
-        body = (
-            '\n'
-            '    if stepOne := buildA; true {\n'
-            '        inside()\n'
-            '    }\n'
-            '    after()\n')
-
-        bindings = COMPILE_CHECKER.go_local_bindings(body, COMPILE_CHECKER.go_brace_pairs(body))
-
-        self.assertIn(
-            'stepOne', COMPILE_CHECKER.go_local_names_at(bindings, body.index('inside')))
-        self.assertNotIn(
-            'stepOne', COMPILE_CHECKER.go_local_names_at(bindings, body.index('after')))
 
     def test_grouped_var_local_build_argument_is_blocking(self):
         proof_body = (
@@ -620,9 +678,8 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'proof/gear/proof_test.go does not show the gate which function a proof run builds '
-            'with: stepOne; write the run\'s arguments out one by one, with the build argument '
-            'a literal step<Title> identifier so a step can claim the run', output)
+            'proof/gear/proof_test.go has a proof run the gate cannot read as a registration: '
+            'stepOne; ' + LOCAL_STEP_PREFIX, output)
 
     def test_loop_whose_body_returns_does_not_hide_a_later_run(self):
         src = (
@@ -651,9 +708,9 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'proof/gear/proof_test.go does not show the gate which function a proof run builds '
-            'with: proofkit3d.Run(runArgs(t)); write the run\'s arguments out one by one, with '
-            'the build argument a literal step<Title> identifier so a step can claim the run',
+            'proof/gear/proof_test.go has a proof run the gate cannot read as a registration: '
+            'proofkit3d.Run(runArgs(t)); write the run\'s arguments out one by one, with the '
+            'build argument a literal step<Title> identifier so a step can claim the run',
             output)
 
     def test_multi_value_forwarded_2d_run_is_blocking(self):
@@ -670,7 +727,7 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'does not show the gate which function a proof run builds with: '
+            'has a proof run the gate cannot read as a registration: '
             'proofkit.Run(runArgs(t))', output)
 
     def test_unclosed_run_call_is_reported_not_dropped(self):
@@ -696,7 +753,8 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
         self.assertEqual(len(unreadable), 1)
-        self.assertTrue(unreadable[0].startswith('proofkit3d.Run(t, solidCases, stepSolid'))
+        self.assertTrue(unreadable[0][0].startswith('proofkit3d.Run(t, solidCases, stepSolid'))
+        self.assertEqual(unreadable[0][1], UNREADABLE_ARGUMENT)
 
     def test_unreachable_unreadable_run_is_not_counted(self):
         proof_body = self.solid_proof(
@@ -707,7 +765,46 @@ class CheckCompileTest(unittest.TestCase):
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 0, output)
-        self.assertNotIn('does not show the gate', output)
+        self.assertNotIn('cannot read as a registration', output)
+
+    # A run the walk cannot decide about used to be dropped before its build argument was read,
+    # which left the step it registers reported as registered nowhere. That is a phantom: the
+    # proof does register the step, and the drafter sent to fix it finds nothing wrong. Both
+    # tests below hold the gate to naming the run instead.
+
+    def test_run_under_an_unreadable_condition_is_loud_not_dropped(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tif enabled() {\n'
+            '\t\tproofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\t}\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('has a proof run the gate cannot read as a registration', output)
+        self.assertIn(UNREADABLE_GUARD, output)
+        self.assertNotIn('no Go Test registers it', output)
+        self.assertNotIn('is defined but is not registered', output)
+
+    def test_run_in_a_helper_is_loud_not_dropped(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tregister(t)\n'
+            '}\n\n'
+            'func register(t *testing.T) {\n'
+            '\tproofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(UNREADABLE_OUTSIDE_TEST, output)
+        self.assertNotIn('no Go Test registers it', output)
+        self.assertNotIn('is defined but is not registered', output)
 
     def test_short_argument_list_is_reported_not_registered(self):
         src = (
@@ -719,7 +816,533 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(registered, set())
         self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['proofkit3d.Run(runArgs(t))'])
+        self.assertEqual(
+            unreadable, [('proofkit3d.Run(runArgs(t))', UNREADABLE_ARGUMENT)])
+
+
+# ---------------------------------------------------------------------------------------------
+# The root-cause map, transcribed as a table and then covered cell by cell.
+#
+# The map crossed the Go binding construct (its rows) with what the construct writes before its
+# block and where the run sits (its columns): C1 no brace group in the header, C2 a brace group
+# mid-header, C3 a brace group ending a clause so a `;` follows its `}`, C4 the run in a sibling
+# clause or after the construct. H is a shape the gate already read correctly, N a shape the
+# grammar does not allow, and a G marks one of the seven gaps the map found.
+#
+# Every cell that is not N is covered below in both directions: the construct binding a
+# `step<Title>` name, where the run must now be unreadable, and the same construct binding an
+# ordinary name, where the literal registration must still be counted. The second direction is
+# what keeps the chokepoint from being a blanket refusal, so it is not optional.
+MAP_TABLE = {
+    ':= single-line left-hand side': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    ':= multi-line left-hand side': {'C1': 'G5', 'C2': 'G5', 'C3': 'N', 'C4': 'H'},
+    'var x = ...': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'var ( ... ) group': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'for ... := range header': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'three-clause for, init binds': {'C1': 'H', 'C2': 'H', 'C3': 'G1', 'C4': 'H'},
+    'if with init, run in the then-branch': {'C1': 'G6', 'C2': 'G6', 'C3': 'G6', 'C4': 'N'},
+    'if with init, run in the else-branch': {'C1': 'H', 'C2': 'H', 'C3': 'G1', 'C4': 'H'},
+    'expression switch with init': {'C1': 'H', 'C2': 'H', 'C3': 'G1', 'C4': 'H'},
+    'type-switch guard': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'switch case clause body binding': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'G3'},
+    'select clause case v := <-ch:': {'C1': 'G2', 'C2': 'G2', 'C3': 'N', 'C4': 'G3'},
+    'plain block': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'func-literal body': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'func-literal parameters and named results': {'C1': 'G4', 'C2': 'G4', 'C3': 'N', 'C4': 'H'},
+    'labelled statement, gofmt form': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'labelled statement on one line': {'C1': 'N', 'C2': 'N', 'C3': 'N', 'C4': 'N'},
+    'const / type declaration': {'C1': 'N', 'C2': 'N', 'C3': 'N', 'C4': 'N'},
+    'range-over-func / range-over-int': {'C1': 'H', 'C2': 'H', 'C3': 'N', 'C4': 'H'},
+    'run in a helper, not in a Test body': {'C1': 'G7', 'C2': 'G7', 'C3': 'G7', 'C4': 'G7'},
+    'run under a condition the walk cannot read': {
+        'C1': 'G6', 'C2': 'G6', 'C3': 'G6', 'C4': 'G6'},
+}
+
+REGISTERED = 'registered'
+LOCAL = 'unreadable: the body binds a step name'
+GUARD = 'unreadable: the guard cannot be read'
+OUTSIDE = 'unreadable: the run is outside every Test'
+
+Cell = collections.namedtuple('Cell', 'row columns source bound free')
+
+# LOCAL_NAME is the identifier the construct binds. Substituting `stepOne` for it gives the
+# false-pass direction, and any other identifier gives the direction that must still count.
+LOCAL_NAME = 'localName'
+
+MAP_CELLS = (
+    Cell(':= single-line left-hand side', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tlocalName := buildA\n'
+        '\t_ = localName\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell(':= single-line left-hand side', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tlocalName := []proofkit.Build{buildA}[0]\n'
+        '\t_ = localName\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell(':= single-line left-hand side', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\tlocalName := buildA\n'
+        '\t_ = localName\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell(':= multi-line left-hand side', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tlocalName,\n'
+        '\t\tother := buildA, buildB\n'
+        '\t_, _ = localName, other\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell(':= multi-line left-hand side', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tlocalName,\n'
+        '\t\tother := []proofkit.Build{buildA}[0], buildB\n'
+        '\t_, _ = localName, other\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell(':= multi-line left-hand side', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\tlocalName,\n'
+        '\t\tother := buildA, buildB\n'
+        '\t_, _ = localName, other\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('var x = ...', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tvar localName = buildA\n'
+        '\t_ = localName\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('var x = ...', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tvar localName = []proofkit.Build{buildA}[0]\n'
+        '\t_ = localName\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('var x = ...', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\tvar localName = buildA\n'
+        '\t_ = localName\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('var ( ... ) group', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tvar (\n'
+        '\t\tlocalName proofkit.Build = buildA\n'
+        '\t)\n'
+        '\t_ = localName\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('var ( ... ) group', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tvar (\n'
+        '\t\tlocalName = []proofkit.Build{buildA}[0]\n'
+        '\t)\n'
+        '\t_ = localName\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('var ( ... ) group', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\tvar (\n'
+        '\t\tlocalName proofkit.Build = buildA\n'
+        '\t)\n'
+        '\t_ = localName\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('for ... := range header', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor _, localName := range []proofkit.Build{buildA} {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('for ... := range header', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor _, localName := range []struct {\n'
+        '\t\tbuild proofkit.Build\n'
+        '\t}{{buildA}} {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('for ... := range header', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor _, localName := range []proofkit.Build{buildA} {\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('three-clause for, init binds', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName := buildA; localName != nil; localName = nil {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('three-clause for, init binds', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName := []proofkit.Build{buildA}[0]; localName != nil; localName = nil {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('three-clause for, init binds', ('C3',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName, list := buildA, []proofkit.Build{buildA}; len(list) > 0; list = nil {\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('three-clause for, init binds', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName := buildA; localName != nil; localName = nil {\n'
+        '\t\tbreak\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('if with init, run in the then-branch', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName := buildA; localName != nil {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), GUARD, GUARD),
+    Cell('if with init, run in the then-branch', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName := []proofkit.Build{buildA}[0]; localName != nil {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), GUARD, GUARD),
+    Cell('if with init, run in the then-branch', ('C3',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName, list := buildA, []proofkit.Build{buildA}; len(list) > 0 {\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), GUARD, GUARD),
+    Cell('if with init, run in the else-branch', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName := buildA; localName == nil {\n'
+        '\t\t_ = localName\n'
+        '\t} else {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('if with init, run in the else-branch', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName := []proofkit.Build{buildA}[0]; localName == nil {\n'
+        '\t\t_ = localName\n'
+        '\t} else {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('if with init, run in the else-branch', ('C3',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName, list := buildA, []proofkit.Build{buildA}; len(list) > 0 {\n'
+        '\t\t_ = localName\n'
+        '\t} else {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('if with init, run in the else-branch', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif localName := buildA; localName == nil {\n'
+        '\t\t_ = localName\n'
+        '\t} else {\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('expression switch with init', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName := buildA; localName {\n'
+        '\tcase buildA:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('expression switch with init', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName := []proofkit.Build{buildA}[0]; localName {\n'
+        '\tcase buildA:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('expression switch with init', ('C3',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName, list := buildA, []proofkit.Build{buildA}; len(list) {\n'
+        '\tcase 1:\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('expression switch with init', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName := buildA; localName {\n'
+        '\tcase buildA:\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('type-switch guard', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName := any(buildA).(type) {\n'
+        '\tcase proofkit.Build:\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('type-switch guard', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName := any([]proofkit.Build{buildA}[0]).(type) {\n'
+        '\tcase proofkit.Build:\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('type-switch guard', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch localName := any(buildA).(type) {\n'
+        '\tcase proofkit.Build:\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('switch case clause body binding', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch {\n'
+        '\tcase true:\n'
+        '\t\tlocalName := buildA\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('switch case clause body binding', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch {\n'
+        '\tcase true:\n'
+        '\t\tlocalName := []proofkit.Build{buildA}[0]\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('switch case clause body binding', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch {\n'
+        '\tcase true:\n'
+        '\t\tlocalName := buildA\n'
+        '\t\t_ = localName\n'
+        '\tdefault:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('select clause case v := <-ch:', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tch := make(chan proofkit.Build)\n'
+        '\tselect {\n'
+        '\tcase localName := <-ch:\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('select clause case v := <-ch:', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tch := make(chan proofkit.Build, len([]proofkit.Build{buildA}))\n'
+        '\tselect {\n'
+        '\tcase localName := <-ch:\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('select clause case v := <-ch:', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tch := make(chan proofkit.Build)\n'
+        '\tselect {\n'
+        '\tcase localName := <-ch:\n'
+        '\t\t_ = localName\n'
+        '\tdefault:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('plain block', ('C1', 'C2'), (
+        'func TestOne(t *testing.T) {\n'
+        '\t{\n'
+        '\t\tlocalName := []proofkit.Build{buildA}[0]\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('plain block', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\t{\n'
+        '\t\tlocalName := buildA\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('func-literal body', ('C1', 'C2'), (
+        'func TestOne(t *testing.T) {\n'
+        '\tt.Run("one", func(t *testing.T) {\n'
+        '\t\tlocalName := []proofkit.Build{buildA}[0]\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t})\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('func-literal body', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tt.Run("one", func(t *testing.T) {\n'
+        '\t\tlocalName := buildA\n'
+        '\t\t_ = localName\n'
+        '\t})\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('func-literal parameters and named results', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tcall := func(localName proofkit.Build) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '\tcall(buildA)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('func-literal parameters and named results', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tcall := func() (localName proofkit.Build) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\treturn []proofkit.Build{buildA}[0]\n'
+        '\t}\n'
+        '\t_ = call\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('func-literal parameters and named results', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tcall := func(localName proofkit.Build) {\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tcall(buildA)\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('labelled statement, gofmt form', ('C1', 'C2'), (
+        'func TestOne(t *testing.T) {\n'
+        'Loop:\n'
+        '\tfor _, localName := range []proofkit.Build{buildA} {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\tbreak Loop\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('labelled statement, gofmt form', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        'Loop:\n'
+        '\tfor _, localName := range []proofkit.Build{buildA} {\n'
+        '\t\t_ = localName\n'
+        '\t\tbreak Loop\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('range-over-func / range-over-int', ('C1',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName := range 3 {\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('range-over-func / range-over-int', ('C2',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName := range slices.Values([]proofkit.Build{buildA}) {\n'
+        '\t\t_ = localName\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('range-over-func / range-over-int', ('C4',), (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor localName := range 3 {\n'
+        '\t\t_ = localName\n'
+        '\t}\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), LOCAL, REGISTERED),
+    Cell('run under a condition the walk cannot read', ('C1', 'C2', 'C3', 'C4'), (
+        'func TestOne(t *testing.T) {\n'
+        '\tif enabled() {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), GUARD, GUARD),
+    Cell('run in a helper, not in a Test body', ('C1', 'C2', 'C3', 'C4'), (
+        'func TestOne(t *testing.T) {\n'
+        '\tregister(t)\n'
+        '}\n'
+        '\n'
+        'func register(t *testing.T) {\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '}\n'), OUTSIDE, OUTSIDE),
+)
+
+
+class MapCellTest(unittest.TestCase):
+    """Every cell of the root-cause map, in both directions.
+
+    A cell fails in one of two ways, and the two are not symmetric. A false pass — a local
+    counted as a registered step — is silent, and it lets the geometry that step claims go
+    unproven behind a green gate. A false failure is loud and costs a drafter a rename. The
+    chokepoint converts the first into the second everywhere, so each cell is asserted twice:
+    once with the construct binding the step name, where the run must now be unreadable, and
+    once with it binding an ordinary name, where the registration must still be counted.
+    """
+
+    def source(self, cell, name):
+        return cell.source.replace(LOCAL_NAME, name)
+
+    def outcome(self, src):
+        """Which of the four results the gate gives this source."""
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+        if registered == {'stepOne'} and not misnamed and not unreadable:
+            return REGISTERED
+        self.assertEqual(registered, set(), src)
+        self.assertEqual(misnamed, [], src)
+        self.assertEqual(len(unreadable), 1, src)
+        reason = unreadable[0][1]
+        if reason.startswith(LOCAL_STEP_PREFIX):
+            return LOCAL
+        if reason == UNREADABLE_GUARD:
+            return GUARD
+        if reason == UNREADABLE_OUTSIDE_TEST:
+            return OUTSIDE
+        return reason
+
+    def test_every_cell_binding_the_step_name(self):
+        for cell in MAP_CELLS:
+            with self.subTest(row=cell.row, columns=cell.columns):
+                self.assertEqual(
+                    self.outcome(self.source(cell, 'stepOne')), cell.bound)
+
+    def test_every_cell_binding_an_ordinary_name(self):
+        for cell in MAP_CELLS:
+            with self.subTest(row=cell.row, columns=cell.columns):
+                self.assertEqual(
+                    self.outcome(self.source(cell, 'localBuild')), cell.free)
+
+    def test_every_cell_of_the_map_is_covered(self):
+        """The table above and the cells below are reconciled, not eyeballed.
+
+        The map is the enumeration of the space, so a cell it lists and no case exercises is a
+        hole, and a case naming a cell the map calls impossible is a case testing nothing.
+        """
+        listed = {(row, column)
+                  for row, columns in MAP_TABLE.items()
+                  for column, mark in columns.items() if mark != 'N'}
+        covered = {(cell.row, column) for cell in MAP_CELLS for column in cell.columns}
+
+        self.assertEqual(covered, listed)
+
+    def test_every_cell_source_is_what_gofmt_writes(self):
+        """gofmt itself, not a guess at it.
+
+        A probe gofmt would reformat is a probe of a shape no drafter would commit, and three
+        review rounds turned on exactly which brace a real formatter puts where.
+        """
+        if shutil.which('gofmt') is None:
+            self.skipTest('gofmt is not on PATH')
+        for cell in MAP_CELLS:
+            for name in ('stepOne', 'localBuild'):
+                with self.subTest(row=cell.row, columns=cell.columns, name=name):
+                    src = 'package proof_test\n\n' + self.source(cell, name)
+
+                    formatted = subprocess.run(
+                        ['gofmt'], input=src, capture_output=True, text=True, check=True)
+
+                    self.assertEqual(formatted.stdout, src)
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -22,6 +22,7 @@ COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
 UNREADABLE_ARGUMENT = COMPILE_CHECKER.UNREADABLE_ARGUMENT
 UNREADABLE_GUARD = COMPILE_CHECKER.UNREADABLE_GUARD
 UNREADABLE_OUTSIDE_TEST = COMPILE_CHECKER.UNREADABLE_OUTSIDE_TEST
+UNREADABLE_CLOSURE = COMPILE_CHECKER.UNREADABLE_CLOSURE
 LOCAL_STEP_PREFIX = 'this Test body binds stepOne'
 
 
@@ -1250,13 +1251,16 @@ MAP_CELLS = (
         '\t}\n'
         '\tcall(buildA)\n'
         '}\n'), LOCAL, REGISTERED),
+    # The literal is called rather than discarded, because a run inside a literal stored under
+    # a name that is never called is unreadable on the reached-literal axis, and this cell is
+    # about which NAME a named result binds. Both axes are asserted, each in its own table.
     Cell('func-literal parameters and named results', ('C2',), (
         'func TestOne(t *testing.T) {\n'
         '\tcall := func() (localName proofkit.Build) {\n'
         '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
         '\t\treturn []proofkit.Build{buildA}[0]\n'
         '\t}\n'
-        '\t_ = call\n'
+        '\t_ = call()\n'
         '}\n'), LOCAL, REGISTERED),
     Cell('func-literal parameters and named results', ('C4',), (
         'func TestOne(t *testing.T) {\n'
@@ -1862,18 +1866,23 @@ SCAN_ANCHORS = (
         '\tproofkit.Run(t, spurCases(), stepOne)\n',
         '\tvar stepOne func(arg stepType)\n\t_ = stepOne\n'
         '\tproofkit.Run(t, spurCases(), stepTwo)\n'),
+    # A row holding its run inside the literal calls that literal rather than discarding it,
+    # because a run inside a literal stored under a name that is never called is unreadable on
+    # the reached-literal axis, which ReachedLiteralTest owns. These rows are about which names
+    # a SIGNATURE binds, and the call keeps them asking only that.
     Signature(
         'func(arg stepType) error', frozenset({'arg'}), frozenset({'call'}),
-        '\tcall := func(arg stepType) error {\n' + RUN + '\t\treturn nil\n\t}\n\t_ = call\n',
+        '\tcall := func(arg stepType) error {\n' + RUN
+        + '\t\treturn nil\n\t}\n\t_ = call(0)\n',
         '\tcall := func(stepOne stepType) error {\n' + BOUND_RUN
-        + '\t\treturn nil\n\t}\n\t_ = call\n'),
+        + '\t\treturn nil\n\t}\n\t_ = call(0)\n'),
     Signature(
         'func() func(arg stepType), a result type', frozenset(), frozenset({'call'}),
         '\tcall := func() func(stepOne stepType) {\n'
         '\t\treturn nil\n\t}\n\t_ = call\n'
         '\tproofkit.Run(t, spurCases(), stepOne)\n',
         '\tcall := func(stepOne stepType) func(arg stepType) {\n' + BOUND_RUN
-        + '\t\treturn nil\n\t}\n\t_ = call\n'),
+        + '\t\treturn nil\n\t}\n\t_ = call(0)\n'),
     Signature(
         '[]func(arg stepType){}, an element type', frozenset(), frozenset({'table'}),
         '\ttable := []func(stepOne stepType){}\n\t_ = table\n'
@@ -1948,7 +1957,8 @@ class GoBodyFixtureTest(unittest.TestCase):
 
     def bound_names(self, body):
         src = self.source(body)
-        spans = list(COMPILE_CHECKER.go_func_body_spans(src, r'Test[A-Z]\w*'))
+        spans = list(COMPILE_CHECKER.go_func_body_spans(
+            src, COMPILE_CHECKER.GO_TEST_FUNCTION_NAME))
         self.assertEqual(len(spans), 1, src)
         _, start, end = spans[0]
         return COMPILE_CHECKER.go_bound_names(src[start:end])
@@ -1989,6 +1999,16 @@ class GoBodyFixtureTest(unittest.TestCase):
         a matrix's two directions stay honest: the bound direction has to keep the same shape
         and change only the name, and a rename that does not type-check fails here.
         """
+        vetted = self.vet_sources(labelled_bodies)
+
+        self.assertEqual(vetted.returncode, 0, vetted.stderr)
+
+    def vet_sources(self, labelled_bodies):
+        """Run `go vet` over the bodies given and return the finished process.
+
+        A table that pins a name Go itself refuses needs the refusal, not just a zero exit, so
+        the run is handed back rather than asserted on here.
+        """
         if shutil.which('go') is None:
             self.skipTest('go is not on PATH')
         with tempfile.TemporaryDirectory() as directory:
@@ -2005,11 +2025,24 @@ class GoBodyFixtureTest(unittest.TestCase):
             (root / 'proof' / 'shapes_test.go').write_text('\n'.join(tests))
             environment = dict(os.environ, GOWORK='off', GOTOOLCHAIN='local', GOFLAGS='-mod=mod')
 
-            vetted = subprocess.run(
+            return subprocess.run(
                 ['go', 'vet', './...'], cwd=directory, env=environment,
                 capture_output=True, text=True)
 
-            self.assertEqual(vetted.returncode, 0, vetted.stderr)
+
+class ScrubbedBodyFixtureTest(GoBodyFixtureTest):
+    """A fixture table read the way the gate reads a proof: after the literals are scrubbed.
+
+    A literal left standing in the raw fixture text ends its own statement, so a table that
+    skipped the scrubber would pass with a scrubber defect in place and say nothing about the
+    copy the gate actually reads.
+    """
+
+    def bound_names(self, body):
+        return super().bound_names(COMPILE_CHECKER.strip_go_comments_and_literals(body))
+
+    def outcome(self, body):
+        return super().outcome(COMPILE_CHECKER.strip_go_comments_and_literals(body))
 
 
 class SignatureShapeTest(GoBodyFixtureTest):
@@ -2072,6 +2105,200 @@ class ScopeBlindShapeTest(GoBodyFixtureTest):
         self.assert_gofmt_writes_every_source(self.labelled_bodies())
 
     def test_every_source_compiles_and_vets(self):
+        self.assert_every_source_compiles_and_vets(self.labelled_bodies())
+
+
+# ---------------------------------------------------------------------------------------------
+# A var block's spec boundaries, and what an initializer written as a literal does to them.
+#
+# Go ends a var spec at a line break whose last token can end a statement, and a literal is
+# such a token. The gate reads the block after the scrubber has blanked every literal, so the
+# scrubber has to leave that token standing. Blanking a literal's delimiters along with its
+# text left `label = "one"` reading as a line that continues into the next one: the block was
+# then read as ONE spec, only the first spec's names came out bound, and a `step<Title>`
+# declared under a string-initialised spec was invisible to the chokepoint. The run built with
+# that local while the gate reported the package-level step of the same name as registered,
+# which is the silent false pass the chokepoint exists to convert into a loud one.
+#
+# Each initializer is written twice, because the two directions fail differently: with the
+# second spec binding `stepOne`, where the run must become unreadable, and with it binding an
+# ordinary name, where the run must still register.
+VarSpecInitializer = collections.namedtuple('VarSpecInitializer', 'kind literal')
+
+VAR_SPEC_INITIALIZERS = (
+    VarSpecInitializer('an int', '1'),
+    VarSpecInitializer('a string', '"one"'),
+    VarSpecInitializer('a rune', "'x'"),
+    VarSpecInitializer('a raw string', '`one`'),
+)
+
+
+class VarSpecInitializerTest(ScrubbedBodyFixtureTest):
+    """Every initializer kind splits a var block the same way, in both directions."""
+
+    def body(self, literal, name):
+        """A var block whose first spec holds the literal and whose second binds `name`.
+
+        gofmt aligns a group's `=` signs, so the first name is padded to the second's width.
+        That padding is asserted rather than assumed: `test_every_source_is_what_gofmt_writes`
+        runs gofmt over each body.
+        """
+        return ('\tvar (\n'
+                '\t\t%s = %s\n'
+                '\t\t%s = stepTwo\n'
+                '\t)\n'
+                '\t_, _ = label, %s\n'
+                '\tproofkit.Run(t, spurCases(), stepOne)\n'
+                % ('label'.ljust(len(name)), literal, name, name))
+
+    def labelled_bodies(self):
+        return [('%s, %s direction' % (initializer.kind, direction), self.body(
+                    initializer.literal, name))
+                for initializer in VAR_SPEC_INITIALIZERS
+                for direction, name in (('bound', 'stepOne'), ('free', 'localBuild'))]
+
+    def test_every_initializer_binds_both_spec_names(self):
+        """The direct probe: a spec the scrubber ended wrongly loses the names after it."""
+        for initializer in VAR_SPEC_INITIALIZERS:
+            for name in ('stepOne', 'localBuild'):
+                with self.subTest(initializer=initializer.kind, name=name):
+                    self.assertEqual(
+                        self.bound_names(self.body(initializer.literal, name)),
+                        {'label', name})
+
+    def test_every_initializer_leaves_the_step_named_local_caught(self):
+        for initializer in VAR_SPEC_INITIALIZERS:
+            with self.subTest(initializer=initializer.kind):
+                self.assertEqual(
+                    self.outcome(self.body(initializer.literal, 'stepOne')), LOCAL)
+
+    def test_every_initializer_leaves_an_ordinary_local_registered(self):
+        for initializer in VAR_SPEC_INITIALIZERS:
+            with self.subTest(initializer=initializer.kind):
+                self.assertEqual(
+                    self.outcome(self.body(initializer.literal, 'localBuild')), REGISTERED)
+
+    def test_every_source_is_what_gofmt_writes(self):
+        self.assert_gofmt_writes_every_source(self.labelled_bodies())
+
+    def test_every_source_compiles_and_vets(self):
+        self.assert_every_source_compiles_and_vets(self.labelled_bodies())
+
+
+# ---------------------------------------------------------------------------------------------
+# The reached-literal axis: does the func literal holding a run ever run?
+#
+# A func literal encloses what is written in it, so the guard axis reads a run inside one as
+# running when the statement around the literal runs. For a literal stored under a name and
+# never called, that statement runs and the run does not, and counting the step registered is a
+# silent false pass. The POSITION the literal is written in separates the two, and both halves
+# are pinned here, because the cheap rule — report every func-literal enclosure unreadable —
+# takes the `t.Run` subtest with it, which is the false failure this module was rewritten to
+# stop producing.
+Position = collections.namedtuple('Position', 'position verdict body')
+
+RUN_IN_A_LITERAL = '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+
+LITERAL_POSITIONS = (
+    Position('stored under a name and never called', UNREADABLE_CLOSURE,
+             '\tunused := func() {\n' + RUN_IN_A_LITERAL + '\t}\n\t_ = unused\n'),
+    Position('declared with var and never called', UNREADABLE_CLOSURE,
+             '\tvar unused = func() {\n' + RUN_IN_A_LITERAL + '\t}\n\t_ = unused\n'),
+    Position('stored under a name and called', REGISTERED,
+             '\tcall := func() {\n' + RUN_IN_A_LITERAL + '\t}\n\tcall()\n'),
+    Position('handed to t.Run', REGISTERED,
+             '\tt.Run("one", func(t *testing.T) {\n' + RUN_IN_A_LITERAL + '\t})\n'),
+    Position('invoked where it stands', REGISTERED,
+             '\tfunc() {\n' + RUN_IN_A_LITERAL + '\t}()\n'),
+    Position('deferred', REGISTERED,
+             '\tdefer func() {\n' + RUN_IN_A_LITERAL + '\t}()\n'),
+    Position('started with go', REGISTERED,
+             '\tgo func() {\n' + RUN_IN_A_LITERAL + '\t}()\n'),
+)
+
+
+class ReachedLiteralTest(ScrubbedBodyFixtureTest):
+    """Every position a func literal holding a run can stand in, and what the gate says."""
+
+    def labelled_bodies(self):
+        return [(position.position, position.body) for position in LITERAL_POSITIONS]
+
+    def test_every_position_reads_as_the_table_says(self):
+        for position in LITERAL_POSITIONS:
+            with self.subTest(position=position.position):
+                self.assertEqual(self.outcome(position.body), position.verdict)
+
+    def test_every_source_is_what_gofmt_writes(self):
+        self.assert_gofmt_writes_every_source(self.labelled_bodies())
+
+    def test_every_source_compiles_and_vets(self):
+        self.assert_every_source_compiles_and_vets(self.labelled_bodies())
+
+
+# ---------------------------------------------------------------------------------------------
+# Which function names `go test` runs.
+#
+# Go's rule is `Test` followed by a rune that is not a lower-case letter, `Test` alone
+# included, and `go vet` enforces the same rule on a function taking `*testing.T`. Reading only
+# `Test[A-Z]\w*` left a run in a `Test_Profile` or `Test1` body reported as 'not inside a Go
+# Test function', which names the wrong thing to fix, since the Test was there and running.
+#
+# The rejected row is not vetted with the others: `go vet` refuses `Testing(t *testing.T)` as
+# a malformed name, and that refusal is asserted below rather than worked around, because it
+# is the evidence that the gate and Go draw the same line.
+TestName = collections.namedtuple('TestName', 'name verdict')
+
+TEST_FUNCTION_NAMES = (
+    TestName('Test', REGISTERED),
+    TestName('TestOne', REGISTERED),
+    TestName('Test_Foo', REGISTERED),
+    TestName('Test1', REGISTERED),
+)
+
+REJECTED_TEST_FUNCTION_NAME = TestName('Testing', UNREADABLE_OUTSIDE_TEST)
+
+
+class TestFunctionNameTest(GoBodyFixtureTest):
+    """Every name shape, against the gate and against `go vet`."""
+
+    def source(self, body):
+        """The fixture is the whole function here, because the name is what is under test."""
+        return body
+
+    def function(self, name):
+        return ('func %s(t *testing.T) {\n'
+                '\tproofkit.Run(t, spurCases(), stepOne)\n'
+                '}\n' % name)
+
+    def labelled_bodies(self):
+        return [(name.name, self.function(name.name)) for name in TEST_FUNCTION_NAMES]
+
+    def test_every_accepted_name_registers_its_run(self):
+        for name in TEST_FUNCTION_NAMES:
+            with self.subTest(name=name.name):
+                self.assertEqual(self.outcome(self.function(name.name)), name.verdict)
+
+    def test_the_rejected_name_leaves_the_run_outside_every_test(self):
+        rejected = REJECTED_TEST_FUNCTION_NAME
+
+        self.assertEqual(self.outcome(self.function(rejected.name)), rejected.verdict)
+
+    def test_go_vet_rejects_the_name_the_gate_rejects(self):
+        """Go itself, not this table, is what says `Testing` is no test."""
+        rejected = REJECTED_TEST_FUNCTION_NAME
+
+        vetted = self.vet_sources([(rejected.name, self.function(rejected.name))])
+
+        self.assertNotEqual(vetted.returncode, 0)
+        self.assertIn('malformed name', vetted.stderr)
+
+    def test_every_source_is_what_gofmt_writes(self):
+        self.assert_gofmt_writes_every_source(
+            self.labelled_bodies()
+            + [(REJECTED_TEST_FUNCTION_NAME.name,
+                self.function(REJECTED_TEST_FUNCTION_NAME.name))])
+
+    def test_every_accepted_source_compiles_and_vets(self):
         self.assert_every_source_compiles_and_vets(self.labelled_bodies())
 
 

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -235,6 +235,160 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(len(misnamed), 1)
         self.assertNotIn('\n', misnamed[0])
         self.assertTrue(misnamed[0].startswith('func(t *testing.T) []*decad.Body {'))
+        self.assertEqual(unreadable, [])
+
+    def looping_proof(self, run_call):
+        """A proof whose only run is run_call, reached through a loop and a subtest closure."""
+        return (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, name := range names {\n'
+            '        t.Run(name, func(t *testing.T) {\n'
+            '            %s\n'
+            '        })\n'
+            '    }\n'
+            '}\n\n'
+            'func stepOne() {}\n' % run_call)
+
+    def test_run_inside_a_loop_is_registered(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, c := range cases() {\n'
+            '        proofkit.Run(t, []proofkit.Case{c}, stepOne)\n'
+            '    }\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_run_inside_a_subtest_closure_is_registered(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '    t.Run("one", func(t *testing.T) {\n'
+            '        proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '    })\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_run_inside_a_loop_and_a_closure_is_registered(self):
+        proof_body = self.looping_proof(
+            'proofkit.Run(t, cases(gear{name: "one"}), stepOne)')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_misnamed_build_inside_a_loop_is_blocking(self):
+        proof_body = self.looping_proof(
+            'proofkit.Run(t, cases(gear{name: "one"}), buildProfile)')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('registers buildProfile as a proof run\'s build argument', output)
+
+    def test_table_registered_build_argument_is_blocking(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '    steps := []struct {\n'
+            '        name  string\n'
+            '        build proofkit.Build\n'
+            '    }{\n'
+            '        {name: "one", build: stepOne},\n'
+            '    }\n'
+            '    for _, step := range steps {\n'
+            '        step := step\n'
+            '        t.Run(step.name, func(t *testing.T) {\n'
+            '            proofkit.Run(t, cases(gear{name: "one"}), step.build)\n'
+            '        })\n'
+            '    }\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'proof/gear/proof_test.go does not show the gate which function a proof run builds '
+            'with: step.build; write the run\'s arguments out one by one, with the build '
+            'argument a literal step<Title> identifier so a step can claim the run', output)
+
+    def test_table_registered_step_is_not_called_unregistered(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, step := range []proofkit.Build{stepOne} {\n'
+            '        proofkit.Run(t, cases(gear{name: "one"}), step)\n'
+            '    }\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertNotIn('no Go Test registers it', output)
+        self.assertNotIn('is defined but is not registered', output)
+
+    def test_unreachable_unreadable_build_argument_is_not_counted(self):
+        proof_body = self.solid_proof(
+            'if false {\n'
+            '        proofkit3d.RunSolid(t, solidCases, builds[0].build, assertSolid)\n'
+            '    }')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertNotIn('builds[0].build', output)
+
+    def test_table_build_argument_is_unreadable_not_misnamed(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, step := range steps {\n'
+            '        proofkit.Run(t, spurCases(), step.build)\n'
+            '    }\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, ['step.build'])
+
+    def test_loop_variable_build_argument_is_unreadable_not_misnamed(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, build := range []proofkit.Build{stepOne} {\n'
+            '        proofkit.Run(t, spurCases(), build)\n'
+            '    }\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, ['build'])
+
+    def test_loop_whose_body_returns_does_not_hide_a_later_run(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    for range cases() {\n'
+            '        return\n'
+            '    }\n'
+            '    proofkit.Run(t, cases(), buildProfile)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, ['buildProfile'])
+        self.assertEqual(unreadable, [])
 
     # A run whose argument list the parse cannot read to the build slot is reported, because
     # such a run can compile: Go lets one multi-value call supply a whole argument list, so
@@ -248,8 +402,10 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'proof/gear/proof_test.go runs proofkit3d.Run(runArgs(t)), whose arguments could '
-            'not be read, so its build argument cannot be checked', output)
+            'proof/gear/proof_test.go does not show the gate which function a proof run builds '
+            'with: proofkit3d.Run(runArgs(t)); write the run\'s arguments out one by one, with '
+            'the build argument a literal step<Title> identifier so a step can claim the run',
+            output)
 
     def test_multi_value_forwarded_2d_run_is_blocking(self):
         proof_body = (
@@ -264,7 +420,9 @@ class CheckCompileTest(unittest.TestCase):
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
-        self.assertIn('runs proofkit.Run(runArgs(t)), whose arguments could not be read', output)
+        self.assertIn(
+            'does not show the gate which function a proof run builds with: '
+            'proofkit.Run(runArgs(t))', output)
 
     def test_unclosed_run_call_is_reported_not_dropped(self):
         """The argument list that never closes is reported too.
@@ -300,7 +458,7 @@ class CheckCompileTest(unittest.TestCase):
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 0, output)
-        self.assertNotIn('could not be read', output)
+        self.assertNotIn('does not show the gate', output)
 
     def test_short_argument_list_is_reported_not_registered(self):
         src = (

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -375,6 +375,89 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(misnamed, [])
         self.assertEqual(unreadable, ['build'])
 
+    def test_comma_declared_local_build_argument_is_unreadable(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    var ignored, stepOne proofkit.Build = buildA, buildB\n'
+            '    _ = ignored\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, ['stepOne'])
+
+    def test_grouped_var_local_build_argument_is_unreadable(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    var (\n'
+            '        stepOne proofkit.Build = buildA\n'
+            '    )\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, ['stepOne'])
+
+    def test_grouped_var_initializer_does_not_hide_a_real_registration(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    var (\n'
+            '        alias proofkit.Build = stepOne\n'
+            '    )\n'
+            '    _ = alias\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, {'stepOne'})
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, [])
+
+    def test_wrapped_var_initializer_does_not_hide_a_real_registration(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    var (\n'
+            '        builds = []proofkit.Build{\n'
+            '            stepOne,\n'
+            '            stepTwo,\n'
+            '        }\n'
+            '    )\n'
+            '    _ = builds\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '    proofkit.Run(t, spurCases(), stepTwo)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, {'stepOne', 'stepTwo'})
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, [])
+
+    def test_grouped_var_local_build_argument_is_blocking(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '    var (\n'
+            '        stepOne proofkit.Build = buildProfile\n'
+            '    )\n'
+            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'proof/gear/proof_test.go does not show the gate which function a proof run builds '
+            'with: stepOne; write the run\'s arguments out one by one, with the build argument '
+            'a literal step<Title> identifier so a step can claim the run', output)
+
     def test_loop_whose_body_returns_does_not_hide_a_later_run(self):
         src = (
             'func TestOne(t *testing.T) {\n'

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -534,6 +534,60 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(misnamed, [])
         self.assertEqual(unreadable, [])
 
+    # A loop header can write a brace group of its own before the block it opens, and gofmt
+    # leaves a space in front of that group's brace exactly as it does in front of the block's.
+    # Every body below is gofmt's own output, so the shapes are what a drafter would really
+    # write, and each one has to end with the loop variable holding the build: a run reported
+    # as registering a step it only names through the loop variable is a false pass, and the
+    # geometry that step claims would go unproven with the gate green.
+    HEADER_BLOCK_SHAPES = {
+        'multi-line anonymous struct': (
+            '\tfor _, stepOne := range []struct {\n'
+            '\t\tbuild proofkit.Build\n'
+            '\t}{{buildA}} {\n'),
+        'function literal in the header': (
+            '\tfor _, stepOne := range func() []proofkit.Build {\n'
+            '\t\treturn []proofkit.Build{buildA}\n'
+            '\t}() {\n'),
+        'build slice literal': (
+            '\tfor _, stepOne := range []proofkit.Build{buildA} {\n'),
+    }
+
+    def test_loop_header_shapes_leave_the_run_unreadable(self):
+        for shape, header in self.HEADER_BLOCK_SHAPES.items():
+            with self.subTest(shape=shape):
+                src = (
+                    'func TestOne(t *testing.T) {\n'
+                    + header
+                    + '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+                    '\t}\n'
+                    '}\n')
+
+                registered, misnamed, unreadable = (
+                    COMPILE_CHECKER.registered_step_functions(src))
+
+                self.assertEqual(registered, set())
+                self.assertEqual(misnamed, [])
+                self.assertEqual(unreadable, ['stepOne'])
+
+    def test_loop_header_shapes_end_their_binding_with_the_loop(self):
+        for shape, header in self.HEADER_BLOCK_SHAPES.items():
+            with self.subTest(shape=shape):
+                src = (
+                    'func TestOne(t *testing.T) {\n'
+                    + header
+                    + '\t\t_ = stepOne\n'
+                    '\t}\n'
+                    '\tproofkit.Run(t, spurCases(), stepOne)\n'
+                    '}\n')
+
+                registered, misnamed, unreadable = (
+                    COMPILE_CHECKER.registered_step_functions(src))
+
+                self.assertEqual(registered, {'stepOne'})
+                self.assertEqual(misnamed, [])
+                self.assertEqual(unreadable, [])
+
     # An if header that carries an init clause states a condition the reachability walk cannot
     # read, so a run inside such a block is skipped before its build argument is judged. The
     # scope the header binding gets is therefore checked on the bindings themselves.

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1839,6 +1839,12 @@ SIGNATURE_SHAPES = (
 # exactly that. The third is the same in a `var` declaration. The fourth is the other side of
 # the restriction: a literal whose single result is written without parentheses is still a
 # literal, and dropping it would lose a real parameter name, which is the silent failure.
+#
+# The last two rows are the audited fixtures for the two positions where a following brace hides
+# a func type: the RESULT type of an enclosing literal, where the brace standing after the type
+# opens that literal's body, and the element type of a composite literal, where it opens the
+# literal's value. A local test at the parameter list sees a brace in both and cannot say whose
+# it is, so the scan over the whole body decides it.
 SCAN_ANCHORS = (
     Signature(
         'type handler func(arg stepType)', frozenset(), frozenset(),
@@ -1861,6 +1867,41 @@ SCAN_ANCHORS = (
         '\tcall := func(arg stepType) error {\n' + RUN + '\t\treturn nil\n\t}\n\t_ = call\n',
         '\tcall := func(stepOne stepType) error {\n' + BOUND_RUN
         + '\t\treturn nil\n\t}\n\t_ = call\n'),
+    Signature(
+        'func() func(arg stepType), a result type', frozenset(), frozenset({'call'}),
+        '\tcall := func() func(stepOne stepType) {\n'
+        '\t\treturn nil\n\t}\n\t_ = call\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) func(arg stepType) {\n' + BOUND_RUN
+        + '\t\treturn nil\n\t}\n\t_ = call\n'),
+    Signature(
+        '[]func(arg stepType){}, an element type', frozenset(), frozenset({'table'}),
+        '\ttable := []func(stepOne stepType){}\n\t_ = table\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) {\n'
+        '\t\ttable := []func(arg stepType){}\n\t\t_ = table\n' + BOUND_RUN
+        + '\t}\n\tcall(0)\n'),
+)
+
+# The chokepoint working as designed, and a fixture so the next reader meets it as a decision.
+#
+# The inner literal below is a real func literal and `stepOne` is a real binding of it, in a
+# scope the Test body cannot reach. This gate tracks no scope by construction — that is what
+# ended the four rounds of header-shape repairs recorded above the chokepoint — so it reads the
+# name as bound and reports the run unreadable. The verdict is a false failure, which is the
+# price this design pays deliberately, and it is the correct verdict for this gate.
+#
+# It sits one keyword apart from the result-type row above: there the same parameter list stands
+# in a TYPE, which binds nothing anywhere in the program, and the run must register. Separating
+# those two is the whole of that fix, so this row is what pins the half that must NOT move.
+ScopeBlind = collections.namedtuple('ScopeBlind', 'shape binds body')
+
+SCOPE_BLIND_SHAPES = (
+    ScopeBlind(
+        'a literal returned by a literal', frozenset({'call', 'stepOne'}),
+        '\tcall := func() func(arg stepType) {\n'
+        '\t\treturn func(stepOne stepType) {}\n\t}\n\t_ = call\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n'),
 )
 
 # The Go package the shapes are compiled in. `stepType` is the package-level type whose name the
@@ -1895,14 +1936,12 @@ FIXTURE_TEST_HEADER = (
     ')\n')
 
 
-class SignatureShapeTest(unittest.TestCase):
-    """The signature matrix, in both directions, against real Go.
+class GoBodyFixtureTest(unittest.TestCase):
+    """What reads the fixture bodies above, shared by the tables that hold them.
 
-    Every source here is a Test body the gate reads and a Go compiler accepts, so a shape that
-    only looks like Go cannot pass as evidence.
+    The gate reads each body, and gofmt and `go vet` read it too, so a shape that only looks
+    like Go cannot pass as evidence here.
     """
-
-    SHAPES = SIGNATURE_SHAPES + SCAN_ANCHORS
 
     def source(self, body):
         return 'func TestOne(t *testing.T) {\n' + body + '}\n'
@@ -1925,6 +1964,64 @@ class SignatureShapeTest(unittest.TestCase):
         reason = unreadable[0][1]
         return LOCAL if reason.startswith(LOCAL_STEP_PREFIX) else reason
 
+    def assert_gofmt_writes_every_source(self, labelled_bodies):
+        """gofmt itself, not a guess at it.
+
+        A shape gofmt would reformat is a shape no drafter would commit, and a table of those
+        proves nothing about the proofs this gate reads.
+        """
+        if shutil.which('gofmt') is None:
+            self.skipTest('gofmt is not on PATH')
+        for label, body in labelled_bodies:
+            with self.subTest(shape=label):
+                src = 'package proof\n\n' + self.source(body)
+
+                formatted = subprocess.run(
+                    ['gofmt'], input=src, capture_output=True, text=True, check=True)
+
+                self.assertEqual(formatted.stdout, src)
+
+    def assert_every_source_compiles_and_vets(self, labelled_bodies):
+        """One `go vet` over every body given, in one package the compiler type-checks.
+
+        A shape that does not compile is not a shape the gate can ever meet, so pinning the
+        gate's reading of one would pin a reading of nothing. Vetting them together is also how
+        a matrix's two directions stay honest: the bound direction has to keep the same shape
+        and change only the name, and a rename that does not type-check fails here.
+        """
+        if shutil.which('go') is None:
+            self.skipTest('go is not on PATH')
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'go.mod').write_text(FIXTURE_MODULE)
+            (root / 'proofkit').mkdir()
+            (root / 'proofkit' / 'proofkit.go').write_text(FIXTURE_PROOFKIT)
+            (root / 'proof').mkdir()
+            (root / 'proof' / 'support.go').write_text(FIXTURE_SUPPORT)
+            tests = [FIXTURE_TEST_HEADER]
+            for index, (_, body) in enumerate(labelled_bodies):
+                tests.append(self.source(body).replace(
+                    'func TestOne(', 'func TestShape%02d(' % index, 1))
+            (root / 'proof' / 'shapes_test.go').write_text('\n'.join(tests))
+            environment = dict(os.environ, GOWORK='off', GOTOOLCHAIN='local', GOFLAGS='-mod=mod')
+
+            vetted = subprocess.run(
+                ['go', 'vet', './...'], cwd=directory, env=environment,
+                capture_output=True, text=True)
+
+            self.assertEqual(vetted.returncode, 0, vetted.stderr)
+
+
+class SignatureShapeTest(GoBodyFixtureTest):
+    """The signature matrix, in both directions, against real Go."""
+
+    SHAPES = SIGNATURE_SHAPES + SCAN_ANCHORS
+
+    def labelled_bodies(self):
+        return [('%s, %s direction' % (shape.shape, direction), body)
+                for shape in self.SHAPES
+                for direction, body in (('type', shape.body), ('binding', shape.bound))]
+
     def test_every_shape_binds_exactly_the_required_names(self):
         for shape in self.SHAPES:
             with self.subTest(shape=shape.shape):
@@ -1942,53 +2039,40 @@ class SignatureShapeTest(unittest.TestCase):
                 self.assertEqual(self.outcome(shape.bound), LOCAL)
 
     def test_every_source_is_what_gofmt_writes(self):
-        """gofmt itself, not a guess at it.
-
-        A shape gofmt would reformat is a shape no drafter would commit, and a matrix of those
-        proves nothing about the proofs this gate reads.
-        """
-        if shutil.which('gofmt') is None:
-            self.skipTest('gofmt is not on PATH')
-        for shape in self.SHAPES:
-            for direction, body in (('type', shape.body), ('binding', shape.bound)):
-                with self.subTest(shape=shape.shape, direction=direction):
-                    src = 'package proof\n\n' + self.source(body)
-
-                    formatted = subprocess.run(
-                        ['gofmt'], input=src, capture_output=True, text=True, check=True)
-
-                    self.assertEqual(formatted.stdout, src)
+        self.assert_gofmt_writes_every_source(self.labelled_bodies())
 
     def test_every_source_compiles_and_vets(self):
-        """One `go vet` over every shape, in one package the compiler type-checks.
+        self.assert_every_source_compiles_and_vets(self.labelled_bodies())
 
-        A shape that does not compile is not a shape the gate can ever meet, so pinning the
-        gate's reading of one would pin a reading of nothing. Vetting them together is also how
-        the two directions stay honest: the bound direction has to keep the same shape and
-        change only the name, and a rename that does not type-check fails here.
-        """
-        if shutil.which('go') is None:
-            self.skipTest('go is not on PATH')
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            (root / 'go.mod').write_text(FIXTURE_MODULE)
-            (root / 'proofkit').mkdir()
-            (root / 'proofkit' / 'proofkit.go').write_text(FIXTURE_PROOFKIT)
-            (root / 'proof').mkdir()
-            (root / 'proof' / 'support.go').write_text(FIXTURE_SUPPORT)
-            tests = [FIXTURE_TEST_HEADER]
-            for index, shape in enumerate(self.SHAPES):
-                for direction, body in (('Type', shape.body), ('Binding', shape.bound)):
-                    tests.append(self.source(body).replace(
-                        'func TestOne(', 'func TestShape%02d%s(' % (index, direction), 1))
-            (root / 'proof' / 'shapes_test.go').write_text('\n'.join(tests))
-            environment = dict(os.environ, GOWORK='off', GOTOOLCHAIN='local', GOFLAGS='-mod=mod')
 
-            vetted = subprocess.run(
-                ['go', 'vet', './...'], cwd=directory, env=environment,
-                capture_output=True, text=True)
+class ScopeBlindShapeTest(GoBodyFixtureTest):
+    """The false failures the chokepoint is designed to take, pinned as such.
 
-            self.assertEqual(vetted.returncode, 0, vetted.stderr)
+    A shape here binds a `step<Title>` name in a scope the run cannot see, and the gate reports
+    the run unreadable anyway. That is the design and not a defect, so it is asserted rather
+    than left for a later reader to read as one and 'fix'.
+    """
+
+    SHAPES = SCOPE_BLIND_SHAPES
+
+    def labelled_bodies(self):
+        return [(shape.shape, shape.body) for shape in self.SHAPES]
+
+    def test_every_shape_binds_exactly_the_names_it_really_binds(self):
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape.shape):
+                self.assertEqual(self.bound_names(shape.body), set(shape.binds))
+
+    def test_every_shape_stays_unreadable(self):
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape.shape):
+                self.assertEqual(self.outcome(shape.body), LOCAL)
+
+    def test_every_source_is_what_gofmt_writes(self):
+        self.assert_gofmt_writes_every_source(self.labelled_bodies())
+
+    def test_every_source_compiles_and_vets(self):
+        self.assert_every_source_compiles_and_vets(self.labelled_bodies())
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -789,6 +789,53 @@ class CheckCompileTest(unittest.TestCase):
         self.assertNotIn('no Go Test registers it', output)
         self.assertNotIn('is defined but is not registered', output)
 
+    def test_run_under_a_wrapped_unreadable_condition_is_loud_not_dropped(self):
+        """The same guard, written over three lines instead of one.
+
+        Reading only the line before the brace left this header as `)`, which named no
+        condition, so the guard passed as an enclosure and the step counted as registered.
+        """
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tif enabled(\n'
+            '\t\t"one",\n'
+            '\t) {\n'
+            '\t\tproofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\t}\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('has a proof run the gate cannot read as a registration', output)
+        self.assertIn(UNREADABLE_GUARD, output)
+        self.assertNotIn('no Go Test registers it', output)
+        self.assertNotIn('is defined but is not registered', output)
+
+    def test_run_in_the_else_arm_of_an_unreadable_if_is_loud_not_dropped(self):
+        """An else arm is as unreadable as the if it closes.
+
+        `} else` names no condition of its own, so it used to read as an enclosure and the run
+        inside it counted, though it executes only when a condition the gate cannot read fails.
+        """
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tif enabled() {\n'
+            '\t} else {\n'
+            '\t\tproofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\t}\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('has a proof run the gate cannot read as a registration', output)
+        self.assertIn(UNREADABLE_GUARD, output)
+        self.assertNotIn('no Go Test registers it', output)
+        self.assertNotIn('is defined but is not registered', output)
+
     def test_run_in_a_helper_is_loud_not_dropped(self):
         proof_body = (
             'func TestOne(t *testing.T) {\n'
@@ -1017,9 +1064,13 @@ MAP_CELLS = (
         '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
         '\t}\n'
         '}\n'), GUARD, GUARD),
+    # These three guard on a literal, so that the else arm they put the run in stays readable.
+    # An else arm inherits the readability of the if it closes (see the guard axis below), so a
+    # condition the walk cannot read would answer for these cells first and they would stop
+    # testing the binding they exist to test.
     Cell('if with init, run in the else-branch', ('C1',), (
         'func TestOne(t *testing.T) {\n'
-        '\tif localName := buildA; localName == nil {\n'
+        '\tif localName := buildA; false {\n'
         '\t\t_ = localName\n'
         '\t} else {\n'
         '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
@@ -1027,7 +1078,7 @@ MAP_CELLS = (
         '}\n'), LOCAL, REGISTERED),
     Cell('if with init, run in the else-branch', ('C2',), (
         'func TestOne(t *testing.T) {\n'
-        '\tif localName := []proofkit.Build{buildA}[0]; localName == nil {\n'
+        '\tif localName := []proofkit.Build{buildA}[0]; false {\n'
         '\t\t_ = localName\n'
         '\t} else {\n'
         '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
@@ -1035,8 +1086,8 @@ MAP_CELLS = (
         '}\n'), LOCAL, REGISTERED),
     Cell('if with init, run in the else-branch', ('C3',), (
         'func TestOne(t *testing.T) {\n'
-        '\tif localName, list := buildA, []proofkit.Build{buildA}; len(list) > 0 {\n'
-        '\t\t_ = localName\n'
+        '\tif localName, list := buildA, []proofkit.Build{buildA}; false {\n'
+        '\t\t_, _ = localName, list\n'
         '\t} else {\n'
         '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
         '\t}\n'
@@ -1342,6 +1393,351 @@ class MapCellTest(unittest.TestCase):
                     formatted = subprocess.run(
                         ['gofmt'], input=src, capture_output=True, text=True, check=True)
 
+                    self.assertEqual(formatted.stdout, src)
+
+
+# ---------------------------------------------------------------------------------------------
+# The guard axis: given a brace the walk crosses on its way to a run, is it a guard or an
+# enclosure, and if a guard, can its condition be read?
+#
+# This is not a column of the map above. That map decided which NAMES a body binds; this decides
+# whether the run executes at all. Go's grammar closes the axis — only the if / else if / else
+# family skips its own block on a condition — so the shapes can be listed once, and HEADER_SHAPES
+# is that list. Every shape gets one case, and the list and the cases are reconciled below rather
+# than eyeballed.
+#
+# Both directions are asserted, because they fail differently. Calling a guard an enclosure is a
+# false pass: the step counts as registered while its run may never execute, and the geometry it
+# claims goes unproven behind a green gate. Calling an enclosure a guard is a false failure: loud,
+# and it costs a drafter a rewrite of a proof that was already correct. The enclosure shapes used
+# to come out right by accident, an unread header falling through to reachable; they are asserted
+# here so that the keyword now deciding them is what keeps them right.
+HEADER_SHAPES = (
+    'if, single-line',
+    'if, wrapped condition',
+    'if with an init statement, single-line',
+    'if with an init statement, wrapped',
+    'else, closing an unreadable if',
+    'else, closing a known-false if',
+    'else, closing a known-true if',
+    'else if, single-line',
+    'else if, wrapped condition',
+    'known literal, true',
+    'known literal, false',
+    'known literals compounded, single-line',
+    'known literals compounded, wrapped',
+    'for, three-clause',
+    'for, range',
+    'for, bare',
+    'for, wrapped range expression',
+    'switch, expression, and its case body',
+    'switch, type, and its case body',
+    'switch with an init statement, and its case body',
+    'select, and its case body',
+    'plain block',
+    'func literal, immediately invoked',
+    'func literal, a t.Run closure',
+    'func literal, started with go',
+    'func literal, deferred',
+    'labelled statement',
+    'composite literal at line start',
+    'struct literal at line start',
+    'map literal at line start',
+    'if alone on its line, which gofmt rewrites',
+)
+
+REACHABLE = REGISTERED
+DEAD = 'dead: the walk knows the run never executes'
+
+# rewritten marks a shape gofmt does not leave alone. Such a shape cannot reach a committed
+# proof, so its case pins the rewrite rather than the reading.
+Shape = collections.namedtuple('Shape', 'name verdict source rewritten', defaults=(False,))
+
+HEADER_SHAPE_CASES = (
+    # The if family. A condition that is not a known literal makes the run unreadable, and the
+    # shape it is written in must not change that: these are the same guard four ways.
+    Shape('if, single-line', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif enabled(t) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('if, wrapped condition', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif enabled(\n'
+        '\t\tt,\n'
+        '\t) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('if with an init statement, single-line', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif on := enabled(t); on {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('if with an init statement, wrapped', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif on := enabled(\n'
+        '\t\tt,\n'
+        '\t); on {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    # The else family. A bare else names no condition of its own, so it takes the readability of
+    # the chain it closes: unreadable behind an unreadable if, live behind a dead one, dead
+    # behind a live one.
+    Shape('else, closing an unreadable if', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif enabled(t) {\n'
+        '\t} else {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('else, closing a known-false if', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif false {\n'
+        '\t} else {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('else, closing a known-true if', DEAD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif true {\n'
+        '\t} else {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('else if, single-line', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif false {\n'
+        '\t} else if enabled(t) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('else if, wrapped condition', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif false {\n'
+        '\t} else if enabled(\n'
+        '\t\tt,\n'
+        '\t) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    # The literal conditions the walk does read. A compound of them is decidable and is still
+    # refused, because deciding it is evaluating Go; the wrapped form must give the same answer
+    # as the single-line one, which is the whole point of reading the header to its start.
+    Shape('known literal, true', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif true {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('known literal, false', DEAD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif false {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('known literals compounded, single-line', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif false || false {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('known literals compounded, wrapped', GUARD, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif false ||\n'
+        '\t\tfalse {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    # Every enclosure below. None of them can skip its block on a condition, so a run inside one
+    # runs when the Test does, and the keyword at the head of the header is what says so.
+    Shape('for, three-clause', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor i := 0; i < 2; i++ {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('for, range', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor range spurCases() {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('for, bare', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\tbreak\n'
+        '\t}\n'
+        '}\n')),
+    Shape('for, wrapped range expression', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tfor range namedCases(\n'
+        '\t\tt,\n'
+        '\t) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('switch, expression, and its case body', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch len(spurCases()) {\n'
+        '\tcase 0:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('switch, type, and its case body', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch any(t).(type) {\n'
+        '\tcase *testing.T:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('switch with an init statement, and its case body', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tswitch n := len(spurCases()); n {\n'
+        '\tcase 0:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('select, and its case body', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tselect {\n'
+        '\tcase <-done:\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('plain block', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\t{\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n')),
+    Shape('func literal, immediately invoked', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tfunc() {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}()\n'
+        '}\n')),
+    Shape('func literal, a t.Run closure', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tt.Run("one", func(t *testing.T) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t})\n'
+        '}\n')),
+    Shape('func literal, started with go', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tgo func() {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}()\n'
+        '}\n')),
+    Shape('func literal, deferred', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tdefer func() {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}()\n'
+        '}\n')),
+    Shape('labelled statement', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        'Loop:\n'
+        '\tfor {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\tbreak Loop\n'
+        '\t}\n'
+        '}\n')),
+    Shape('composite literal at line start', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\truns := []func(){\n'
+        '\t\tfunc() {\n'
+        '\t\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\t},\n'
+        '\t}\n'
+        '\t_ = runs\n'
+        '}\n')),
+    Shape('struct literal at line start', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tspec := runSpec{\n'
+        '\t\trun: func() {\n'
+        '\t\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\t},\n'
+        '\t}\n'
+        '\t_ = spec\n'
+        '}\n')),
+    Shape('map literal at line start', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tbyName := map[string]func(){\n'
+        '\t\t"one": func() {\n'
+        '\t\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t\t},\n'
+        '\t}\n'
+        '\t_ = byName\n'
+        '}\n')),
+    # The one shape read wrongly, kept in the list rather than hidden. An `if` alone on its line
+    # is legal Go, the scan stops at the line break, and the guard reads as an enclosure. gofmt
+    # rewrites it to one line, where it reads as the guard it is, so no committed proof holds it.
+    Shape('if alone on its line, which gofmt rewrites', REACHABLE, (
+        'func TestOne(t *testing.T) {\n'
+        '\tif\n'
+        '\tenabled(t) {\n'
+        '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+        '\t}\n'
+        '}\n'), True),
+)
+
+
+class HeaderShapeTest(unittest.TestCase):
+    """Every header shape the Go grammar allows in front of a brace, one case each."""
+
+    def outcome(self, src):
+        """Which of the three verdicts the gate gives this source."""
+        scrubbed = COMPILE_CHECKER.strip_go_comments_and_literals(src)
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(scrubbed)
+        self.assertEqual(misnamed, [], src)
+        if registered == {'stepOne'} and not unreadable:
+            return REACHABLE
+        self.assertEqual(registered, set(), src)
+        if not unreadable:
+            return DEAD
+        self.assertEqual(len(unreadable), 1, src)
+        reason = unreadable[0][1]
+        return GUARD if reason == UNREADABLE_GUARD else reason
+
+    def test_every_shape_reads_as_the_table_says(self):
+        for shape in HEADER_SHAPE_CASES:
+            with self.subTest(shape=shape.name):
+                self.assertEqual(self.outcome(shape.source), shape.verdict)
+
+    def test_every_shape_of_the_grammar_is_covered(self):
+        """The list above and the cases below it are reconciled, not eyeballed.
+
+        Three review rounds each repaired one header shape and left another open, because the
+        shapes were found one at a time rather than listed. The list is the enumeration now, so
+        a shape it names and no case exercises is a hole.
+        """
+        self.assertEqual(
+            [shape.name for shape in HEADER_SHAPE_CASES], list(HEADER_SHAPES))
+
+    def test_every_shape_source_is_what_gofmt_writes(self):
+        """gofmt itself, not a guess at it.
+
+        A probe gofmt would reformat is a probe of a shape no drafter can commit. The one shape
+        that is reformatted says so in the table, and is asserted to be reformatted, so the gap
+        it documents cannot quietly become a shape the gate must read.
+        """
+        if shutil.which('gofmt') is None:
+            self.skipTest('gofmt is not on PATH')
+        for shape in HEADER_SHAPE_CASES:
+            with self.subTest(shape=shape.name):
+                src = 'package proof_test\n\n' + shape.source
+
+                formatted = subprocess.run(
+                    ['gofmt'], input=src, capture_output=True, text=True, check=True)
+
+                if shape.rewritten:
+                    self.assertNotEqual(formatted.stdout, src)
+                else:
                     self.assertEqual(formatted.stdout, src)
 
 

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1741,6 +1741,256 @@ class HeaderShapeTest(unittest.TestCase):
                     self.assertEqual(formatted.stdout, src)
 
 
+# ---------------------------------------------------------------------------------------------
+# The signature matrix: which identifiers a func SIGNATURE binds.
+#
+# A parameter list holds names and types together, and only the names are bindings. The types
+# must stay out, because every name collected here reaches the chokepoint through
+# `go_bound_step_names`, which keeps anything matching `step<Title>`. A proof is free to declare
+# a package-level `type stepType`, `stepCase` or `stepResult` and write it in a parameter's
+# type; reading that type as a binding makes every run in the body unreadable, which suppresses
+# the registration verdict for the whole proof directory and tells the drafter to rename a local
+# that was never written.
+#
+# The eleven shapes below are the audited matrix, and `required` is its third column verbatim.
+# `incidental` names what the surrounding statements bind — the `call` of a `call := func...` —
+# so the two together are the whole binding set of the body and the assertion is exact rather
+# than a containment check.
+#
+# Both directions are asserted, because they fail differently. Reading a type as a binding is a
+# false failure: loud, and it costs a drafter a rename with nothing to rename. Losing a real
+# parameter name is a false pass: silent, and it lets a run that builds with a local count as
+# the registration of the package-level step of the same name, leaving that step's geometry
+# unproven behind a green gate. So each shape is written twice, once with `stepType` standing in
+# the type position, where the run must still register, and once with `stepOne` standing in the
+# shape's binding position, where the run must become unreadable.
+#
+# Three shapes bind nothing at all in either direction — a func-typed struct field, an interface
+# method and `func()` — so their bound direction wraps the same shape in a literal that does
+# bind, which is the nearest genuine binding the shape admits.
+Signature = collections.namedtuple('Signature', 'shape required incidental body bound')
+
+RUN = '\t\tproofkit.Run(t, spurCases(), stepOne)\n'
+BOUND_RUN = '\t\tproofkit.Run(t, spurCases(), stepTwo)\n'
+
+SIGNATURE_SHAPES = (
+    Signature(
+        'func(a, b stepType)', frozenset({'a', 'b'}), frozenset({'call'}),
+        '\tcall := func(a, b stepType) {\n' + RUN + '\t}\n\tcall(0, 0)\n',
+        '\tcall := func(a, stepOne stepType) {\n' + BOUND_RUN + '\t}\n\tcall(0, 0)\n'),
+    Signature(
+        'func(a ...stepType)', frozenset({'a'}), frozenset({'call'}),
+        '\tcall := func(a ...stepType) {\n' + RUN + '\t}\n\tcall()\n',
+        '\tcall := func(stepOne ...stepType) {\n' + BOUND_RUN + '\t}\n\tcall()\n'),
+    Signature(
+        'func() (res stepType, err error)', frozenset({'res', 'err'}), frozenset({'call'}),
+        '\tcall := func() (res stepType, err error) {\n' + RUN
+        + '\t\treturn 0, nil\n\t}\n\t_, _ = call()\n',
+        '\tcall := func() (stepOne stepType, err error) {\n' + BOUND_RUN
+        + '\t\treturn 0, nil\n\t}\n\t_, _ = call()\n'),
+    # The unnamed result list and the named one hold groups of a single identifier alike, so
+    # this shape and the one above it are what the list-wide rule separates. Writing the names
+    # in is what turns this list into that one, and it is the bound direction of both.
+    Signature(
+        'func() (stepType, error)', frozenset(), frozenset({'call'}),
+        '\tcall := func() (stepType, error) {\n' + RUN
+        + '\t\treturn 0, nil\n\t}\n\t_, _ = call()\n',
+        '\tcall := func() (stepOne stepType, err error) {\n' + BOUND_RUN
+        + '\t\treturn 0, nil\n\t}\n\t_, _ = call()\n'),
+    Signature(
+        'func(stepType)', frozenset(), frozenset({'call'}),
+        '\tcall := func(stepType) {\n' + RUN + '\t}\n\tcall(0)\n',
+        '\tcall := func(stepOne stepType) {\n' + BOUND_RUN + '\t}\n\tcall(0)\n'),
+    Signature(
+        'func(cb func(arg stepType))', frozenset({'cb'}), frozenset({'call'}),
+        '\tcall := func(cb func(arg stepType)) {\n' + RUN + '\t}\n\tcall(nil)\n',
+        '\tcall := func(stepOne func(arg stepType)) {\n' + BOUND_RUN + '\t}\n\tcall(nil)\n'),
+    Signature(
+        'struct field run func(arg stepType)', frozenset(), frozenset(),
+        '\ttype config struct{ run func(arg stepType) }\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) {\n'
+        '\t\ttype config struct{ run func(arg stepType) }\n' + BOUND_RUN + '\t}\n\tcall(0)\n'),
+    Signature(
+        'interface method do(arg stepType)', frozenset(), frozenset(),
+        '\ttype doer interface{ do(arg stepType) }\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) {\n'
+        '\t\ttype doer interface{ do(arg stepType) }\n' + BOUND_RUN + '\t}\n\tcall(0)\n'),
+    Signature(
+        'func(p pair[stepType])', frozenset({'p'}), frozenset({'call'}),
+        '\tcall := func(p pair[stepType]) {\n' + RUN + '\t}\n\tcall(pair[stepType]{})\n',
+        '\tcall := func(stepOne pair[stepType]) {\n' + BOUND_RUN
+        + '\t}\n\tcall(pair[stepType]{})\n'),
+    Signature(
+        'func()', frozenset(), frozenset({'call'}),
+        '\tcall := func() {\n' + RUN + '\t}\n\tcall()\n',
+        '\tcall := func(stepOne stepType) {\n' + BOUND_RUN + '\t}\n\tcall(0)\n'),
+    Signature(
+        't.Run("x", func(inner *testing.T) {})', frozenset({'inner'}), frozenset(),
+        '\tt.Run("x", func(inner *testing.T) {\n'
+        '\t\tproofkit.Run(inner, spurCases(), stepOne)\n\t})\n',
+        '\tt.Run("x", func(stepOne *testing.T) {\n'
+        '\t\tproofkit.Run(stepOne, spurCases(), stepTwo)\n\t})\n'),
+)
+
+# The scan restriction, anchored the same way. A func TYPE writes a parameter list that no body
+# can read, so nothing in it is a binding, and the first two rows are the audited fixtures for
+# exactly that. The third is the same in a `var` declaration. The fourth is the other side of
+# the restriction: a literal whose single result is written without parentheses is still a
+# literal, and dropping it would lose a real parameter name, which is the silent failure.
+SCAN_ANCHORS = (
+    Signature(
+        'type handler func(arg stepType)', frozenset(), frozenset(),
+        '\ttype handler func(arg stepType)\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) {\n'
+        '\t\ttype handler func(arg stepType)\n' + BOUND_RUN + '\t}\n\tcall(0)\n'),
+    Signature(
+        'call := func(arg stepType)', frozenset({'arg'}), frozenset({'call'}),
+        '\tcall := func(arg stepType) {\n' + RUN + '\t}\n\tcall(0)\n',
+        '\tcall := func(stepOne stepType) {\n' + BOUND_RUN + '\t}\n\tcall(0)\n'),
+    Signature(
+        'var local func(arg stepType)', frozenset(), frozenset({'local'}),
+        '\tvar local func(arg stepType)\n\t_ = local\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tvar stepOne func(arg stepType)\n\t_ = stepOne\n'
+        '\tproofkit.Run(t, spurCases(), stepTwo)\n'),
+    Signature(
+        'func(arg stepType) error', frozenset({'arg'}), frozenset({'call'}),
+        '\tcall := func(arg stepType) error {\n' + RUN + '\t\treturn nil\n\t}\n\t_ = call\n',
+        '\tcall := func(stepOne stepType) error {\n' + BOUND_RUN
+        + '\t\treturn nil\n\t}\n\t_ = call\n'),
+)
+
+# The Go package the shapes are compiled in. `stepType` is the package-level type whose name the
+# gate used to read as a binding, `stepOne` and `stepTwo` are the step functions a run can
+# register, and the proof kit is stubbed down to the shapes the runs need, so the fixtures vet
+# without the real engines.
+FIXTURE_MODULE = 'module fixture\n\ngo 1.24\n'
+
+FIXTURE_PROOFKIT = (
+    'package proofkit\n\n'
+    'import "testing"\n\n'
+    'type Case int\n\n'
+    'type Build func(int)\n\n'
+    'func Run(t *testing.T, cases []Case, build Build) {\n'
+    '\t_, _, _ = t, cases, build\n'
+    '}\n')
+
+FIXTURE_SUPPORT = (
+    'package proof\n\n'
+    'import "fixture/proofkit"\n\n'
+    'type stepType int\n\n'
+    'type pair[T any] struct{}\n\n'
+    'func spurCases() []proofkit.Case { return nil }\n\n'
+    'func stepOne(int) {}\n\n'
+    'func stepTwo(int) {}\n')
+
+FIXTURE_TEST_HEADER = (
+    'package proof\n\n'
+    'import (\n'
+    '\t"testing"\n\n'
+    '\t"fixture/proofkit"\n'
+    ')\n')
+
+
+class SignatureShapeTest(unittest.TestCase):
+    """The signature matrix, in both directions, against real Go.
+
+    Every source here is a Test body the gate reads and a Go compiler accepts, so a shape that
+    only looks like Go cannot pass as evidence.
+    """
+
+    SHAPES = SIGNATURE_SHAPES + SCAN_ANCHORS
+
+    def source(self, body):
+        return 'func TestOne(t *testing.T) {\n' + body + '}\n'
+
+    def bound_names(self, body):
+        src = self.source(body)
+        spans = list(COMPILE_CHECKER.go_func_body_spans(src, r'Test[A-Z]\w*'))
+        self.assertEqual(len(spans), 1, src)
+        _, start, end = spans[0]
+        return COMPILE_CHECKER.go_bound_names(src[start:end])
+
+    def outcome(self, body):
+        registered, misnamed, unreadable = (
+            COMPILE_CHECKER.registered_step_functions(self.source(body)))
+        if registered == {'stepOne'} and not misnamed and not unreadable:
+            return REGISTERED
+        self.assertEqual(registered, set(), body)
+        self.assertEqual(misnamed, [], body)
+        self.assertEqual(len(unreadable), 1, body)
+        reason = unreadable[0][1]
+        return LOCAL if reason.startswith(LOCAL_STEP_PREFIX) else reason
+
+    def test_every_shape_binds_exactly_the_required_names(self):
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape.shape):
+                self.assertEqual(
+                    self.bound_names(shape.body), set(shape.required | shape.incidental))
+
+    def test_no_shape_makes_the_body_unreadable(self):
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape.shape):
+                self.assertEqual(self.outcome(shape.body), REGISTERED)
+
+    def test_a_step_named_binding_in_the_same_shape_still_does(self):
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape.shape):
+                self.assertEqual(self.outcome(shape.bound), LOCAL)
+
+    def test_every_source_is_what_gofmt_writes(self):
+        """gofmt itself, not a guess at it.
+
+        A shape gofmt would reformat is a shape no drafter would commit, and a matrix of those
+        proves nothing about the proofs this gate reads.
+        """
+        if shutil.which('gofmt') is None:
+            self.skipTest('gofmt is not on PATH')
+        for shape in self.SHAPES:
+            for direction, body in (('type', shape.body), ('binding', shape.bound)):
+                with self.subTest(shape=shape.shape, direction=direction):
+                    src = 'package proof\n\n' + self.source(body)
+
+                    formatted = subprocess.run(
+                        ['gofmt'], input=src, capture_output=True, text=True, check=True)
+
+                    self.assertEqual(formatted.stdout, src)
+
+    def test_every_source_compiles_and_vets(self):
+        """One `go vet` over every shape, in one package the compiler type-checks.
+
+        A shape that does not compile is not a shape the gate can ever meet, so pinning the
+        gate's reading of one would pin a reading of nothing. Vetting them together is also how
+        the two directions stay honest: the bound direction has to keep the same shape and
+        change only the name, and a rename that does not type-check fails here.
+        """
+        if shutil.which('go') is None:
+            self.skipTest('go is not on PATH')
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'go.mod').write_text(FIXTURE_MODULE)
+            (root / 'proofkit').mkdir()
+            (root / 'proofkit' / 'proofkit.go').write_text(FIXTURE_PROOFKIT)
+            (root / 'proof').mkdir()
+            (root / 'proof' / 'support.go').write_text(FIXTURE_SUPPORT)
+            tests = [FIXTURE_TEST_HEADER]
+            for index, shape in enumerate(self.SHAPES):
+                for direction, body in (('Type', shape.body), ('Binding', shape.bound)):
+                    tests.append(self.source(body).replace(
+                        'func TestOne(', 'func TestShape%02d%s(' % (index, direction), 1))
+            (root / 'proof' / 'shapes_test.go').write_text('\n'.join(tests))
+            environment = dict(os.environ, GOWORK='off', GOTOOLCHAIN='local', GOFLAGS='-mod=mod')
+
+            vetted = subprocess.run(
+                ['go', 'vet', './...'], cwd=directory, env=environment,
+                capture_output=True, text=True)
+
+            self.assertEqual(vetted.returncode, 0, vetted.stderr)
+
+
 class CommittedStepListProofPathsTest(unittest.TestCase):
     """The proof-path gate must have something to check on the real step lists.
 

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1844,11 +1844,15 @@ SIGNATURE_SHAPES = (
 # the restriction: a literal whose single result is written without parentheses is still a
 # literal, and dropping it would lose a real parameter name, which is the silent failure.
 #
-# The last two rows are the audited fixtures for the two positions where a following brace hides
-# a func type: the RESULT type of an enclosing literal, where the brace standing after the type
-# opens that literal's body, and the element type of a composite literal, where it opens the
-# literal's value. A local test at the parameter list sees a brace in both and cannot say whose
-# it is, so the scan over the whole body decides it.
+# The fifth and sixth rows are the audited fixtures for the two positions where a following
+# brace hides a func type: the RESULT type of an enclosing literal, where the brace standing
+# after the type opens that literal's body, and the element type of a composite literal, where
+# it opens the literal's value. A local test at the parameter list sees a brace in both and
+# cannot say whose it is, so the scan over the whole body decides it. TYPE_TEXT_SHAPES below
+# takes the element-type position through every bracketed context it is written in.
+#
+# The last row is the other side of the pointer prefix that scan walks over, and it is here
+# rather than there because it is not type text at all.
 SCAN_ANCHORS = (
     Signature(
         'type handler func(arg stepType)', frozenset(), frozenset(),
@@ -1890,6 +1894,20 @@ SCAN_ANCHORS = (
         '\tcall := func(stepOne stepType) {\n'
         '\t\ttable := []func(arg stepType){}\n\t\t_ = table\n' + BOUND_RUN
         + '\t}\n\tcall(0)\n'),
+    # The half of the pointer prefix that must NOT move. `[]*func(arg stepType){}` is a func
+    # TYPE and this is a product whose right operand is an invoked literal, and the two are
+    # told apart by the space gofmt writes around a binary operator and never inside a pointer
+    # type. Reading this one as type text would drop a real parameter name, which is the
+    # direction that can leave a run counted when it should not be.
+    Signature(
+        'm[0] * func(arg stepType) int { ... }(0), a product', frozenset({'arg'}),
+        frozenset({'m'}),
+        '\tm := []int{1}\n'
+        '\t_ = m[0] * func(arg stepType) int { return 1 }(0)\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tm := []int{1}\n'
+        '\t_ = m[0] * func(stepOne stepType) int { return 1 }(0)\n'
+        '\tproofkit.Run(t, spurCases(), stepTwo)\n'),
 )
 
 # The chokepoint working as designed, and a fixture so the next reader meets it as a decision.
@@ -1911,6 +1929,67 @@ SCOPE_BLIND_SHAPES = (
         '\tcall := func() func(arg stepType) {\n'
         '\t\treturn func(stepOne stepType) {}\n\t}\n\t_ = call\n'
         '\tproofkit.Run(t, spurCases(), stepOne)\n'),
+)
+
+# A func TYPE written inside larger type text, in every context that announces itself with a
+# bracket, and one that announces itself with nothing.
+#
+# The element-type row in SCAN_ANCHORS covers one of these — a bracket standing directly in
+# front of the keyword. It is not the shape. The shape is a `func` keyword standing in TYPE
+# text, and the bracket is one of the ways it is announced: an element type can carry `*`,
+# `chan` or `<-chan` in front of its own keyword, and a bracketed element type can be a func
+# type whose RESULT is another func type, where the inner keyword has a `)` in front of it and
+# no bracket anywhere near.
+#
+# Seven of the twelve rows below were read as func literals: the parameter list of the type was
+# collected as a binding, `stepOne` came out bound in a Test body that binds nothing, and the
+# run built with the package-level `stepOne` was reported unreadable. The verdict was a false
+# failure, never a false pass, because a spuriously bound name can only send a run down the
+# chokepoint. The other five rows already read correctly and are here so a later change cannot
+# move them: four through the bracket test, and `chan func(...)` at the top of a var
+# declaration only because no brace follows it, which is an accident of that shape rather than
+# a decision anything makes.
+#
+# Every row is written twice, like the tables above: with the type's parameter named `stepOne`,
+# where the run must register because a type binds nothing, and with a real literal binding
+# `stepOne` around the same type, where the run must become unreadable.
+
+
+def type_text_row(type_text):
+    """A row whose two directions write `type_text` with its parameter named two ways.
+
+    The type direction writes it as the type of a composite literal, which is where a func
+    type standing in type text is followed by a brace and reads locally like a literal.
+    """
+    return Signature(
+        type_text % 'arg', frozenset(), frozenset({'f'}),
+        '\tf := %s\n\t_ = f\n' % (type_text % 'stepOne')
+        + '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) {\n'
+        '\t\tf := %s\n\t\t_ = f\n' % (type_text % 'arg')
+        + BOUND_RUN + '\t}\n\tcall(0)\n')
+
+
+TYPE_TEXT_SHAPES = tuple(type_text_row(type_text) for type_text in (
+    '[]func(%s stepType){}',
+    'map[string]func(%s stepType){}',
+    '[2]func(%s stepType){}',
+    '[][]func(%s stepType){}',
+    '[]func() func(%s stepType){}',
+    'map[string]func() func(%s stepType){}',
+    '[2]func() func(%s stepType){}',
+    '[][]func() func(%s stepType){}',
+    '[]func(a stepType) func(%s stepType){}',
+    'map[string]chan func(%s stepType){}',
+    '[]*func(%s stepType){}',
+)) + (
+    Signature(
+        'chan func(arg stepType), declared with var', frozenset(), frozenset({'ch'}),
+        '\tvar ch chan func(stepOne stepType)\n\t_ = ch\n'
+        '\tproofkit.Run(t, spurCases(), stepOne)\n',
+        '\tcall := func(stepOne stepType) {\n'
+        '\t\tvar ch chan func(arg stepType)\n\t\t_ = ch\n' + BOUND_RUN
+        + '\t}\n\tcall(0)\n'),
 )
 
 # The Go package the shapes are compiled in. `stepType` is the package-level type whose name the
@@ -2078,6 +2157,17 @@ class SignatureShapeTest(GoBodyFixtureTest):
         self.assert_every_source_compiles_and_vets(self.labelled_bodies())
 
 
+class TypeTextShapeTest(SignatureShapeTest):
+    """The twelve-variant type-text table, read the same way the signature matrix is.
+
+    Every row's type direction has to bind nothing and register, and every row's bound
+    direction has to bind `stepOne` and stop the run, so the two halves of the rule are pinned
+    against the same Go the signature matrix is pinned against.
+    """
+
+    SHAPES = TYPE_TEXT_SHAPES
+
+
 class ScopeBlindShapeTest(GoBodyFixtureTest):
     """The false failures the chokepoint is designed to take, pinned as such.
 
@@ -2243,9 +2333,20 @@ class ReachedLiteralTest(ScrubbedBodyFixtureTest):
 # `Test[A-Z]\w*` left a run in a `Test_Profile` or `Test1` body reported as 'not inside a Go
 # Test function', which names the wrong thing to fix, since the Test was there and running.
 #
-# The rejected row is not vetted with the others: `go vet` refuses `Testing(t *testing.T)` as
-# a malformed name, and that refusal is asserted below rather than worked around, because it
-# is the evidence that the gate and Go draw the same line.
+# The rule is Unicode, and `[^a-z]` was the ASCII reading of it. `Testé`, `Testα`, `Testñ` and
+# `Testı` are not tests: `go vet` refuses each one with the same malformed-name error it gives
+# `Testing`, and `go test` runs none of them. Reading them as tests counted the runs in them as
+# registered, which is a false pass, so the four stand in the rejected table below with the
+# refusal asserted for each.
+#
+# `TestÉ` is the other side of the same rule and registers, because an upper-case letter is not
+# a lower-case one whatever alphabet it comes from. `Testʰ` is the row that separates Go's rule
+# from Python's `str.islower()`: U+02B0 is Other_Lowercase but category Lm, so Go runs it and
+# Python's own predicate would have called it lower and dropped it.
+#
+# The rejected rows are not vetted with the accepted ones: `go vet` refuses them, and that
+# refusal is asserted below rather than worked around, because it is the evidence that the gate
+# and Go draw the same line.
 TestName = collections.namedtuple('TestName', 'name verdict')
 
 TEST_FUNCTION_NAMES = (
@@ -2253,9 +2354,17 @@ TEST_FUNCTION_NAMES = (
     TestName('TestOne', REGISTERED),
     TestName('Test_Foo', REGISTERED),
     TestName('Test1', REGISTERED),
+    TestName('TestÉ', REGISTERED),
+    TestName('Testʰ', REGISTERED),
 )
 
-REJECTED_TEST_FUNCTION_NAME = TestName('Testing', UNREADABLE_OUTSIDE_TEST)
+REJECTED_TEST_FUNCTION_NAMES = (
+    TestName('Testing', UNREADABLE_OUTSIDE_TEST),
+    TestName('Testé', UNREADABLE_OUTSIDE_TEST),
+    TestName('Testα', UNREADABLE_OUTSIDE_TEST),
+    TestName('Testñ', UNREADABLE_OUTSIDE_TEST),
+    TestName('Testı', UNREADABLE_OUTSIDE_TEST),
+)
 
 
 class TestFunctionNameTest(GoBodyFixtureTest):
@@ -2278,28 +2387,183 @@ class TestFunctionNameTest(GoBodyFixtureTest):
             with self.subTest(name=name.name):
                 self.assertEqual(self.outcome(self.function(name.name)), name.verdict)
 
-    def test_the_rejected_name_leaves_the_run_outside_every_test(self):
-        rejected = REJECTED_TEST_FUNCTION_NAME
+    def test_every_rejected_name_leaves_the_run_outside_every_test(self):
+        for rejected in REJECTED_TEST_FUNCTION_NAMES:
+            with self.subTest(name=rejected.name):
+                self.assertEqual(self.outcome(self.function(rejected.name)), rejected.verdict)
 
-        self.assertEqual(self.outcome(self.function(rejected.name)), rejected.verdict)
+    def test_go_vet_rejects_every_name_the_gate_rejects(self):
+        """Go itself, not this table, is what says these names are no tests.
 
-    def test_go_vet_rejects_the_name_the_gate_rejects(self):
-        """Go itself, not this table, is what says `Testing` is no test."""
-        rejected = REJECTED_TEST_FUNCTION_NAME
+        One vet run per name, because a run over all of them together proves only that one of
+        them is malformed.
+        """
+        for rejected in REJECTED_TEST_FUNCTION_NAMES:
+            with self.subTest(name=rejected.name):
+                vetted = self.vet_sources([(rejected.name, self.function(rejected.name))])
 
-        vetted = self.vet_sources([(rejected.name, self.function(rejected.name))])
-
-        self.assertNotEqual(vetted.returncode, 0)
-        self.assertIn('malformed name', vetted.stderr)
+                self.assertNotEqual(vetted.returncode, 0)
+                self.assertIn('malformed name', vetted.stderr)
 
     def test_every_source_is_what_gofmt_writes(self):
         self.assert_gofmt_writes_every_source(
             self.labelled_bodies()
-            + [(REJECTED_TEST_FUNCTION_NAME.name,
-                self.function(REJECTED_TEST_FUNCTION_NAME.name))])
+            + [(rejected.name, self.function(rejected.name))
+               for rejected in REJECTED_TEST_FUNCTION_NAMES])
 
     def test_every_accepted_source_compiles_and_vets(self):
         self.assert_every_source_compiles_and_vets(self.labelled_bodies())
+
+
+# ---------------------------------------------------------------------------------------------
+# A build constraint on a proof file.
+#
+# `go test` never compiles a file its build constraint excludes, so a run written in one never
+# executes and registers nothing. The gate reads every `*_test.go` in the proof directory, and
+# the scrubber blanks the constraint along with every other comment before anything looks at
+# it, so a run parked behind `//go:build never` used to come back registered. That is a false
+# pass with no second line of defence: the proof runs green because Go skips the file, and the
+# gate says the step it holds is proven.
+#
+# Only the two never-build markers are honoured, which is the whole realistic case. The table
+# below pins that boundary in both directions, including the constraints that are read as if
+# the file compiled, so the gate's own documentation of what it honours is mechanical rather
+# than a claim.
+BuildConstraint = collections.namedtuple('BuildConstraint', 'shape header built')
+
+BUILD_CONSTRAINTS = (
+    BuildConstraint('no constraint', '', True),
+    BuildConstraint('//go:build never', '//go:build never\n\n', False),
+    BuildConstraint('//go:build ignore', '//go:build ignore\n\n', False),
+    BuildConstraint('//go:build linux', '//go:build linux\n\n', True),
+    BuildConstraint('//go:build !windows', '//go:build !windows\n\n', True),
+    BuildConstraint('//go:build never && linux', '//go:build never && linux\n\n', True),
+)
+
+# The legacy build line, which is not in the table because gofmt does not leave it standing: it
+# writes the `//go:build` form above it, and that form is honoured. The rewrite is asserted
+# below, so "the legacy spelling is not read" is a statement about a file no drafter can commit
+# rather than a hole in the rule.
+LEGACY_BUILD_LINE = '// +build never\n\n'
+
+CONSTRAINED_RUN = (
+    'func TestExcluded(t *testing.T) {\n'
+    '\tproofkit.Run(t, spurCases(), stepTwo)\n'
+    '}\n')
+
+UNCONSTRAINED_RUN = (
+    'func TestIncluded(t *testing.T) {\n'
+    '\tproofkit.Run(t, spurCases(), stepOne)\n'
+    '}\n')
+
+
+def constrained_file(header, body):
+    """A whole `_test.go` file: the constraint header, the package clause, then the body."""
+    return header + FIXTURE_TEST_HEADER + '\n' + body
+
+
+class BuildConstraintTest(unittest.TestCase):
+    """What a build constraint on a proof file does to the registrations read out of it."""
+
+    def registrations(self, files):
+        """`proof_registrations` over a directory holding exactly the files given."""
+        with tempfile.TemporaryDirectory() as directory:
+            for name, text in files:
+                (Path(directory) / name).write_text(text, encoding='utf-8')
+            found, misnamed, unreadable = COMPILE_CHECKER.proof_registrations(directory)
+            return found, misnamed, [(label, reason) for _, label, reason in unreadable]
+
+    def test_a_never_built_file_registers_nothing(self):
+        files = [('excluded_test.go', constrained_file('//go:build never\n\n', CONSTRAINED_RUN))]
+
+        self.assertEqual(self.registrations(files), (set(), [], []))
+
+    def test_an_unconstrained_file_still_registers(self):
+        files = [('proof_test.go', constrained_file('', UNCONSTRAINED_RUN))]
+
+        self.assertEqual(self.registrations(files), ({'stepOne'}, [], []))
+
+    def test_only_the_compiled_file_of_the_two_registers(self):
+        """Both in one directory, which is how the shape reaches a real proof."""
+        files = [
+            ('excluded_test.go', constrained_file('//go:build never\n\n', CONSTRAINED_RUN)),
+            ('proof_test.go', constrained_file('', UNCONSTRAINED_RUN)),
+        ]
+
+        self.assertEqual(self.registrations(files), ({'stepOne'}, [], []))
+
+    def test_every_constraint_is_honoured_or_read_as_the_table_says(self):
+        for constraint in BUILD_CONSTRAINTS:
+            with self.subTest(constraint=constraint.shape):
+                files = [('proof_test.go',
+                          constrained_file(constraint.header, UNCONSTRAINED_RUN))]
+
+                registered, _, _ = self.registrations(files)
+
+                self.assertEqual(registered, {'stepOne'} if constraint.built else set())
+
+    def test_a_constraint_below_the_package_clause_is_not_a_constraint(self):
+        """Go reads `//go:build` only above the package clause, and so does this."""
+        files = [('proof_test.go', constrained_file('', UNCONSTRAINED_RUN)
+                  + '\n// //go:build never\nfunc helper() {}\n')]
+
+        registered, _, _ = self.registrations(files)
+
+        self.assertEqual(registered, {'stepOne'})
+
+    def test_every_source_is_what_gofmt_writes(self):
+        if shutil.which('gofmt') is None:
+            self.skipTest('gofmt is not on PATH')
+        for constraint in BUILD_CONSTRAINTS:
+            with self.subTest(constraint=constraint.shape):
+                text = constrained_file(constraint.header, UNCONSTRAINED_RUN)
+
+                formatted = subprocess.run(
+                    ['gofmt'], input=text, capture_output=True, text=True, check=True)
+
+                self.assertEqual(formatted.stdout, text)
+
+    def test_gofmt_rewrites_the_legacy_build_line_into_the_honoured_one(self):
+        if shutil.which('gofmt') is None:
+            self.skipTest('gofmt is not on PATH')
+        text = constrained_file(LEGACY_BUILD_LINE, UNCONSTRAINED_RUN)
+
+        formatted = subprocess.run(
+            ['gofmt'], input=text, capture_output=True, text=True, check=True)
+
+        self.assertTrue(formatted.stdout.startswith('//go:build never\n// +build never\n'),
+                        formatted.stdout)
+        rewritten = [('proof_test.go', formatted.stdout)]
+        self.assertEqual(self.registrations(rewritten), (set(), [], []))
+
+    def test_go_test_runs_only_the_unconstrained_file(self):
+        """Go itself, not this table, is what says the excluded file never runs."""
+        if shutil.which('go') is None:
+            self.skipTest('go is not on PATH')
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'go.mod').write_text(FIXTURE_MODULE)
+            (root / 'proofkit').mkdir()
+            (root / 'proofkit' / 'proofkit.go').write_text(FIXTURE_PROOFKIT)
+            (root / 'proof').mkdir()
+            (root / 'proof' / 'support.go').write_text(FIXTURE_SUPPORT)
+            (root / 'proof' / 'excluded_test.go').write_text(
+                constrained_file('//go:build never\n\n', CONSTRAINED_RUN))
+            (root / 'proof' / 'proof_test.go').write_text(
+                constrained_file('', UNCONSTRAINED_RUN))
+            environment = dict(os.environ, GOWORK='off', GOTOOLCHAIN='local', GOFLAGS='-mod=mod')
+
+            vetted = subprocess.run(
+                ['go', 'vet', './...'], cwd=directory, env=environment,
+                capture_output=True, text=True)
+            listed = subprocess.run(
+                ['go', 'test', '-list', '.*', './proof'], cwd=directory, env=environment,
+                capture_output=True, text=True)
+
+            self.assertEqual(vetted.returncode, 0, vetted.stderr)
+            self.assertEqual(listed.returncode, 0, listed.stderr)
+            self.assertIn('TestIncluded', listed.stdout)
+            self.assertNotIn('TestExcluded', listed.stdout)
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -440,6 +440,118 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(misnamed, [])
         self.assertEqual(unreadable, [])
 
+    # Go scopes a local from the end of its own spec to the end of the block that contains
+    # it, so only a declaration whose block encloses the run can hide what that run registers.
+    LOCAL_DECLARATIONS = (
+        'var stepOne proofkit.Build = buildA',
+        'stepOne := buildA',
+    )
+
+    def test_local_that_does_not_enclose_the_run_leaves_it_registered(self):
+        shapes = {
+            'later in the same block': (
+                'func TestOne(t *testing.T) {\n'
+                '    proofkit.Run(t, spurCases(), stepOne)\n'
+                '    %s\n'
+                '    _ = stepOne\n'
+                '}\n'),
+            'earlier sibling block': (
+                'func TestOne(t *testing.T) {\n'
+                '    if true {\n'
+                '        %s\n'
+                '        _ = stepOne\n'
+                '    }\n'
+                '    proofkit.Run(t, spurCases(), stepOne)\n'
+                '}\n'),
+            'sibling blocks': (
+                'func TestOne(t *testing.T) {\n'
+                '    if true {\n'
+                '        %s\n'
+                '        _ = stepOne\n'
+                '    }\n'
+                '    if true {\n'
+                '        proofkit.Run(t, spurCases(), stepOne)\n'
+                '    }\n'
+                '}\n'),
+        }
+
+        for shape, template in shapes.items():
+            for declaration in self.LOCAL_DECLARATIONS:
+                with self.subTest(shape=shape, declaration=declaration):
+                    src = template % declaration
+
+                    registered, misnamed, unreadable = (
+                        COMPILE_CHECKER.registered_step_functions(src))
+
+                    self.assertEqual(registered, {'stepOne'})
+                    self.assertEqual(misnamed, [])
+                    self.assertEqual(unreadable, [])
+
+    def test_local_in_an_enclosing_block_still_makes_the_run_unreadable(self):
+        for declaration in self.LOCAL_DECLARATIONS:
+            with self.subTest(declaration=declaration):
+                src = (
+                    'func TestOne(t *testing.T) {\n'
+                    '    if true {\n'
+                    '        %s\n'
+                    '        proofkit.Run(t, spurCases(), stepOne)\n'
+                    '    }\n'
+                    '}\n') % declaration
+
+                registered, misnamed, unreadable = (
+                    COMPILE_CHECKER.registered_step_functions(src))
+
+                self.assertEqual(registered, set())
+                self.assertEqual(misnamed, [])
+                self.assertEqual(unreadable, ['stepOne'])
+
+    def test_loop_header_binding_covers_the_loop_body(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, stepOne := range []proofkit.Build{buildA} {\n'
+            '        proofkit.Run(t, spurCases(), stepOne)\n'
+            '    }\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, set())
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, ['stepOne'])
+
+    def test_loop_header_binding_ends_with_its_loop(self):
+        src = (
+            'func TestOne(t *testing.T) {\n'
+            '    for _, stepOne := range []proofkit.Build{buildA} {\n'
+            '        _ = stepOne\n'
+            '    }\n'
+            '    proofkit.Run(t, spurCases(), stepOne)\n'
+            '}\n')
+
+        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+
+        self.assertEqual(registered, {'stepOne'})
+        self.assertEqual(misnamed, [])
+        self.assertEqual(unreadable, [])
+
+    # An if header that carries an init clause states a condition the reachability walk cannot
+    # read, so a run inside such a block is skipped before its build argument is judged. The
+    # scope the header binding gets is therefore checked on the bindings themselves.
+    def test_if_header_binding_is_scoped_to_the_block_it_opens(self):
+        body = (
+            '\n'
+            '    if stepOne := buildA; true {\n'
+            '        inside()\n'
+            '    }\n'
+            '    after()\n')
+
+        bindings = COMPILE_CHECKER.go_local_bindings(body, COMPILE_CHECKER.go_brace_pairs(body))
+
+        self.assertIn(
+            'stepOne', COMPILE_CHECKER.go_local_names_at(bindings, body.index('inside')))
+        self.assertNotIn(
+            'stepOne', COMPILE_CHECKER.go_local_names_at(bindings, body.index('after')))
+
     def test_grouped_var_local_build_argument_is_blocking(self):
         proof_body = (
             'func TestOne(t *testing.T) {\n'


### PR DESCRIPTION
- A proof run inside a `for` loop or a `t.Run` closure was judged unreachable and silently dropped.
- Twelve step functions registered from a table read as unregistered, twice each, all false.
- The gate now reports an unreadable build argument. Stacks on #35.
