### PR TITLE
match watchlist receivers by class name

### DIFF
--- a/.claude/skills/generate-gear/check_api_calls.py
+++ b/.claude/skills/generate-gear/check_api_calls.py
@@ -1002,9 +1002,9 @@ def main():
             if watched != name or not fusion_api.receiver_matches(receivers, receiver):
                 continue
             expected = normalize_api_type(cls)
-            # `self.sketch` is a generated receiver shape, but its field must still be
-            # proven to be a Fusion Sketch. Exact matching alone would waive an arbitrary
-            # namesake field, while tail matching would reopen `other.sketch`.
+            # The watchlist reads a receiver by the class its name denotes, which is all a
+            # step list can offer. Here there are types, so the name alone waives nothing:
+            # `self.sketch` and `other.sketch` both still have to be proven Fusion Sketches.
             if receiver.startswith('self.') and not has_verified_receiver_binding(
                     func.value, receiver_type, containing_class):
                 continue

--- a/.claude/skills/generate-gear/check_novel_types.py
+++ b/.claude/skills/generate-gear/check_novel_types.py
@@ -195,18 +195,14 @@ def verified_fusion_classes(path):
         walk_statements(node.body, bindings)
 
     local_classes = {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
-    receiver_types = {
-        (member, receiver): class_name.rsplit('.', 1)[-1]
-        for member, class_name, receivers, _ in fusion_api.UNVERIFIED_CALLS
-        for receiver in receivers
-    }
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
             continue
         class_name = None
         receiver = node.func.value
         receiver_expression = ast.unparse(receiver)
-        class_name = receiver_types.get((node.func.attr, receiver_expression))
+        watched = fusion_api.unverified_class(node.func.attr, receiver_expression)
+        class_name = None if watched is None else watched.rsplit('.', 1)[-1]
         containing_class = containing_classes.get(id(node))
         if (class_name is not None and receiver_expression.startswith('self.')
                 and isinstance(receiver, ast.Attribute)

--- a/.claude/skills/generate-gear/fusion_api.py
+++ b/.claude/skills/generate-gear/fusion_api.py
@@ -50,8 +50,20 @@ _GROUP = re.compile(r'^(adsk\.[A-Za-z0-9_.]+)\s+\(\d+\s+members?\):\s*$')
 _MEMBER = re.compile(r'^\s{2}(\w+)')
 
 # Calls the shipped add-in makes that the API database does not back. Every entry is
-# (member, the class the shipped code calls it on, receiver names that identify that class in the
-# source, a note). Receiver names are exact so an unrelated namesake cannot be exempted.
+# (member, the class the shipped code calls it on, the words that make a receiver denote that
+# class, a note).
+#
+# The words are class names, never variable names. A step list is compiled from prose without
+# reading any implementation, so whoever writes it picks its own receiver spellings, and an entry
+# that listed one implementation's locals would exempt that implementation and block every other
+# spelling of the same call. A word is matched against the last segment of the receiver
+# expression, ignoring case, and only where the segment ends on a word boundary, so `gearSketch`,
+# `bore_sketch` and `self.sketch` all denote a Sketch.
+#
+# The words still keep an unrelated namesake out, because a receiver is named after the class it
+# holds: `chamferFeatures.createInput2()` is a real call on a real class, its receiver denotes
+# ChamferFeatures and not SketchTexts, and so the SketchTexts entry never covers it. It reaches
+# the database on its own, which is where it belongs.
 #
 # The checkers re-ask the database about each entry on every run rather than trusting this
 # comment, so an entry whose member has since been documented is reported as stale and deleted.
@@ -62,15 +74,14 @@ _MEMBER = re.compile(r'^\s{2}(\w+)')
 # shipped add-in makes all three and is believed to run. Only loading the add-in settles it, and
 # whichever way it goes the fix belongs in the spec, not in a generated file.
 UNVERIFIED_CALLS = (
-    ('project', 'adsk.fusion.Sketch', ('sketch', 'toolsSketch', 'Sketch', 'self.sketch'),
+    ('project', 'adsk.fusion.Sketch', ('Sketch',),
      'the shipped add-ins call `sketch.project(entity)`, and the spur step list names it'),
-    ('createInput2', 'adsk.fusion.SketchTexts',
-     ('sketch.sketchTexts', 'sketchTexts', 'SketchTexts'),
+    ('createInput2', 'adsk.fusion.SketchTexts', ('SketchTexts',),
      'the shipped add-ins call `sketch.sketchTexts.createInput2(text, height)`, and the spur '
      'step list names it; '
      '`ChamferFeatures.createInput2` and `MoveFeatures.createInput2` are real and not at issue'),
     ('addConstantRadiusEdgeSet', 'adsk.fusion.FilletFeatureInput',
-     ('filletInput', 'FilletFeatureInput'),
+     ('FilletFeatureInput', 'FilletInput'),
      'the shipped add-in calls `filletInput.addConstantRadiusEdgeSet(...)`, and the spur '
      'step list states that `filletInput.edgeSetInputs` does not exist'),
 )
@@ -220,9 +231,36 @@ def receiver_tail(receiver):
     return receiver.rsplit('.', 1)[-1]
 
 
+def denotes_class(word, name):
+    """Does an identifier name something of this class — `gearSketch` for `Sketch`?
+
+    The word has to be the whole name or the last word of it. Case is ignored on the word, and
+    the boundary is read from the spelling the source actually uses: the front of the name, an
+    underscore, or a capital. So `boreSketch` and `bore_sketch` denote a Sketch, `sketchTexts`
+    does not, and neither does a run-on lowercase namesake such as `mysketch`.
+    """
+    if name is None or len(name) < len(word):
+        return False
+    if name[-len(word):].lower() != word.lower():
+        return False
+    start = len(name) - len(word)
+    return start == 0 or name[start - 1] == '_' or name[start].isupper()
+
+
 def receiver_matches(receivers, receiver):
-    """Does a call belong to a watchlist entry naming this exact receiver expression?"""
-    return receivers is None or receiver in receivers
+    """Does a call belong to a watchlist entry, judged by what its receiver denotes?"""
+    if receivers is None:
+        return True
+    tail = receiver_tail(receiver)
+    return any(denotes_class(word, tail) for word in receivers)
+
+
+def unverified_class(name, receiver):
+    """The class a watchlist entry says this call is made on, or None when none covers it."""
+    for member, cls, receivers, _ in UNVERIFIED_CALLS:
+        if member == name and receiver_matches(receivers, receiver):
+            return cls
+    return None
 
 
 def unverified_findings(called):

--- a/.claude/skills/generate-gear/test_check_novel_types.py
+++ b/.claude/skills/generate-gear/test_check_novel_types.py
@@ -108,7 +108,7 @@ class DiagnosticFilterTests(unittest.TestCase):
 
         self.assertTrue(MODULE.is_unverified_api_diagnostic(diagnostic, verified))
 
-    def test_prefixed_receiver_name_does_not_match_sanctioned_call(self):
+    def test_qualified_receiver_name_matches_sanctioned_call(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / 'candidate.py'
             path.write_text(
@@ -122,7 +122,9 @@ class DiagnosticFilterTests(unittest.TestCase):
 
             verified = MODULE.verified_fusion_classes(str(path))
 
-        self.assertFalse(MODULE.is_unverified_api_diagnostic(diagnostic, verified))
+        # `other.sketch` denotes a Sketch, and pyright named that same class, so the pair
+        # agrees. The receiver still has to be typed for the api-call check to exempt it.
+        self.assertTrue(MODULE.is_unverified_api_diagnostic(diagnostic, verified))
 
     def test_verified_self_fusion_field_matches_sanctioned_call(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/.claude/skills/generate-gear/test_check_step_calls.py
+++ b/.claude/skills/generate-gear/test_check_step_calls.py
@@ -581,10 +581,14 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(
             COMPILE_CHECKER.watched_calls(invalid, 'steps.md'), {})
 
-    def test_compile_watchlist_rejects_prefixed_receiver(self):
+    def test_compile_watchlist_reads_a_qualified_sketch_receiver(self):
+        # A step list carries no types, so a receiver is judged by the class its own name
+        # denotes. `other.sketch` denotes a Sketch however it was reached. The type-aware
+        # checkers still gate this shape; only the step list treats it as the watched call.
         self.assertEqual(
             COMPILE_CHECKER.watched_calls(
-                'Call `other.sketch.project(entity)`.', 'steps.md'), {})
+                'Call `other.sketch.project(entity)`.', 'steps.md'),
+            {'project': 'steps.md:1'})
 
     def test_compile_watchlist_accepts_verified_receiver_shape(self):
         self.assertEqual(

--- a/.claude/skills/generate-gear/test_fusion_api.py
+++ b/.claude/skills/generate-gear/test_fusion_api.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Regression tests for how the unverified-call watchlist reads a receiver."""
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+API_PATH = Path(__file__).with_name('fusion_api.py')
+API_SPEC = importlib.util.spec_from_file_location('fusion_api', API_PATH)
+FUSION_API = importlib.util.module_from_spec(API_SPEC)
+API_SPEC.loader.exec_module(FUSION_API)
+
+COMPILE_PATH = Path(__file__).with_name('check_compile.py')
+COMPILE_SPEC = importlib.util.spec_from_file_location('check_compile', COMPILE_PATH)
+COMPILE_CHECKER = importlib.util.module_from_spec(COMPILE_SPEC)
+COMPILE_SPEC.loader.exec_module(COMPILE_CHECKER)
+
+
+def entry(member):
+    """The watchlist entry for one member name."""
+    for row in FUSION_API.UNVERIFIED_CALLS:
+        if row[0] == member:
+            return row
+    raise AssertionError('no watchlist entry for %s' % member)
+
+
+class DenotesClassTest(unittest.TestCase):
+    def test_whole_name_denotes_the_class(self):
+        for name in ('sketch', 'Sketch', 'SKETCH'):
+            with self.subTest(name=name):
+                self.assertTrue(FUSION_API.denotes_class('Sketch', name))
+
+    def test_trailing_word_denotes_the_class(self):
+        for name in ('gearSketch', 'boreSketch', 'toolsSketch', 'bore_sketch'):
+            with self.subTest(name=name):
+                self.assertTrue(FUSION_API.denotes_class('Sketch', name))
+
+    def test_run_on_lowercase_namesake_does_not_denote_the_class(self):
+        for name in ('mysketch', 'unsketch'):
+            with self.subTest(name=name):
+                self.assertFalse(FUSION_API.denotes_class('Sketch', name))
+
+    def test_leading_word_does_not_denote_the_class(self):
+        self.assertFalse(FUSION_API.denotes_class('Sketch', 'sketchTexts'))
+
+    def test_shorter_name_does_not_denote_the_class(self):
+        self.assertFalse(FUSION_API.denotes_class('SketchTexts', 'Texts'))
+
+    def test_missing_name_does_not_denote_the_class(self):
+        self.assertFalse(FUSION_API.denotes_class('Sketch', None))
+
+
+class SketchEntryTest(unittest.TestCase):
+    """A step list is compiled without reading an implementation, so it names its own sketches."""
+
+    def matches(self, receiver):
+        return FUSION_API.receiver_matches(entry('project')[2], receiver)
+
+    def test_any_sketch_variable_matches(self):
+        for receiver in ('sketch', 'toolsSketch', 'gearSketch', 'boreSketch', 'self.sketch',
+                         'ctx.gearSketch', 'Sketch'):
+            with self.subTest(receiver=receiver):
+                self.assertTrue(self.matches(receiver))
+
+    def test_unrelated_receiver_does_not_match(self):
+        for receiver in ('component', 'self.rootComponent', 'sketchTexts'):
+            with self.subTest(receiver=receiver):
+                self.assertFalse(self.matches(receiver))
+
+    def test_bare_call_does_not_match(self):
+        self.assertFalse(self.matches(None))
+
+
+class SketchTextsEntryTest(unittest.TestCase):
+    def matches(self, receiver):
+        return FUSION_API.receiver_matches(entry('createInput2')[2], receiver)
+
+    def test_qualified_sketch_texts_receiver_matches(self):
+        for receiver in ('sketchTexts', 'sketch.sketchTexts', 'gearSketch.sketchTexts',
+                         'self.sketch.sketchTexts', 'SketchTexts'):
+            with self.subTest(receiver=receiver):
+                self.assertTrue(self.matches(receiver))
+
+    def test_real_namesake_on_another_class_is_not_exempted(self):
+        for receiver in ('chamferFeatures', 'component.features.chamferFeatures',
+                         'ChamferFeatures', 'moveFeatures', 'MoveFeatures'):
+            with self.subTest(receiver=receiver):
+                self.assertFalse(self.matches(receiver))
+
+
+class FilletEntryTest(unittest.TestCase):
+    def matches(self, receiver):
+        return FUSION_API.receiver_matches(entry('addConstantRadiusEdgeSet')[2], receiver)
+
+    def test_fillet_input_receiver_matches(self):
+        for receiver in ('filletInput', 'FilletFeatureInput', 'self.filletInput'):
+            with self.subTest(receiver=receiver):
+                self.assertTrue(self.matches(receiver))
+
+    def test_edge_set_inputs_receiver_does_not_match(self):
+        for receiver in ('FilletEdgeSetInputs', 'edgeSetInputs'):
+            with self.subTest(receiver=receiver):
+                self.assertFalse(self.matches(receiver))
+
+
+class WatchlistShapeTest(unittest.TestCase):
+    def test_every_entry_names_its_own_class(self):
+        """Entries carry class names. A local variable lifted from one gear would fail here."""
+        for member, cls, words, _ in FUSION_API.UNVERIFIED_CALLS:
+            with self.subTest(member=member):
+                self.assertIn(cls.rsplit('.', 1)[-1], words)
+
+    def test_unverified_class_reports_the_matching_entry(self):
+        self.assertEqual(FUSION_API.unverified_class('project', 'boreSketch'),
+                         'adsk.fusion.Sketch')
+        self.assertEqual(FUSION_API.unverified_class('createInput2', 'gearSketch.sketchTexts'),
+                         'adsk.fusion.SketchTexts')
+
+    def test_unverified_class_reports_nothing_for_an_uncovered_call(self):
+        self.assertIsNone(FUSION_API.unverified_class('createInput2', 'chamferFeatures'))
+        self.assertIsNone(FUSION_API.unverified_class('project', 'component'))
+
+
+class IsWatchedCallTest(unittest.TestCase):
+    """The compile gate reads the watchlist through the same rule."""
+
+    def test_every_sketch_spelling_is_watched(self):
+        for receiver in ('toolsSketch', 'gearSketch', 'boreSketch'):
+            with self.subTest(receiver=receiver):
+                self.assertTrue(COMPILE_CHECKER.is_watched_call('project', receiver))
+
+    def test_sketch_texts_receiver_is_watched(self):
+        self.assertTrue(
+            COMPILE_CHECKER.is_watched_call('createInput2', 'gearSketch.sketchTexts'))
+
+    def test_chamfer_receiver_is_not_watched(self):
+        self.assertFalse(
+            COMPILE_CHECKER.is_watched_call('createInput2', 'component.features.chamferFeatures'))
+
+    def test_fillet_input_receiver_is_watched(self):
+        self.assertTrue(
+            COMPILE_CHECKER.is_watched_call('addConstantRadiusEdgeSet', 'filletInput'))
+
+
+class StepListTest(unittest.TestCase):
+    """The shapes a compiled step list actually produces, straight through the parser."""
+
+    SPANS = (
+        '`toolsSketch.project([self.anchorPoint], True)`',
+        '`gearSketch.project([ctx.anchorPoint], True)`',
+        '`boreSketch.project([ctx.anchorPoint], True)`',
+        '`gearSketch.sketchTexts.createInput2(text, size)`',
+        '`component.features.chamferFeatures.createInput2()`',
+        '`filletInput.addConstantRadiusEdgeSet(edges, radius)`',
+    )
+
+    def verdicts(self):
+        src = '\n'.join(self.SPANS)
+        return {
+            (name, receiver): COMPILE_CHECKER.is_watched_call(name, receiver)
+            for name, receiver in COMPILE_CHECKER.named_call_shapes(src)
+        }
+
+    def test_watchlist_covers_every_sketch_call_and_no_namesake(self):
+        self.assertEqual(self.verdicts(), {
+            ('project', 'toolsSketch'): True,
+            ('project', 'gearSketch'): True,
+            ('project', 'boreSketch'): True,
+            ('createInput2', 'gearSketch.sketchTexts'): True,
+            ('createInput2', 'component.features.chamferFeatures'): False,
+            ('addConstantRadiusEdgeSet', 'filletInput'): True,
+        })
+
+    def test_watched_calls_reports_every_line_a_sketch_call_sits_on(self):
+        src = '\n'.join(self.SPANS)
+        seen = COMPILE_CHECKER.watched_calls(src, 'steps.md')
+        self.assertEqual(seen['project'], 'steps.md:1,2,3')
+        self.assertEqual(seen['createInput2'], 'steps.md:4')
+        self.assertEqual(seen['addConstantRadiusEdgeSet'], 'steps.md:6')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Watchlist entries encoded local variable names from `lib/geargen/spurgear.py`, which a compiler cannot read.
- `gearSketch.project` blocked a clean compile run while `toolsSketch.project` passed.
- Entries now carry class names matched on a word boundary, so `chamferFeatures.createInput2` stays unexempted.
