### PR TITLE
gate proof registration by declared shape

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -239,6 +239,15 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > exception Go strips, so a file that opens with a single mark is read normally and every line
 > below it keeps its number. Write the file as UTF-8, with none of those bytes in it.
 >
+> **Separate tokens and spell names the way Go's scanner reads them.** Between two tokens Go skips
+> space, tab, carriage return and newline and nothing else, and a name is a Unicode letter or `_`
+> followed by letters, decimal digits or `_`. A vertical tab between `func` and a name, a
+> non-breaking space in the indentation, a superscript digit inside a step title: each makes the
+> file illegal where it sits, `go test` reports it as an illegal character and the package builds
+> nothing, so the gate reads no declaration on that line and names the step or the run that went
+> missing instead. Unicode letters themselves are ordinary — `stepPrüfung` is a name Go compiles
+> and the gate reads.
+>
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one
 > way needs a case for each way, because the ways differ in what they get wrong. Cover the ends of

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -177,9 +177,10 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > do not quietly correct it.
 >
 > **The proof is a Go test** in package `<gear>_test`, spread over as many files as the split
-> needs, with one function per step. Every step function, 2D or 3D alike, is named `step<Title>`,
-> matching what the step list names, and is registered by the Go `Test` of the same title, in a
-> shape that is fixed and has no variants:
+> needs, with one function per step. Every step function, 2D or 3D alike, is declared as a
+> function, `func step<Title>(...)`, matching what the step list names — a step bound to a
+> variable is not read — and is registered by the Go `Test` of the same title, in a shape that is
+> fixed and has no variants:
 >
 > ```go
 > func TestGearProfileSketch(t *testing.T) {
@@ -187,24 +188,38 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > }
 > ```
 >
-> Three lines, and the `Test` function holds nothing else. Use `proofkit3d.Run`,
-> `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of `proofkit.Run` for a solid step,
-> and put the assertion after the build where the run takes one. The build argument is always the
+> Three lines, headed exactly as above, with the testing package named in full: `go test` also
+> runs `Test_Foo`, `Test1x` and a header written against an aliased import of `testing`, and the
+> gate refuses all three by name rather than reading them. The `Test` function holds nothing else.
+> Use `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
+> `proofkit.Run` for a solid step, and put the assertion after the build where the run takes one. The build argument is always the
 > third, each argument is written out as a plain name, and the case table is a named variable
 > rather than a call built in place. Each run takes a table of parameter cases, one subtest each.
 > Pass exactly the arguments the run's own signature declares — `proofkit3d.RunWithGate` takes the
 > gate as well as the assertion, and `proofkit.Run` takes neither — since a count the method does
-> not declare is a call Go cannot compile.
+> not declare is a call Go cannot compile. The gate reads the run methods and their argument
+> counts out of `proof/proofkit/` and `proof/proofkit3d/`, so those sources are what a run is
+> checked against.
 >
 > The gate reads this shape by line rather than by parsing Go, so anything else is refused, not
-> interpreted. A build under another name, a `Test` whose title does not match the step it builds,
-> a run reached through a loop, a condition or a closure, a run whose arguments come from one
-> forwarded call as in `proofkit3d.Run(runArgs(t))`, a run on a method outside the four named
-> above, a run passing a different number of arguments than its method declares, and a proof file
-> whose header carries a `//go:build` line comment all fail the check by name and line. Go reads a
-> constraint only from a `//` line comment above the package clause, so the same text further down,
-> inside a string, and the same text inside a `/* */` comment in the header are both content rather
-> than a constraint, and both pass. The refusal says what to write; write that.
+> interpreted. A build under another name, a `Test` header outside the shape shown above, a `Test`
+> whose title does not match the step it builds, a run reached through a loop, a condition or a
+> closure, a run whose arguments come from one forwarded call as in `proofkit3d.Run(runArgs(t))`,
+> a run on a method neither harness package declares, a run passing a different number of
+> arguments than its method declares, and a proof file whose header carries a build constraint all
+> fail the check by name and line. Go reads a constraint from `//go:build` with nothing between
+> the slashes and the directive, and from `+build` with or without a space, and only above the
+> package clause, so the same text further down, inside a string, inside a `/* */` comment in the
+> header, or written `// go:build …` with a space, is content rather than a constraint, and all of
+> it passes. The refusal says what to write; write that.
+>
+> **Name proof files so Go compiles them.** Go decides which files are in a package from their
+> names alone: a name starting with `_` or `.` is invisible to it, and a name whose trailing
+> `_`-separated words are a GOOS, a GOARCH, or a GOOS and a GOARCH — `steps_windows_test.go`,
+> `steps_arm64_test.go`, `steps_windows_amd64_test.go` — is compiled only on that platform. A
+> proof in such a file registers nothing, `go test` reports no test files rather than failing, and
+> the gate names the file and asks for a rename. Ordinary trailing words are unaffected, so
+> `geometry_test.go`, `sketches_test.go` and `solids_test.go` are all fine.
 >
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -190,7 +190,11 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 >
 > Three lines, headed exactly as above, with the testing package named in full: `go test` also
 > runs `Test_Foo`, `Test1x` and a header written against an aliased import of `testing`, and the
-> gate refuses all three by name rather than reading them. The `Test` function holds nothing else.
+> gate refuses all three by name rather than reading them. The header and the closing `}` each
+> start at column 1, which is where `gofmt` writes them. Go compiles an indented one, and the gate
+> refuses it anyway, because these three lines are the shape rather than ordinary code; the refusal
+> names the header or quotes the shape, so it is never silent. The step function is not part of
+> that shape and is read wherever it starts on its line. The `Test` function holds nothing else.
 > Use `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
 > `proofkit.Run` for a solid step, and put the assertion after the build where the run takes one. The build argument is always the
 > third, each argument is written out as a plain name, and the case table is a named variable

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -192,14 +192,19 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > and put the assertion after the build where the run takes one. The build argument is always the
 > third, each argument is written out as a plain name, and the case table is a named variable
 > rather than a call built in place. Each run takes a table of parameter cases, one subtest each.
+> Pass exactly the arguments the run's own signature declares — `proofkit3d.RunWithGate` takes the
+> gate as well as the assertion, and `proofkit.Run` takes neither — since a count the method does
+> not declare is a call Go cannot compile.
 >
 > The gate reads this shape by line rather than by parsing Go, so anything else is refused, not
 > interpreted. A build under another name, a `Test` whose title does not match the step it builds,
 > a run reached through a loop, a condition or a closure, a run whose arguments come from one
 > forwarded call as in `proofkit3d.Run(runArgs(t))`, a run on a method outside the four named
-> above, and a proof file whose header carries a `//go:build` constraint all fail the check by name
-> and line. A `//go:build` line further down, inside a string, is content rather than a constraint
-> and passes. The refusal says what to write; write that.
+> above, a run passing a different number of arguments than its method declares, and a proof file
+> whose header carries a `//go:build` line comment all fail the check by name and line. Go reads a
+> constraint only from a `//` line comment above the package clause, so the same text further down,
+> inside a string, and the same text inside a `/* */` comment in the header are both content rather
+> than a constraint, and both pass. The refusal says what to write; write that.
 >
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -245,8 +245,10 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > non-breaking space in the indentation, a superscript digit inside a step title: each makes the
 > file illegal where it sits, `go test` reports it as an illegal character and the package builds
 > nothing, so the gate reads no declaration on that line and names the step or the run that went
-> missing instead. Unicode letters themselves are ordinary — `stepPrüfung` is a name Go compiles
-> and the gate reads.
+> missing instead. The name a step claims in the step list is held to the same rule and is read
+> whole: with such a character written against it the claim is not a Go name at all, so it credits
+> nothing and the step is reported as naming no proof function. Unicode letters themselves are
+> ordinary — `stepPrüfung` is a name Go compiles and the gate reads.
 >
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -225,6 +225,14 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > the gate names the file and asks for a rename. Ordinary trailing words are unaffected, so
 > `geometry_test.go`, `sketches_test.go` and `solids_test.go` are all fine.
 >
+> **Write proof files as UTF-8 Go can read.** Go refuses to compile a source file whose bytes it
+> cannot read, and a refused file registers nothing, so the gate refuses it too, naming the file,
+> the line and the column. Four byte patterns do it: a UTF-16 byte order mark, which is what a
+> file saved as UTF-16 opens with; any other bytes that are not UTF-8; a NUL byte anywhere; and a
+> byte order mark anywhere other than the very first character. One leading `EF BB BF` is the
+> exception Go strips, so a file that opens with a single mark is read normally and every line
+> below it keeps its number. Write the file as UTF-8, with none of those bytes in it.
+>
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one
 > way needs a case for each way, because the ways differ in what they get wrong. Cover the ends of

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -207,11 +207,15 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > closure, a run whose arguments come from one forwarded call as in `proofkit3d.Run(runArgs(t))`,
 > a run on a method neither harness package declares, a run passing a different number of
 > arguments than its method declares, and a proof file whose header carries a build constraint all
-> fail the check by name and line. Go reads a constraint from `//go:build` with nothing between
-> the slashes and the directive, and from `+build` with or without a space, and only above the
-> package clause, so the same text further down, inside a string, inside a `/* */` comment in the
-> header, or written `// go:build …` with a space, is content rather than a constraint, and all of
-> it passes. The refusal says what to write; write that.
+> fail the check by name and line. Go reads a constraint from `//go:build` when nothing sits
+> between the slashes and the directive, whitespace or the end of the line follows the directive,
+> and the line is above the package clause. A leading byte order mark hides nothing: Go strips one
+> and honours what is under it, and the gate reads it the same way. The same text further down,
+> inside a string, inside a `/* */` comment in the header, written `// go:build …` with a space, or
+> run straight on as `//go:build!ignore`, is content rather than a constraint, and all of it
+> passes. The legacy `+build` form is refused in every spelling, including the near-misses Go
+> builds, because a proof file needs no build constraint at all. The refusal says what to write;
+> write that.
 >
 > **Name proof files so Go compiles them.** Go decides which files are in a package from their
 > names alone: a name starting with `_` or `.` is invisible to it, and a name whose trailing

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -196,8 +196,10 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > The gate reads this shape by line rather than by parsing Go, so anything else is refused, not
 > interpreted. A build under another name, a `Test` whose title does not match the step it builds,
 > a run reached through a loop, a condition or a closure, a run whose arguments come from one
-> forwarded call as in `proofkit3d.Run(runArgs(t))`, and a proof file carrying a `//go:build`
-> constraint all fail the check by name and line. The refusal says what to write; write that.
+> forwarded call as in `proofkit3d.Run(runArgs(t))`, a run on a method outside the four named
+> above, and a proof file whose header carries a `//go:build` constraint all fail the check by name
+> and line. A `//go:build` line further down, inside a string, is content rather than a constraint
+> and passes. The refusal says what to write; write that.
 >
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -178,13 +178,26 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 >
 > **The proof is a Go test** in package `<gear>_test`, spread over as many files as the split
 > needs, with one function per step. Every step function, 2D or 3D alike, is named `step<Title>`,
-> matching what the step list names, and is passed as the build argument — the third — to a
-> `proofkit.Run`, `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` call inside a
-> Go `Test` function. A build function under any other name, or one no `Test` reaches, is invisible
-> to the gate, and the step naming it fails the check. Write each run's arguments out one by one:
-> a run that forwards them from a single call, as in `proofkit3d.Run(runArgs(t))`, hides its build
-> argument from the gate and fails the check too. Each run takes a table of parameter cases, one
-> subtest each.
+> matching what the step list names, and is registered by the Go `Test` of the same title, in a
+> shape that is fixed and has no variants:
+>
+> ```go
+> func TestGearProfileSketch(t *testing.T) {
+>         proofkit.Run(t, profileCases, stepGearProfileSketch)
+> }
+> ```
+>
+> Three lines, and the `Test` function holds nothing else. Use `proofkit3d.Run`,
+> `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of `proofkit.Run` for a solid step,
+> and put the assertion after the build where the run takes one. The build argument is always the
+> third, each argument is written out as a plain name, and the case table is a named variable
+> rather than a call built in place. Each run takes a table of parameter cases, one subtest each.
+>
+> The gate reads this shape by line rather than by parsing Go, so anything else is refused, not
+> interpreted. A build under another name, a `Test` whose title does not match the step it builds,
+> a run reached through a loop, a condition or a closure, a run whose arguments come from one
+> forwarded call as in `proofkit3d.Run(runArgs(t))`, and a proof file carrying a `//go:build`
+> constraint all fail the check by name and line. The refusal says what to write; write that.
 >
 > **The case table reaches every branch, from every direction the spec offers.** A branch a step
 > takes needs a case on each side of it, and a branch the spec says is reachable in more than one

--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -205,9 +205,11 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > interpreted. A build under another name, a `Test` header outside the shape shown above, a `Test`
 > whose title does not match the step it builds, a run reached through a loop, a condition or a
 > closure, a run whose arguments come from one forwarded call as in `proofkit3d.Run(runArgs(t))`,
-> a run on a method neither harness package declares, a run passing a different number of
-> arguments than its method declares, and a proof file whose header carries a build constraint all
-> fail the check by name and line. Go reads a constraint from `//go:build` when nothing sits
+> a run passing a different number of arguments than its method declares, and a proof file whose
+> header carries a build constraint all fail the check by name and line. A call to a `Run…` method
+> no harness package declares fails the same way, and that one is not confined to a registration:
+> a misspelled run in a helper is `undefined` to Go wherever it sits, so it is named wherever it
+> is written. Go reads a constraint from `//go:build` when nothing sits
 > between the slashes and the directive, whitespace or the end of the line follows the directive,
 > and the line is above the package clause. A leading byte order mark hides nothing: Go strips one
 > and honours what is under it, and the gate reads it the same way. The same text further down,

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -412,6 +412,10 @@ def strip_go_comments_and_literals(src):
 # no more and no fewer. The Test's title and the step's title are the same word, which is what
 # lets a step list claim a function by name alone.
 #
+# The header and the closing brace are read at column 1 only, which is part of the shape rather
+# than a fact about Go: Go compiles an indented one. `TEST_HEADER` and `BLOCK_END` each say why
+# they hold that column, and `GO_DECLARATION_INDENT` says where an ordinary declaration may start.
+#
 # What this buys is that the gate never has to decide what a brace means. What it costs is that a
 # run written any other way is refused rather than read. That is the safe direction: a refusal
 # names the file and line and says what to write, while a misreading silently credits a step no
@@ -575,13 +579,58 @@ def go_style_build_comment(line):
     return go_reads_build_constraint(line) or bool(PLUS_BUILD_DIRECTIVE.match(line))
 
 
+# Where a package-level declaration may start, for every pattern below that reads one. Go's layout
+# is free and nothing in this repository holds a `.go` file to `gofmt`: `proof/run.sh` runs only
+# `go work init/edit` and `go test ./...`, and neither `.github/workflows/3d-proof.yml` nor
+# `sketch-bench.yml` has a gofmt, vet or lint step. An indented declaration therefore reaches the
+# harness sources and the proof files alike, and Go compiles it, exports it and runs the test built
+# on it.
+#
+# Allowing the indentation stays exact rather than becoming a guess. Go does not permit a named
+# function declaration inside a function body — an indented `func Inner(x int) {}` there is
+# `syntax error: unexpected name Inner, expected (` — so `func` followed by a name can only be a
+# package-level declaration, whatever column it sits in. A function literal has no name, so a
+# `func(` opening a continuation line never matches. A method is `func (r *T) Name…`, whose
+# parenthesis follows `func` directly, and the name each pattern requires already excludes it.
+# Comments and string literals are blanked to spaces by `strip_go_comments_and_literals` before
+# every scan these patterns run in, so a `func` quoted in either cannot match.
+#
+# The indentation set is Go's rather than Python's `\s`. Go's scanner skips space, tab, carriage
+# return and newline between tokens and nothing else, and a file indented with anything wider is
+# one Go refuses outright: the compiler reports a leading U+00A0 as `invalid character U+00A0 in
+# identifier`, and `go test` reports the same file `illegal character U+00A0`, with U+000B and
+# U+000C refused the same way. Reading those would find a declaration in a file that never
+# compiles, which is what every rule on this path exists to stop. Newline is left out because a
+# line is what these anchor to.
+#
+# Which pattern uses this is a decision per pattern rather than a blanket widening. The two lines
+# that carry the declared registration shape — `TEST_HEADER` and `BLOCK_END` — stay anchored at
+# column 1 on purpose, and each says so at its own site.
+GO_DECLARATION_INDENT = ' \t\r'
+
 # A step is read only from a function declaration. Go would also accept `var stepFoo = func(...)`,
 # and that form is deliberately not recognised: the drafting contract in
 # `.claude/skills/compile-gear/SKILL.md` is one function per step, and a gate that reads both forms
 # has two shapes to keep right instead of one. What the refusal must not do is call a
 # variable-bound step undefined, so the complaint says the step has to be declared as a function.
-STEP_DEFINITION = re.compile(r'^func\s+(step[A-Z]\w*)\s*[\[(]')
+#
+# The declaration is read wherever it starts on its line. This pattern is not part of the declared
+# registration shape; it only discovers which steps a proof directory defines. Go compiles an
+# indented `func stepFoo`, `go test` runs the registration built on it, and anchoring at column 1
+# hid the definition and reported the step as one the proof directory does not declare as a
+# function — a complaint that sends the reader to a proof where the step is already written as a
+# function, and hides the whitespace that is the real difference.
+STEP_DEFINITION = re.compile(
+    r'^[%s]*func\s+(step[A-Z]\w*)\s*[\[(]' % re.escape(GO_DECLARATION_INDENT))
 
+# The header is anchored at column 1, and that is a decision rather than an oversight. It is the
+# first of the three lines of the registration shape `.claude/skills/compile-gear/SKILL.md` states
+# to the drafter, and that shape is a contract: the example there writes the header at column 1,
+# `gofmt` writes it there, and holding the contract is what this pattern is for. Go does run an indented
+# `Test`, so the refusal is this gate holding its own shape rather than following Go, and it is
+# intended. It is also loud rather than silent: `TEST_FUNCTION` below reads the indented header and
+# names it as the header problem, at its own line, instead of leaving the run beneath it to be
+# blamed.
 TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)\s*\{\s*$')
 
 # `go test` runs any function named `Test` followed by a rune that is not a lowercase letter, and
@@ -590,7 +639,13 @@ TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)
 # pattern exists so a Test that Go runs but this gate cannot read is named as the header problem it
 # is: the run inside such a Test is often perfectly formed, and reporting the run would send the
 # drafter to the wrong line.
-TEST_FUNCTION = re.compile(r'^func\s+(Test\w*)\s*\(')
+#
+# So this one is read wherever it starts on its line, unlike the shape pattern above. An indented
+# header is precisely a header Go runs and the shape does not read, which is the case this
+# diagnostic exists for; while it was anchored too, the diagnostic went silent for exactly that
+# file and the complaint fell back to the run beneath it.
+TEST_FUNCTION = re.compile(
+    r'^[%s]*func\s+(Test\w*)\s*\(' % re.escape(GO_DECLARATION_INDENT))
 
 TEST_HEADER_SHAPE = ('a proof Test is headed `func Test<Title>(t *testing.T) {`, with the testing '
                      'package named in full')
@@ -626,31 +681,11 @@ def go_runs_test(name):
 # green. Reading the `.go` files as text adds no toolchain dependency.
 PROOF_RUN_PACKAGES = ('proofkit', 'proofkit3d')
 
-# The declaration is read wherever it starts on its line, because Go's layout is free and nothing
-# here holds the harness to `gofmt`: `proof/run.sh` runs only `go work init/edit` and
-# `go test ./...`, and neither `.github/workflows/3d-proof.yml` nor `sketch-bench.yml` has a
-# gofmt, vet or lint step. Anchoring at column 1 meant one stray tab in front of `func RunSolid`
-# lost the method while `go build` and `go vet` stayed at exit 0, and every sound registration on
-# it was then reported as a call no harness package declares, sending the reader to the proof for
-# a defect in the harness.
-#
-# Allowing the indentation stays exact rather than becoming a guess. Go does not permit a named
-# function declaration inside a function body — an indented `func RunInner(x int) {}` there is
-# `syntax error: unexpected name RunInner, expected (` — so `func` followed by a name can only be
-# a package-level declaration, whatever column it sits in. A function literal has no name, so a
-# `func(` opening a continuation line never matches. A method is `func (r *T) Run…`, whose
-# parenthesis follows `func` directly, and the name required here already excludes it. Comments
-# and string literals are blanked to spaces by `strip_go_comments_and_literals` before this scan,
-# so a `func` quoted in either cannot match.
-#
-# The indentation set is Go's rather than Python's `\s`. Go's scanner skips space, tab, carriage
-# return and newline between tokens and nothing else, and a file indented with anything wider is
-# one Go refuses outright: a leading U+00A0 is `invalid character U+00A0 in identifier`, U+000B is
-# `invalid character U+000B`, U+000C is `illegal character U+000C`. Reading those would derive a
-# method from a file that never compiles, which is what every rule on this path exists to stop.
-# Newline is left out because a line is what this anchors to.
-GO_DECLARATION_INDENT = ' \t\r'
-
+# The declaration is read wherever it starts on its line, under `GO_DECLARATION_INDENT` above.
+# Anchoring at column 1 meant one stray tab in front of `func RunSolid` lost the method while
+# `go build` and `go vet` stayed at exit 0, and every sound registration on it was then reported
+# as a call no harness package declares, sending the reader to the proof for a defect in the
+# harness.
 GO_RUN_DECLARATION = re.compile(
     r'^[%s]*func\s+(Run\w*)\s*\(' % re.escape(GO_DECLARATION_INDENT), re.M)
 
@@ -755,6 +790,12 @@ def go_name_alternation(names):
     return '|'.join(re.escape(name) for name in sorted(names, key=lambda name: (-len(name), name)))
 
 
+# The closing brace is anchored at column 1 for the reason `TEST_HEADER` gives: it is the third
+# line of the declared registration shape, the SKILL.md example writes it at column 1, and `gofmt`
+# writes it there. Go compiles an indented `}`, so refusing one is this gate holding the contract
+# rather than following Go, and the refusal is intended. It is loud: the three lines are reported
+# as a run written outside the shape, and the shape quoted in that complaint names all three of
+# them.
 BLOCK_END = re.compile(r'^\}\s*$')
 
 STEP_NAME = re.compile(r'step[A-Z]\w*')

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -745,8 +745,90 @@ REGISTRATION_SHAPE = ('a registration is three lines and nothing else: '
                       'then `}`')
 
 
+GO_BYTE_ORDER_MARK_BYTES = GO_BYTE_ORDER_MARK.encode('utf-8')
+
+# The UTF-16 marks, in both byte orders. Go names this one specially — `illegal UTF-8 encoding
+# (got UTF-16)` — because it is the byte pattern a file saved as UTF-16 by an editor opens with,
+# and telling the drafter "not UTF-8" without naming the encoding sends them looking for a stray
+# character instead of at the save dialog.
+GO_UTF16_MARKS = (b'\xff\xfe', b'\xfe\xff')
+
+# What each refused byte pattern is, in Go's own words, and what removing it means. Go reports
+# `unexpected NUL in input` from the reader `go/build` uses for a file's header and `invalid NUL
+# character` from the compiler for one further down; either way the file is refused, so the gate
+# does not distinguish them.
+GO_UTF16_REFUSAL = ('opens with a UTF-16 byte order mark, which Go reports as `illegal UTF-8 '
+                    'encoding (got UTF-16)`', 'as UTF-8 rather than UTF-16')
+GO_NOT_UTF8_REFUSAL = ('holds bytes that are not UTF-8, which Go reports as `illegal UTF-8 '
+                       'encoding`', 'as UTF-8')
+GO_NUL_REFUSAL = ('holds a NUL byte, which Go reports as `unexpected NUL in input`',
+                  'without that byte')
+GO_STRAY_MARK_REFUSAL = ('holds a byte order mark below the first character, which Go reports as '
+                         '`illegal byte order mark`', 'without that mark')
+
+
+def go_refused_bytes(data):
+    """The first byte pattern in `data` that Go refuses to read, or None when there is none.
+
+    Returns `(offset, reason, remedy)`, the offset being the byte the complaint points at.
+
+    Go refuses to compile a source file whose bytes it cannot read, and a refused file registers
+    nothing, so crediting one is a false pass of this gate. Four patterns do it, and each is
+    checked here rather than guessed at:
+
+    - `FF FE` or `FE FF` at the very start, which is a UTF-16 mark.
+    - Any other byte sequence that is not UTF-8.
+    - A NUL byte anywhere.
+    - `EF BB BF` anywhere other than the first character.
+
+    The last two decode as perfectly good UTF-8, so a strict decode alone catches neither, and
+    both were credited with no complaint before they were looked for by hand.
+
+    One leading `EF BB BF` is skipped before the scan, because Go strips that one; the search for
+    a stray mark then starts below it, so a second mark is found at the offset Go names.
+
+    Which pattern is reported when a file holds more than one is the earliest in the file, except
+    that a leading UTF-16 mark is named first: it is also invalid UTF-8, and the specific message
+    is the useful one.
+    """
+    if data.startswith(GO_UTF16_MARKS):
+        return (0,) + GO_UTF16_REFUSAL
+    start = len(GO_BYTE_ORDER_MARK_BYTES) if data.startswith(GO_BYTE_ORDER_MARK_BYTES) else 0
+    found = []
+    nul = data.find(b'\x00', start)
+    if nul >= 0:
+        found.append((nul,) + GO_NUL_REFUSAL)
+    mark = data.find(GO_BYTE_ORDER_MARK_BYTES, start)
+    if mark >= 0:
+        found.append((mark,) + GO_STRAY_MARK_REFUSAL)
+    try:
+        data[start:].decode('utf-8')
+    except UnicodeDecodeError as bad:
+        found.append((start + bad.start,) + GO_NOT_UTF8_REFUSAL)
+    if not found:
+        return None
+    return min(found, key=lambda refusal: refusal[0])
+
+
+def go_byte_position(data, offset):
+    """The 1-based line and column Go names for a byte offset, counted in bytes.
+
+    Go counts a column in bytes, not in characters, so counting them here the same way makes the
+    position the gate prints the one the compiler prints. Lines are cut at `\\n`, which is the
+    only line ending Go recognises. The count runs over bytes because a file refused for its bytes
+    may have no text form to count over at all.
+    """
+    line = data.count(b'\n', 0, offset) + 1
+    column = offset - (data.rfind(b'\n', 0, offset) + 1) + 1
+    return line, column
+
+
 def go_source(path):
-    """A `.go` file's text as Go reads it, with one leading byte order mark removed.
+    """A `.go` file's text as Go reads it, or a complaint saying why Go will not read it.
+
+    Returns `(text, complaint)`, exactly one of which is None. Nothing here raises: every byte
+    pattern Go refuses becomes a complaint the drafter can act on, because a traceback fails the
+    whole run without naming the file.
 
     Go strips a UTF-8 byte order mark only when it is the first code point in the file, and only
     one of them, before it looks for a build constraint. So `EF BB BF` above a `//go:build ignore`
@@ -757,19 +839,27 @@ def go_source(path):
     The mark is removed as a character, not as a line, so every line number below it is the one
     Go, an editor and this gate's complaints all name.
 
-    A second mark, or one anywhere below the first character, is left in place, which is what Go
-    does: the line then does not begin with `//`, no constraint is read, and the parser reports
-    `illegal byte order mark` for the one that is not at the start.
-
-    Bytes that are not UTF-8 are replaced rather than raised on. A UTF-16 mark, and every other
-    leading byte Go rejects instead of stripping, leaves a line Go reads no constraint from, and
-    the gate agrees with that by reading the file rather than by crashing on it.
+    A second mark, one anywhere below the first character, a NUL byte, and bytes that are not
+    UTF-8 are all refusals rather than text to scan, because `go build` fails on each of them and
+    a file Go never compiles registers nothing. `go_refused_bytes` is the whole list and states
+    what Go does with each. Reading such a file as text — with `errors='replace'` for the
+    undecodable ones — credited its registrations and, for a UTF-16 mark, also hid the build
+    constraint under it, because the two replacement characters pushed the line off its `//`
+    start.
     """
     with open(path, 'rb') as fh:
-        text = fh.read().decode('utf-8', 'replace')
+        data = fh.read()
+    refused = go_refused_bytes(data)
+    if refused is not None:
+        offset, reason, remedy = refused
+        line, column = go_byte_position(data, offset)
+        return None, (
+            "  %s:%d:%d %s, so Go refuses the file: `go test` never compiles it, and nothing it "
+            "registers is ever built; write the file %s" % (path, line, column, reason, remedy))
+    text = data.decode('utf-8')
     if text.startswith(GO_BYTE_ORDER_MARK):
         text = text[len(GO_BYTE_ORDER_MARK):]
-    return text
+    return text, None
 
 
 def go_header_constraint_lines(lines):
@@ -831,8 +921,12 @@ def scan_proof_file(path):
 
     The source arrives from `go_source`, which removes a leading byte order mark as Go does, so
     line 1 reads the same to this gate as it does to the compiler and every line number holds.
+    That is also where a file Go refuses to read at all is turned into the one complaint such a
+    file has: nothing below is scanned, because Go never compiles it and so registers nothing.
     """
-    src = go_source(path)
+    src, refused = go_source(path)
+    if refused is not None:
+        return set(), [], [refused]
     raw = src.split('\n')
     code = strip_go_comments_and_literals(src).split('\n')
     defined = set()

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -11,12 +11,13 @@ Four checks gate, and one is reported:
   1. CITATIONS RESOLVE. Every step has a nonempty `**From:**` line naming real files and line
      ranges that exist.
   2. STEPS AND PROOF AGREE. Every `[GO]` step names the proof function that realises it, every
-     proof function is claimed by a step, and every proof run's build argument is a `step<Title>`
-     function so a step can claim it. Drift in either direction means one artifact moved without
-     the other, and a build function under any other name is a proof no step can reach. A run
-     whose arguments this checker cannot read to the build slot — one written as a single
-     multi-value call, say — is reported for the same reason: an unread build argument is an
-     unchecked one.
+     proof function is claimed by a step, and every proof function is built by the Go Test of its
+     own title: `stepGearProfileSketch` by `TestGearProfileSketch`, and by no other. Drift in
+     either direction means one artifact moved without the other, and a build the matching Test
+     does not name is a proof no step can reach. The registration is written in one fixed shape
+     the gate matches by line ("Registration is read by SHAPE" below says why and states it); a
+     run written any other way is reported rather than read, because an unread build argument is
+     an unchecked one.
   3. API CALLS ARE REAL. Every Fusion call the step list names exists in the API database the
      `fusion` plugin ships. Catches a spec that names a method Fusion does not have.
   4. INPUTS HAVE NOT DRIFTED. The provenance table contains and matches the existing instructions,
@@ -385,219 +386,147 @@ def strip_go_comments_and_literals(src):
     return ''.join(out)
 
 
-def matching_delimiter(src, start):
-    """Return the matching delimiter index for src[start], or None."""
-    pairs = {'(': ')', '{': '}', '[': ']'}
-    opens = set(pairs)
-    closes = {v: k for k, v in pairs.items()}
-    stack = [src[start]]
-    for i in range(start + 1, len(src)):
-        ch = src[i]
-        if ch in opens:
-            stack.append(ch)
-        elif ch in closes:
-            if not stack or stack[-1] != closes[ch]:
-                return None
-            stack.pop()
-            if not stack:
-                return i
-    return None
+# Registration is read by SHAPE, not by parsing Go.
+#
+# The gate has one question about the proof: which step function does each proof run build with?
+# Answering it by reading Go is answering a much harder question than the one asked, and the
+# checker spent a long time getting Go's grammar wrong at the edges — a type brace in a range
+# header, a func literal in a for-init, a wrapped if, a func type in a result position. Every one
+# of those was a shape no committed proof contains.
+#
+# So the proof declares its registrations in a fixed shape instead, and the gate matches that
+# shape. A registration is three lines and nothing else:
+#
+#     func Test<Title>(t *testing.T) {
+#             proofkit.Run(t, <cases>, step<Title>)
+#     }
+#
+# with `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
+# `proofkit.Run`, and an assertion argument after the build where the run takes one. The build
+# argument is always the third. The Test's title and the step's title are the same word, which is
+# what lets a step list claim a function by name alone.
+#
+# What this buys is that the gate never has to decide what a brace means. What it costs is that a
+# run written any other way is refused rather than read. That is the safe direction: a refusal
+# names the file and line and says what to write, while a misreading silently credits a step no
+# test builds. `.claude/skills/compile-gear/SKILL.md` states the same shape to the drafter, so the
+# refusal is a contract violation rather than a surprise.
+#
+# Comments and literals are blanked before matching, so a registration quoted inside a doc comment
+# or a raw string is not mistaken for a real one. Blanking preserves newlines, so a line number in
+# a complaint is a line number in the file.
+
+GO_BUILD_CONSTRAINT = re.compile(r'^\s*//\s*(?:go:build|\+build)\b')
+
+STEP_DEFINITION = re.compile(r'^func\s+(step[A-Z]\w*)\s*[\[(]')
+
+TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)\s*\{\s*$')
+
+# The build slot is a bare name, because it has to be `step<Title>` for a step to claim it. Every
+# other argument may be qualified, so a gate like `proofkit3d.RequireSolid` reads as one argument.
+PROOF_RUN = re.compile(
+    r'^\s*proofkit(?:3d)?\s*\.\s*Run(?:Solid|WithGate)?\s*\('
+    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*(?:,\s*[\w.]+\s*)*\)\s*$')
+
+PROOF_RUN_MENTION = re.compile(r'\bproofkit(?:3d)?\s*\.\s*Run(?:Solid|WithGate)?\s*\(')
+
+BLOCK_END = re.compile(r'^\}\s*$')
+
+STEP_NAME = re.compile(r'step[A-Z]\w*')
+
+REGISTRATION_SHAPE = ('a registration is three lines and nothing else: '
+                      '`func Test<Title>(t *testing.T) {`, one proof run whose third argument is '
+                      '`step<Title>`, then `}`')
 
 
-def go_func_bodies(src, name_pattern):
-    """Yield (name, body) for top-level Go functions whose names match name_pattern."""
-    pattern = r'(?m)^func\s+(%s)\s*\(' % name_pattern
-    for m in re.finditer(pattern, src):
-        open_brace = src.find('{', m.end())
-        if open_brace == -1:
-            continue
-        close_brace = matching_delimiter(src, open_brace)
-        if close_brace is None:
-            continue
-        yield m.group(1), src[open_brace + 1:close_brace]
+def scan_proof_file(path):
+    """Return one proof file's step definitions, registrations and complaints.
 
-
-def split_go_args(src):
-    """Split a Go argument list on top-level commas."""
-    args = []
-    start = 0
-    stack = []
-    pairs = {'(': ')', '{': '}', '[': ']'}
-    closes = {v: k for k, v in pairs.items()}
-    for i, ch in enumerate(src):
-        if ch in pairs:
-            stack.append(ch)
-        elif ch in closes:
-            if stack and stack[-1] == closes[ch]:
-                stack.pop()
-        elif ch == ',' and not stack:
-            args.append(src[start:i].strip())
-            start = i + 1
-    tail = src[start:].strip()
-    if tail:
-        args.append(tail)
-    return args
-
-
-PROOF_RUN_CALLS = [
-    (r'\bproofkit\s*\.\s*Run\s*\(', 2),
-    (r'\bproofkit3d\s*\.\s*Run\s*\(', 2),
-    (r'\bproofkit3d\s*\.\s*RunSolid\s*\(', 2),
-    (r'\bproofkit3d\s*\.\s*RunWithGate\s*\(', 2),
-]
-
-
-def go_brace_pairs(src):
-    """Return matching brace positions in already-scrubbed Go source."""
-    pairs = {}
-    stack = []
-    for pos, char in enumerate(src):
-        if char == '{':
-            stack.append(pos)
-        elif char == '}' and stack:
-            opening = stack.pop()
-            pairs[opening] = pos
-    return pairs
-
-
-def go_brace_depth(src, pos):
-    """Return brace nesting depth before pos in already-scrubbed Go source."""
-    return sum(char == '{' for char in src[:pos]) - sum(char == '}' for char in src[:pos])
-
-
-def go_block_condition(src, opening):
-    """Return the known reachability of an if block, or None when it is unknown."""
-    line_start = src.rfind('\n', 0, opening) + 1
-    header = src[line_start:opening].strip()
-    match = re.match(r'if\s+(.+)$', header)
-    if not match:
-        return False
-    condition = re.sub(r'\s+', ' ', match.group(1)).strip()
-    if condition == 'false':
-        return False
-    if condition in ('true', 't != nil'):
-        return True
-    return None
-
-
-def go_top_level_return_before(src, pos):
-    """Return whether an unconditional return precedes pos in a test body."""
-    for match in re.finditer(r'\breturn\b', src[:pos]):
-        if go_brace_depth(src, match.start()) == 0:
-            return True
-    return False
-
-
-def go_early_return_before(src, pos, brace_pairs):
-    """Return whether a known-true top-level if-return precedes pos."""
-    for opening, closing in brace_pairs.items():
-        if closing >= pos or go_brace_depth(src, opening) != 0:
-            continue
-        if go_block_condition(src, opening) is not True:
-            continue
-        if re.fullmatch(r'\s*return\s*;?\s*', src[opening + 1:closing]):
-            return True
-    return False
-
-
-def go_call_is_reachable(src, pos, brace_pairs):
-    """Return whether a proof run at pos can execute on the test path."""
-    if go_top_level_return_before(src, pos) or go_early_return_before(src, pos, brace_pairs):
-        return False
-    for opening, closing in brace_pairs.items():
-        if not opening < pos < closing:
-            continue
-        condition = go_block_condition(src, opening)
-        if condition is not True:
-            return False
-    return True
-
-
-def go_argument_label(argument):
-    """A one-line label for a Go argument expression, for diagnostics."""
-    label = re.sub(r'\s+', ' ', argument).strip()
-    if len(label) > 60:
-        label = label[:57] + '...'
-    return label
-
-
-def registered_step_functions(src):
-    """Return (step functions, other build arguments, unreadable runs) for reachable runs.
-
-    The first two come out of the same parse of the same run, because they are the same fact
-    read two ways: a run's build argument either is a step function or is a build the step
-    list has no name for. Dropping the second half is how a proof registered under a name
-    like buildSolid used to escape every check — no step could claim it, and nothing looked
-    for it. Only the build argument is judged; the gate and assertion arguments are not steps.
-
-    The third is every reachable run whose argument list this parse could not read to the
-    build slot: an unterminated call, or an argument list shorter than that slot, which is
-    what a run written as one multi-value call — the build argument forwarded from a helper
-    rather than written out — parses to. Such a run compiles, so silently skipping it would
-    let its build argument escape the same check. It is reported instead, and the fix is to
-    write the run's arguments out one by one.
+    A registration comes back as (line number, Test name, build argument) so a complaint can say
+    where to go. Complaints here are the ones only this file can see: a build constraint, and a
+    proof run written outside the registration shape.
     """
-    registered = set()
-    other = set()
-    unreadable = set()
-    for _, body in go_func_bodies(src, r'Test[A-Z]\w*'):
-        brace_pairs = go_brace_pairs(body)
-        for pattern, build_arg in PROOF_RUN_CALLS:
-            for m in re.finditer(pattern, body):
-                if not go_call_is_reachable(body, m.start(), brace_pairs):
-                    continue
-                open_paren = m.end() - 1
-                close_paren = matching_delimiter(body, open_paren)
-                if close_paren is None:
-                    unreadable.add(go_argument_label(body[m.start():]))
-                    continue
-                args = split_go_args(body[open_paren + 1:close_paren])
-                if len(args) <= build_arg:
-                    unreadable.add(go_argument_label(body[m.start():close_paren + 1]))
-                    continue
-                if re.fullmatch(r'step[A-Z]\w*', args[build_arg]):
-                    registered.add(args[build_arg])
-                else:
-                    other.add(go_argument_label(args[build_arg]))
-    return registered, sorted(other), sorted(unreadable)
+    src = read(path)
+    raw = src.splitlines()
+    code = strip_go_comments_and_literals(src).splitlines()
+    defined = set()
+    registrations = []
+    complaints = []
+    run_lines = set()
 
-
-def proof_functions(proof_dir):
-    """Every step function the proof defines, by name."""
-    found = set()
-    if not os.path.isdir(proof_dir):
-        return found
-    for entry in sorted(os.listdir(proof_dir)):
-        if not entry.endswith('.go'):
+    for index, line in enumerate(code):
+        match = STEP_DEFINITION.match(line)
+        if match:
+            defined.add(match.group(1))
+        header = TEST_HEADER.match(line)
+        if not header:
             continue
-        src = strip_go_comments_and_literals(read(os.path.join(proof_dir, entry)))
-        # step<Title>, so a helper called steps() is not mistaken for a step.
-        for name, _ in go_func_bodies(src, r'step[A-Z]\w*'):
-            found.add(name)
-    return found
+        run = PROOF_RUN.match(code[index + 1]) if index + 1 < len(code) else None
+        closed = BLOCK_END.match(code[index + 2]) if index + 2 < len(code) else None
+        if not run or not closed:
+            continue
+        run_lines.add(index + 1)
+        registrations.append((index + 2, header.group(1), run.group(1)))
+
+    for index, line in enumerate(code):
+        if PROOF_RUN_MENTION.search(line) and index not in run_lines:
+            complaints.append(
+                "  %s:%d runs a proof outside the shape this gate reads, so its build argument "
+                "cannot be checked; %s" % (path, index + 1, REGISTRATION_SHAPE))
+
+    # The build constraint is read from the raw source, because blanking has already removed it
+    # from the scrubbed copy. A constrained file decides outside itself whether it compiles, so
+    # the gate would otherwise credit registrations Go never builds.
+    for number, line in enumerate(raw, 1):
+        if GO_BUILD_CONSTRAINT.match(line):
+            complaints.append(
+                "  %s:%d carries a build constraint, so whether Go ever compiles these "
+                "registrations is decided outside the file; a proof file needs no build "
+                "constraint, so remove it" % (path, number))
+
+    return defined, registrations, complaints
 
 
 def proof_registrations(proof_dir):
-    """Return registrations, misnamed builds and unreadable runs, the last two file-anchored.
+    """Return the proof's step functions, its registered ones, and every complaint about them.
 
-    Misnamed builds come back as (file, argument) and unreadable runs as (file, call), because
-    the name alone does not say where to go and fix it.
+    A step function is registered when the Test of the same title builds with it. Requiring the
+    titles to agree is what makes the mapping readable from names alone, and it catches a crossed
+    pair — a Test building with some other step — which a gate that only looked for a `step<Title>`
+    argument would pass.
     """
-    found = set()
-    misnamed = set()
-    unreadable = set()
+    defined = set()
+    registered = set()
+    complaints = []
     if not os.path.isdir(proof_dir):
-        return found, [], []
+        return defined, registered, complaints
     for entry in sorted(os.listdir(proof_dir)):
-        if not entry.endswith('_test.go'):
+        if not entry.endswith('.go'):
             continue
         path = os.path.join(proof_dir, entry)
-        src = strip_go_comments_and_literals(read(path))
-        registered, other, unread = registered_step_functions(src)
-        found.update(registered)
-        misnamed.update((path, argument) for argument in other)
-        unreadable.update((path, call) for call in unread)
-    return found, sorted(misnamed), sorted(unreadable)
+        found, registrations, file_complaints = scan_proof_file(path)
+        defined |= found
+        complaints.extend(file_complaints)
+        for number, test, build in registrations:
+            if not entry.endswith('_test.go'):
+                complaints.append(
+                    "  %s:%d registers %s, but `go test` only runs tests in a _test.go file, so "
+                    "nothing here ever builds it" % (path, number, build))
+                continue
+            expected = 'step' + test[len('Test'):]
+            if build == expected:
+                registered.add(build)
+            elif STEP_NAME.fullmatch(build):
+                complaints.append(
+                    "  %s:%d registers %s inside %s, but a step is registered by the Test of its "
+                    "own title, so this build belongs in Test%s"
+                    % (path, number, build, test, build[len('step'):]))
+            else:
+                complaints.append(
+                    "  %s:%d registers %s as a proof run's build argument, but that argument "
+                    "must be a step<Title> function so a step can claim it"
+                    % (path, number, build))
+    return defined, registered, complaints
 
 
 def main(argv):
@@ -637,8 +566,8 @@ def main(argv):
             cited.setdefault(path, set()).update(range(first, last + 1))
 
     # 2. steps and proof agree
-    functions = proof_functions(proof_dir)
-    registered, misnamed_builds, unreadable_runs = proof_registrations(proof_dir)
+    functions, registered, registration_problems = proof_registrations(proof_dir)
+    problems.extend(registration_problems)
     claimed = set()
     for sid, tag, body in steps:
         named = set(re.findall(r'\b(step[A-Z]\w*)\b', body))
@@ -649,22 +578,14 @@ def main(argv):
                 problems.append("  %s names proof function %s, which %s/ does not define"
                                 % (sid, fn, proof_dir))
             elif fn not in registered:
-                problems.append("  %s names proof function %s, but no Go Test registers it "
-                                "in a proofkit run" % (sid, fn))
+                problems.append("  %s names proof function %s, which Test%s does not build with; "
+                                "%s" % (sid, fn, fn[len('step'):], REGISTRATION_SHAPE))
             claimed.add(fn)
     for fn in sorted(functions - claimed):
         problems.append("  proof function %s is not claimed by any step" % fn)
-    for fn in sorted(functions - registered):
-        problems.append("  proof function %s is defined but is not registered in any "
-                        "proofkit run inside a Go Test" % fn)
-    for path, argument in misnamed_builds:
-        problems.append("  %s registers %s as a proof run's build argument, but that argument "
-                        "must be a step<Title> function so a step can claim it"
-                        % (path, argument))
-    for path, call in unreadable_runs:
-        problems.append("  %s runs %s, whose arguments could not be read, so its build argument "
-                        "cannot be checked; write the run's arguments out one by one"
-                        % (path, call))
+    for fn in sorted(functions - registered - claimed):
+        problems.append("  proof function %s is defined but no Test%s builds with it; %s"
+                        % (fn, fn[len('step'):], REGISTRATION_SHAPE))
 
     # 3. API calls are real
     local = PYTHON_METHODS | defined_names(FRAMEWORK) | contract_names(gear)

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -521,12 +521,57 @@ def go_ignores_file(name, goos=None, goarch=None):
     return None
 
 
-# Go's two constraint forms differ in what may sit between the slashes and the directive, and the
-# gate has to differ with them or it refuses comments Go compiles. `//go:build` is recognised only
-# with no space after the slashes, so `// go:build is discussed here` is ordinary prose and its
-# file is built. The legacy `+build` form does allow the space, and every spelling of it is
-# honoured.
-GO_BUILD_CONSTRAINT = re.compile(r'^\s*//(?:go:build\b|\s*\+build\b)')
+# Go trims every header line with `bytes.TrimSpace`, which uses `unicode.IsSpace`, before it looks
+# at the line at all. Python's `\s` is nearly that set but also counts U+001C to U+001F, which Go
+# does not, so a header opening with one of those reads to Python as an indented comment and to Go
+# as a line that does not begin with `//`. The set is written out rather than borrowed. A
+# non-breaking space is in it, which is why `\xa0//go:build ignore` is a constraint Go honours.
+GO_SPACE = ('\t\n\v\f\r \u0085\u00a0\u1680'
+            '\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a'
+            '\u2028\u2029\u202f\u205f\u3000')
+
+GO_BUILD_DIRECTIVE = '//go:build'
+
+GO_BYTE_ORDER_MARK = '\ufeff'
+
+
+def go_reads_build_constraint(line):
+    """Whether Go reads this trimmed header line as a `//go:build` constraint.
+
+    Transcribed from `go/build`'s `isGoBuildComment`. Two rules, and the gate has to hold both or
+    it disagrees with Go about a spelling.
+
+    Nothing may sit between the slashes and the directive, so `// go:build is discussed here` is
+    ordinary prose and its file is built.
+
+    The directive must be followed by whitespace or the end of the line. `//go:build!ignore` and
+    `//go:build/ignore` are prose by that rule, and `go list` reports both in `GoFiles`; ending
+    the directive at a word boundary instead refused files Go compiles, at line 1, for a `!` or a
+    `/`. Bare `//go:build`, and `//go:build` followed only by spaces or tabs, are constraints Go
+    cannot parse — it reports the file in `InvalidGoFiles` with "unexpected end of expression" —
+    so they stay refused.
+    """
+    if not line.startswith(GO_BUILD_DIRECTIVE):
+        return False
+    rest = line[len(GO_BUILD_DIRECTIVE):]
+    return not rest or rest[0] in GO_SPACE
+
+
+# Every `+build` spelling is refused, and that is this gate's decision rather than Go's rule. Go
+# reads the legacy form only when the directive is followed by whitespace or the end of the line,
+# and only when the comment run holding it is closed by a blank line, so `// +build!ignore` and a
+# `// +build ignore` written directly above the package clause are both in `GoFiles`. The gate
+# refuses them anyway. A proof file needs no build constraint in any form, so an over-refusal here
+# costs one message and a rewritten header, while matching Go would add two more rules to keep
+# right for a form nothing in this repository should be writing. The `//go:build` side above is
+# matched exactly instead, because there a wider gate refuses files Go builds and buys nothing.
+PLUS_BUILD_DIRECTIVE = re.compile(r'//[%s]*\+build' % re.escape(GO_SPACE))
+
+
+def go_style_build_comment(line):
+    """Whether this trimmed header line is refused as a build constraint."""
+    return go_reads_build_constraint(line) or bool(PLUS_BUILD_DIRECTIVE.match(line))
+
 
 # A step is read only from a function declaration. Go would also accept `var stepFoo = func(...)`,
 # and that form is deliberately not recognised: the drafting contract in
@@ -700,31 +745,69 @@ REGISTRATION_SHAPE = ('a registration is three lines and nothing else: '
                       'then `}`')
 
 
-def blank_block_comments(text):
-    """Blank `/* */` spans, leaving line comments alone.
+def go_source(path):
+    """A `.go` file's text as Go reads it, with one leading byte order mark removed.
 
-    Go reads a build constraint only from a `//` line comment, so constraint text inside a block
-    comment above the package clause is prose. Blanking the block comments and nothing else leaves
-    exactly the lines Go would read. Line comments are stepped over rather than blanked, so a `/*`
-    written inside one does not open a span.
+    Go strips a UTF-8 byte order mark only when it is the first code point in the file, and only
+    one of them, before it looks for a build constraint. So `EF BB BF` above a `//go:build ignore`
+    line leaves a constraint Go honours, and `go list` reports the file in `IgnoredGoFiles`.
+    Reading the bytes as they sit left the line beginning with U+FEFF, which no `//` match
+    reaches, and the gate credited registrations Go never compiles.
+
+    The mark is removed as a character, not as a line, so every line number below it is the one
+    Go, an editor and this gate's complaints all name.
+
+    A second mark, or one anywhere below the first character, is left in place, which is what Go
+    does: the line then does not begin with `//`, no constraint is read, and the parser reports
+    `illegal byte order mark` for the one that is not at the start.
+
+    Bytes that are not UTF-8 are replaced rather than raised on. A UTF-16 mark, and every other
+    leading byte Go rejects instead of stripping, leaves a line Go reads no constraint from, and
+    the gate agrees with that by reading the file rather than by crashing on it.
     """
-    out = list(text)
-    i = 0
-    while i < len(text):
-        if text.startswith('//', i):
-            j = text.find('\n', i)
-            i = len(text) if j == -1 else j
-            continue
-        if text.startswith('/*', i):
-            j = text.find('*/', i + 2)
-            j = len(text) if j == -1 else j + 2
-            for k in range(i, j):
-                if out[k] != '\n':
-                    out[k] = ' '
-            i = j
-            continue
-        i += 1
-    return ''.join(out)
+    with open(path, 'rb') as fh:
+        text = fh.read().decode('utf-8', 'replace')
+    if text.startswith(GO_BYTE_ORDER_MARK):
+        text = text[len(GO_BYTE_ORDER_MARK):]
+    return text
+
+
+def go_header_constraint_lines(lines):
+    """The 1-based numbers of the lines this gate refuses as a build constraint.
+
+    Transcribed from `go/build`'s `parseFileHeader`. Go walks the file from the top tracking
+    whether it is inside a `/* */` comment, and stops at the first text that is neither a comment
+    nor blank — the package clause, in a proof file. A constraint is taken only from a `//` line
+    comment outside a block comment, which is why the same text quoted inside a leading `/* */`
+    note is content, and why `/* note */ //go:build ignore` written on one line is content too:
+    the line does not begin with the directive, and Go never revisits it. Text below the package
+    clause, most often a line inside a raw string, is never reached at all.
+
+    Which trimmed lines are refused is `go_style_build_comment`: Go's `//go:build` rule exactly,
+    and every `+build` spelling by this gate's own decision.
+    """
+    numbers = []
+    in_block_comment = False
+    for number, source in enumerate(lines, 1):
+        line = source.strip(GO_SPACE)
+        if not in_block_comment and go_style_build_comment(line):
+            numbers.append(number)
+        while line:
+            if in_block_comment:
+                end = line.find('*/')
+                if end < 0:
+                    break
+                in_block_comment = False
+                line = line[end + 2:].strip(GO_SPACE)
+                continue
+            if line.startswith('//'):
+                break
+            if line.startswith('/*'):
+                in_block_comment = True
+                line = line[2:].strip(GO_SPACE)
+                continue
+            return numbers
+    return numbers
 
 
 def proof_run_arguments(match):
@@ -745,8 +828,11 @@ def scan_proof_file(path):
     Python's own line splitting is wider, ending a line at a form feed, a vertical tab and
     several more, so a header comment holding one of them was read as two lines: the tail became
     a build constraint the file does not carry, and every line number after it was off by one.
+
+    The source arrives from `go_source`, which removes a leading byte order mark as Go does, so
+    line 1 reads the same to this gate as it does to the compiler and every line number holds.
     """
-    src = read(path)
+    src = go_source(path)
     raw = src.split('\n')
     code = strip_go_comments_and_literals(src).split('\n')
     defined = set()
@@ -796,33 +882,17 @@ def scan_proof_file(path):
                 "  %s:%d runs a proof outside the shape this gate reads, so its build argument "
                 "cannot be checked; %s" % (path, index + 1, REGISTRATION_SHAPE))
 
-    # The build constraint is read from the raw source, because blanking has already removed it
-    # from the scrubbed copy. A constrained file decides outside itself whether it compiles, so
-    # the gate would otherwise credit registrations Go never builds.
+    # The build constraint is read from the raw source, because the scrubbed copy has already had
+    # its comments blanked. A constrained file decides outside itself whether it compiles, so the
+    # gate would otherwise credit registrations Go never builds.
     #
-    # Only the header is read, because that is the only place Go reads one: a constraint is taken
-    # from the lines before the package clause, so the same text lower down is ordinary content,
-    # most often a line inside a raw string. Scanning the whole file on raw lines refused proofs Go
-    # builds happily. The blanked copy locates the package clause at no cost, since every header
-    # comment is already whitespace there, which leaves the first line carrying anything at all as
-    # the first line of real code.
-    #
-    # Within the header, only `//` line comments are read, because those are the only ones Go takes
-    # a constraint from. Reading every raw header line refused a file whose leading `/* */` licence
-    # or design note happened to quote `//go:build`, which Go builds and `go list` reports as
-    # unconstrained.
-    header_end = len(raw)
-    for index, line in enumerate(code):
-        if line.strip():
-            header_end = index
-            break
-    header_lines = blank_block_comments('\n'.join(raw[:header_end])).split('\n')
-    for number, line in enumerate(header_lines, 1):
-        if GO_BUILD_CONSTRAINT.match(line):
-            complaints.append(
-                "  %s:%d carries a build constraint, so whether Go ever compiles these "
-                "registrations is decided outside the file; a proof file needs no build "
-                "constraint, so remove it" % (path, number))
+    # Which lines those are, and where the walk stops, is `go_header_constraint_lines`, which
+    # follows `go/build` rather than approximating it.
+    for number in go_header_constraint_lines(raw):
+        complaints.append(
+            "  %s:%d carries a build constraint, so whether Go ever compiles these "
+            "registrations is decided outside the file; a proof file needs no build "
+            "constraint, so remove it" % (path, number))
 
     return defined, registrations, complaints
 

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -527,6 +527,13 @@ def go_ignores_file(name, goos=None, goarch=None):
     return None
 
 
+# The whitespace `go/build` trims off a header line, and nothing else. This set is for the
+# textual pass Go makes over a file's header before the compiler scans anything, so it is the
+# right one in `go_header_constraint_lines` and `PLUS_BUILD_DIRECTIVE` and the wrong one anywhere
+# a Go token is being read: it holds U+000B, U+000C, U+0085, U+00A0 and the Unicode space
+# separators, every one of which Go's scanner refuses outright. `GO_DECLARATION_INDENT` below is
+# the set for separating tokens on a line.
+#
 # Go trims every header line with `bytes.TrimSpace`, which uses `unicode.IsSpace`, before it looks
 # at the line at all. Python's `\s` is nearly that set but also counts U+001C to U+001F, which Go
 # does not, so a header opening with one of those reads to Python as an indented comment and to Go
@@ -606,7 +613,84 @@ def go_style_build_comment(line):
 # Which pattern uses this is a decision per pattern rather than a blanket widening. The two lines
 # that carry the declared registration shape — `TEST_HEADER` and `BLOCK_END` — stay anchored at
 # column 1 on purpose, and each says so at its own site.
+#
+# The same set separates one token from the next, which is the other job it has here. Go's scanner
+# makes no distinction between the run of whitespace in front of `func` and the run between `func`
+# and the name, so every gap in every pattern below is this set and never Python's `\s`. `GO_SPACE`
+# above is a different set for a different job and would be wrong in either position.
 GO_DECLARATION_INDENT = ' \t\r'
+
+
+def go_word_exclusion_ranges():
+    """Code point ranges Python's `\\w` matches that Go's identifier rule refuses.
+
+    `\\w` is exactly the alphanumeric characters plus `_`, and Go's rule is a Unicode letter or `_`
+    to start, then letters, Unicode decimal digits or `_`. Go's two halves are `str.isalpha` (the
+    letter categories) and `str.isdecimal` (the decimal digits), so what `\\w` has and Go does not
+    is what is alphanumeric to Python and neither of those — the numeral-like characters such as
+    U+00B2, U+00BD and U+2160, which Go reports as `invalid character U+00B2 in identifier` and
+    `go test` reports as `illegal character U+00B2`.
+
+    The set is derived rather than typed out, for the reason `PROOF_RUN_PACKAGES` gives about the
+    run table: a list of code points copied into Python is a fact about Unicode that nothing keeps
+    honest. `test_check_compile.py` holds the derived classes against the Go toolchain's own
+    tables, so a release that moved the boundary fails there.
+    """
+    ranges = []
+    for code in range(sys.maxunicode + 1):
+        character = chr(code)
+        if not character.isalnum() or character.isalpha() or character.isdecimal():
+            continue
+        if ranges and ranges[-1][1] == code - 1:
+            ranges[-1][1] = code
+        else:
+            ranges.append([code, code])
+    return [(first, last) for first, last in ranges]
+
+
+def character_class_body(ranges):
+    """Those ranges as the inside of a character class, every code point written as an escape."""
+    def escaped(code):
+        return '\\u%04x' % code if code <= 0xFFFF else '\\U%08x' % code
+    return ''.join(
+        escaped(first) if first == last else '%s-%s' % (escaped(first), escaped(last))
+        for first, last in ranges)
+
+
+GO_WORD_EXCLUSION = character_class_body(go_word_exclusion_ranges())
+
+# Go's identifier rule as two classes: `\w` with the numerals Go refuses taken out, and without
+# the decimal digits as well for the first rune, since a Go identifier cannot open with one. Go
+# identifiers do include Unicode letters, so `stepPrüfung` is a name a proof may declare and these
+# classes read it.
+GO_IDENTIFIER_START = '[^\\W\\d%s]' % GO_WORD_EXCLUSION
+GO_IDENTIFIER_PART = '[^\\W%s]' % GO_WORD_EXCLUSION
+GO_IDENTIFIER = '%s%s*' % (GO_IDENTIFIER_START, GO_IDENTIFIER_PART)
+
+# The pieces every pattern that reads Go source is written from, so no pattern below spells a
+# character class of its own:
+#
+#   sp, sp1     a run of token separation, optional and required — `GO_DECLARATION_INDENT`
+#   part        one rune a Go identifier may carry after its first
+#   name        a whole Go identifier
+#   qualified   a Go name, optionally package qualified: `proofkit3d.RequireSolid`
+#   left        the left edge of a Go token: the rune before it is not one an identifier carries
+#
+# `left` is a lookbehind rather than `\b` because `\b` is defined by Python's `\w`, so a
+# neighbouring U+00B2 counts to Python as part of a word and to Go does not, and the match is
+# suppressed. That is the one place on this path where Python's class is too narrow rather than
+# too wide, and a match suppressed there silences a diagnostic instead of over-accepting.
+GO_TOKENS = {
+    'sp': '[%s]*' % re.escape(GO_DECLARATION_INDENT),
+    'sp1': '[%s]+' % re.escape(GO_DECLARATION_INDENT),
+    'part': GO_IDENTIFIER_PART,
+    'name': GO_IDENTIFIER,
+    'qualified': '%s(?:\\.%s)*' % (GO_IDENTIFIER, GO_IDENTIFIER),
+    'left': '(?<!%s)' % GO_IDENTIFIER_PART,
+}
+
+# The run of separation between two tokens, for stripping it out of a captured qualifier.
+GO_TOKEN_SEPARATION = re.compile('%(sp1)s' % GO_TOKENS)
 
 # A step is read only from a function declaration. Go would also accept `var stepFoo = func(...)`,
 # and that form is deliberately not recognised: the drafting contract in
@@ -621,7 +705,7 @@ GO_DECLARATION_INDENT = ' \t\r'
 # function — a complaint that sends the reader to a proof where the step is already written as a
 # function, and hides the whitespace that is the real difference.
 STEP_DEFINITION = re.compile(
-    r'^[%s]*func\s+(step[A-Z]\w*)\s*[\[(]' % re.escape(GO_DECLARATION_INDENT))
+    r'^%(sp)sfunc%(sp1)s(step[A-Z]%(part)s*)%(sp)s[\[(]' % GO_TOKENS)
 
 # The header is anchored at column 1, and that is a decision rather than an oversight. It is the
 # first of the three lines of the registration shape `.claude/skills/compile-gear/SKILL.md` states
@@ -631,7 +715,9 @@ STEP_DEFINITION = re.compile(
 # intended. It is also loud rather than silent: `TEST_FUNCTION` below reads the indented header and
 # names it as the header problem, at its own line, instead of leaving the run beneath it to be
 # blamed.
-TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)\s*\{\s*$')
+TEST_HEADER = re.compile(
+    r'^func%(sp1)s(Test[A-Z]%(part)s*)%(sp)s\(%(sp)s%(name)s%(sp1)s\*testing\.T%(sp)s\)'
+    r'%(sp)s\{%(sp)s$' % GO_TOKENS)
 
 # `go test` runs any function named `Test` followed by a rune that is not a lowercase letter, and
 # it does not care how the testing package is spelled, so `Test_Foo`, `Test1x` and a header written
@@ -645,7 +731,7 @@ TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)
 # diagnostic exists for; while it was anchored too, the diagnostic went silent for exactly that
 # file and the complaint fell back to the run beneath it.
 TEST_FUNCTION = re.compile(
-    r'^[%s]*func\s+(Test\w*)\s*\(' % re.escape(GO_DECLARATION_INDENT))
+    r'^%(sp)sfunc%(sp1)s(Test%(part)s*)%(sp)s\(' % GO_TOKENS)
 
 TEST_HEADER_SHAPE = ('a proof Test is headed `func Test<Title>(t *testing.T) {`, with the testing '
                      'package named in full')
@@ -687,7 +773,7 @@ PROOF_RUN_PACKAGES = ('proofkit', 'proofkit3d')
 # as a call no harness package declares, sending the reader to the proof for a defect in the
 # harness.
 GO_RUN_DECLARATION = re.compile(
-    r'^[%s]*func\s+(Run\w*)\s*\(' % re.escape(GO_DECLARATION_INDENT), re.M)
+    r'^%(sp)sfunc%(sp1)s(Run%(part)s*)%(sp)s\(' % GO_TOKENS, re.M)
 
 
 def go_balanced_span(text, start):
@@ -796,9 +882,18 @@ def go_name_alternation(names):
 # rather than following Go, and the refusal is intended. It is loud: the three lines are reported
 # as a run written outside the shape, and the shape quoted in that complaint names all three of
 # them.
-BLOCK_END = re.compile(r'^\}\s*$')
+BLOCK_END = re.compile(r'^\}%(sp)s$' % GO_TOKENS)
 
-STEP_NAME = re.compile(r'step[A-Z]\w*')
+# The build argument a registration passed, tested against the step naming rule. It is read from
+# Go source and so follows Go's identifier rule.
+STEP_NAME = re.compile(r'step[A-Z]%(part)s*' % GO_TOKENS)
+
+# The step names one step's Markdown body claims. The subject is prose, but what the token names
+# is a Go identifier compared against the names read from the proof sources, so it follows Go's
+# rule too: a name Go cannot have is a name no proof can declare, and reading a wider one compares
+# a name that cannot exist against a set that cannot hold it. Both sides used Python's `\w`, which
+# agreed with itself and credited a step in a proof `go test` refuses.
+STEP_NAME_CLAIM = re.compile(r'%(left)s(step[A-Z]%(part)s*)' % GO_TOKENS)
 
 REGISTRATION_SHAPE = ('a registration is three lines and nothing else: '
                       '`func Test<Title>(t *testing.T) {`, one proof run whose third argument is '
@@ -1006,13 +1101,15 @@ def harness_source(path):
 
 def proof_run_shape(arguments):
     """The registration shape, over the run methods the harness packages declare."""
+    method = '|'.join(
+        '%s%s\\.%s(?:%s)' % (re.escape(package), GO_TOKENS['sp'], GO_TOKENS['sp'],
+                             go_name_alternation(names))
+        for package, names in sorted(run_methods_by_package(arguments).items(),
+                                     key=lambda item: (-len(item[0]), item[0])))
     return re.compile(
-        r'^\s*(%s)\s*\('
-        r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$'
-        % '|'.join(
-            r'%s\s*\.\s*(?:%s)' % (re.escape(package), go_name_alternation(names))
-            for package, names in sorted(run_methods_by_package(arguments).items(),
-                                         key=lambda item: (-len(item[0]), item[0]))))
+        r'^%(sp)s(%(method)s)%(sp)s\('
+        r'%(sp)s%(qualified)s%(sp)s,%(sp)s%(qualified)s%(sp)s,%(sp)s(%(name)s)'
+        r'%(sp)s((?:,%(sp)s%(qualified)s%(sp)s)*)\)%(sp)s$' % dict(GO_TOKENS, method=method))
 
 
 ProofRunShapes = collections.namedtuple('ProofRunShapes', 'arguments shape')
@@ -1059,18 +1156,26 @@ def proof_run_shapes():
 # `proofkit3d.RunTypa` are both seen, and both are reported as the undeclared method Go calls
 # `undefined`.
 #
-# The `Run\w*` boundary is what keeps the ordinary harness calls in a step body silent, and it
-# rests on a fact about the harness rather than on a rule Go enforces: no exported harness helper
-# other than the run methods has a name starting with `Run`. A test in `test_check_compile.py`
-# holds that fact against the harness sources, so a helper named `Run…` fails there rather than
-# turning every call to it into a false complaint here.
+# The `Run` prefix is what keeps the ordinary harness calls in a step body silent, and it rests on
+# a fact about the harness rather than on a rule Go enforces: no exported harness helper other
+# than the run methods has a name starting with `Run`. A test in `test_check_compile.py` holds
+# that fact against the harness sources, so a helper named `Run…` fails there rather than turning
+# every call to it into a false complaint here.
+#
+# What follows that prefix is read under Go's identifier rule, like every other name here: the
+# width this pattern needs is the `Run` prefix and the package alternation, not a wider class. The
+# left edge is `left` from `GO_TOKENS` rather than `\b`, and this is the site that reason was
+# written for. `\b` is defined by Python's `\w`, so a character in front of the package name that
+# Python counts as part of a word and Go does not suppressed the whole mention, and with it the
+# only complaint that names an undeclared method.
 PROOF_RUN_MENTION = re.compile(
-    r'\b(%s)\s*\.\s*(Run\w*)\s*\(' % go_name_alternation(PROOF_RUN_PACKAGES))
+    r'%(left)s(%(packages)s)%(sp)s\.%(sp)s(Run%(part)s*)%(sp)s\('
+    % dict(GO_TOKENS, packages=go_name_alternation(PROOF_RUN_PACKAGES)))
 
 
 def proof_run_arguments(match):
     """Return a matched proof run's method name and the number of arguments it passes."""
-    method = re.sub(r'\s+', '', match.group(1))
+    method = GO_TOKEN_SEPARATION.sub('', match.group(1))
     return method, 3 + match.group(3).count(',')
 
 
@@ -1296,7 +1401,7 @@ def main(argv):
     problems.extend(registration_problems)
     claimed = set()
     for sid, tag, body in steps:
-        named = set(re.findall(r'\b(step[A-Z]\w*)\b', body))
+        named = set(STEP_NAME_CLAIM.findall(body))
         if tag == 'GO' and not named:
             problems.append("  %s is tagged [GO] but names no proof function" % sid)
         for fn in named:

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -403,8 +403,9 @@ def strip_go_comments_and_literals(src):
 #
 # with `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
 # `proofkit.Run`, and an assertion argument after the build where the run takes one. The build
-# argument is always the third. The Test's title and the step's title are the same word, which is
-# what lets a step list claim a function by name alone.
+# argument is always the third, and the run passes exactly the arguments its own method declares,
+# no more and no fewer. The Test's title and the step's title are the same word, which is what
+# lets a step list claim a function by name alone.
 #
 # What this buys is that the gate never has to decide what a brace means. What it costs is that a
 # run written any other way is refused rather than read. That is the safe direction: a refusal
@@ -428,9 +429,22 @@ TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)
 # `proofkit` defines only `Run`, and the `Solid` and `WithGate` variants belong to `proofkit3d`
 # alone. Letting the namespace and the suffix vary independently would credit a registration built
 # on `proofkit.RunSolid`, which no package defines and Go cannot compile.
+#
+# The argument count is tied to the method for the same reason. A tail of any length accepted a
+# three-argument `proofkit3d.RunWithGate` and a five-argument `proofkit.Run`, neither of which Go
+# compiles, so the shape read a step as registered by a call that never builds. The counts below
+# are the declared signatures: `proofkit.Run` takes the harness, the case table and the build;
+# every `proofkit3d` run adds the assertion, and `RunWithGate` the gate before it.
+PROOF_RUN_ARGUMENTS = {
+    'proofkit.Run': 3,
+    'proofkit3d.Run': 4,
+    'proofkit3d.RunSolid': 4,
+    'proofkit3d.RunWithGate': 5,
+}
+
 PROOF_RUN = re.compile(
-    r'^\s*(?:proofkit\s*\.\s*Run|proofkit3d\s*\.\s*Run(?:Solid|WithGate)?)\s*\('
-    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*(?:,\s*[\w.]+\s*)*\)\s*$')
+    r'^\s*(proofkit\s*\.\s*Run|proofkit3d\s*\.\s*Run(?:Solid|WithGate)?)\s*\('
+    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$')
 
 # The mention pattern stays deliberately wider than the shape above: it is what turns a run the
 # shape refuses into a named complaint. A line calling `proofkit.RunSolid` has to be seen here, or
@@ -443,7 +457,41 @@ STEP_NAME = re.compile(r'step[A-Z]\w*')
 
 REGISTRATION_SHAPE = ('a registration is three lines and nothing else: '
                       '`func Test<Title>(t *testing.T) {`, one proof run whose third argument is '
-                      '`step<Title>`, then `}`')
+                      '`step<Title>` and which passes exactly the arguments its method declares, '
+                      'then `}`')
+
+
+def blank_block_comments(text):
+    """Blank `/* */` spans, leaving line comments alone.
+
+    Go reads a build constraint only from a `//` line comment, so constraint text inside a block
+    comment above the package clause is prose. Blanking the block comments and nothing else leaves
+    exactly the lines Go would read. Line comments are stepped over rather than blanked, so a `/*`
+    written inside one does not open a span.
+    """
+    out = list(text)
+    i = 0
+    while i < len(text):
+        if text.startswith('//', i):
+            j = text.find('\n', i)
+            i = len(text) if j == -1 else j
+            continue
+        if text.startswith('/*', i):
+            j = text.find('*/', i + 2)
+            j = len(text) if j == -1 else j + 2
+            for k in range(i, j):
+                if out[k] != '\n':
+                    out[k] = ' '
+            i = j
+            continue
+        i += 1
+    return ''.join(out)
+
+
+def proof_run_arguments(match):
+    """Return a matched proof run's method name and the number of arguments it passes."""
+    method = re.sub(r'\s+', '', match.group(1))
+    return method, 3 + match.group(3).count(',')
 
 
 def scan_proof_file(path):
@@ -451,7 +499,8 @@ def scan_proof_file(path):
 
     A registration comes back as (line number, Test name, build argument) so a complaint can say
     where to go. Complaints here are the ones only this file can see: a build constraint in the
-    file header, and a proof run written outside the registration shape.
+    file header, a proof run written outside the registration shape, and a run whose argument
+    count is not the one its method declares.
     """
     src = read(path)
     raw = src.splitlines()
@@ -459,7 +508,7 @@ def scan_proof_file(path):
     defined = set()
     registrations = []
     complaints = []
-    run_lines = set()
+    read_runs = set()
 
     for index, line in enumerate(code):
         match = STEP_DEFINITION.match(line)
@@ -472,11 +521,22 @@ def scan_proof_file(path):
         closed = BLOCK_END.match(code[index + 2]) if index + 2 < len(code) else None
         if not run or not closed:
             continue
-        run_lines.add(index + 1)
-        registrations.append((index + 2, header.group(1), run.group(1)))
+        method, passed = proof_run_arguments(run)
+        declared = PROOF_RUN_ARGUMENTS[method]
+        # A run on the right method with the wrong count is named as that, rather than left to the
+        # mention loop below, because "outside the shape" would send the drafter looking at the
+        # three lines instead of at the one argument that is missing or spare.
+        read_runs.add(index + 1)
+        if passed != declared:
+            complaints.append(
+                "  %s:%d passes %d arguments to %s, which takes %d, so Go cannot compile this "
+                "registration; pass exactly the arguments the method declares"
+                % (path, index + 2, passed, method, declared))
+            continue
+        registrations.append((index + 2, header.group(1), run.group(2)))
 
     for index, line in enumerate(code):
-        if PROOF_RUN_MENTION.search(line) and index not in run_lines:
+        if PROOF_RUN_MENTION.search(line) and index not in read_runs:
             complaints.append(
                 "  %s:%d runs a proof outside the shape this gate reads, so its build argument "
                 "cannot be checked; %s" % (path, index + 1, REGISTRATION_SHAPE))
@@ -491,12 +551,18 @@ def scan_proof_file(path):
     # builds happily. The blanked copy locates the package clause at no cost, since every header
     # comment is already whitespace there, which leaves the first line carrying anything at all as
     # the first line of real code.
+    #
+    # Within the header, only `//` line comments are read, because those are the only ones Go takes
+    # a constraint from. Reading every raw header line refused a file whose leading `/* */` licence
+    # or design note happened to quote `//go:build`, which Go builds and `go list` reports as
+    # unconstrained.
     header_end = len(raw)
     for index, line in enumerate(code):
         if line.strip():
             header_end = index
             break
-    for number, line in enumerate(raw[:header_end], 1):
+    header_lines = blank_block_comments('\n'.join(raw[:header_end])).splitlines()
+    for number, line in enumerate(header_lines, 1):
         if GO_BUILD_CONSTRAINT.match(line):
             complaints.append(
                 "  %s:%d carries a build constraint, so whether Go ever compiles these "

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -41,11 +41,13 @@ Run from the repo root. Exit 0 = OK, 1 = BLOCKING, 2 = something is missing.
 """
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, os.pardir))
 sys.path.insert(0, HERE)
 import fusion_api  # noqa: E402  (sibling module; sys.path is fixed up just above)
 from call_parser import call_shapes  # noqa: E402
@@ -401,8 +403,9 @@ def strip_go_comments_and_literals(src):
 #             proofkit.Run(t, <cases>, step<Title>)
 #     }
 #
-# with `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
-# `proofkit.Run`, and an assertion argument after the build where the run takes one. The build
+# with any run method `proof/proofkit/` or `proof/proofkit3d/` declares in place of `proofkit.Run`,
+# and an assertion argument after the build where the run takes one. The methods and their
+# argument counts are read from those two packages, so this comment does not list them. The build
 # argument is always the third, and the run passes exactly the arguments its own method declares,
 # no more and no fewer. The Test's title and the step's title are the same word, which is what
 # lets a step list claim a function by name alone.
@@ -417,39 +420,275 @@ def strip_go_comments_and_literals(src):
 # or a raw string is not mistaken for a real one. Blanking preserves newlines, so a line number in
 # a complaint is a line number in the file.
 
-GO_BUILD_CONSTRAINT = re.compile(r'^\s*//\s*(?:go:build|\+build)\b')
+# Which files Go puts in a package is decided by their names alone, and by two rules nothing in
+# the file itself shows. A basename starting with `_` or `.` is invisible to `go/build`: it lands
+# in neither `TestGoFiles` nor `IgnoredGoFiles`, and `go test` reports the package as having no
+# test files. A basename whose trailing `_`-separated words name a GOOS, a GOARCH, or a GOOS and a
+# GOARCH, with a `_test` word stripped first, carries a build constraint and is compiled only
+# where those match.
+#
+# The gate needs both, because a proof file Go never builds cannot register anything, and reading
+# `_test.go` off the end of a name credits steps whose tests never run. The name lists and the
+# matching order below are transcribed from `go/build`'s `syslist.go` and `goodOSArchFile`.
+GO_KNOWN_OS = frozenset((
+    'aix', 'android', 'darwin', 'dragonfly', 'freebsd', 'hurd', 'illumos', 'ios', 'js', 'linux',
+    'nacl', 'netbsd', 'openbsd', 'plan9', 'solaris', 'wasip1', 'windows', 'zos',
+))
 
+GO_KNOWN_ARCH = frozenset((
+    '386', 'amd64', 'amd64p32', 'arm', 'armbe', 'arm64', 'arm64be', 'loong64', 'mips', 'mipsle',
+    'mips64', 'mips64le', 'mips64p32', 'mips64p32le', 'ppc', 'ppc64', 'ppc64le', 'riscv',
+    'riscv64', 's390', 's390x', 'sparc', 'sparc64', 'wasm',
+))
+
+# Go's name for the machine this checker runs on. `go env` would answer directly, but running the
+# toolchain is out of scope here, so the two identifiers are translated from Python's own. Only
+# the platforms this repo is built on need an entry; anything else falls back to the Python name
+# with a trailing release number dropped, which is already Go's spelling for the BSDs.
+GOOS_BY_SYS_PLATFORM = {
+    'aix': 'aix', 'cygwin': 'windows', 'darwin': 'darwin', 'linux': 'linux', 'sunos': 'solaris',
+    'win32': 'windows',
+}
+
+GOARCH_BY_MACHINE = {
+    '386': '386', 'aarch64': 'arm64', 'amd64': 'amd64', 'arm': 'arm', 'arm64': 'arm64',
+    'armv6l': 'arm', 'armv7l': 'arm', 'i386': '386', 'i686': '386', 'loongarch64': 'loong64',
+    'mips': 'mips', 'mips64': 'mips64', 'mips64le': 'mips64le', 'mipsel': 'mipsle',
+    'ppc64': 'ppc64', 'ppc64le': 'ppc64le', 'riscv64': 'riscv64', 's390x': 's390x',
+    'sparc64': 'sparc64', 'x86': '386', 'x86_64': 'amd64',
+}
+
+
+def current_goos():
+    """Go's name for this operating system."""
+    name = sys.platform
+    if name in GOOS_BY_SYS_PLATFORM:
+        return GOOS_BY_SYS_PLATFORM[name]
+    return name.rstrip('0123456789')
+
+
+def current_goarch():
+    """Go's name for this processor architecture."""
+    machine = platform.machine().lower()
+    return GOARCH_BY_MACHINE.get(machine, machine)
+
+
+GOOS = current_goos()
+GOARCH = current_goarch()
+
+
+def go_platform_tag_matches(tag, goos, goarch):
+    """Whether one GOOS or GOARCH filename suffix is satisfied here.
+
+    The three aliases are Go's own: an `android` build also takes `linux` files, `illumos` takes
+    `solaris`, and `ios` takes `darwin`.
+    """
+    if tag in (goos, goarch):
+        return True
+    return (goos, tag) in (('android', 'linux'), ('illumos', 'solaris'), ('ios', 'darwin'))
+
+
+def go_ignores_file(name, goos=None, goarch=None):
+    """Why Go never compiles this basename here, or None when it does.
+
+    `unix` is a build tag and never a filename suffix, the name match is case-sensitive, and a
+    basename that is only a GOOS with nothing before it carries no constraint at all, because Go
+    reads the suffix from the first `_` onwards. All three follow from `goodOSArchFile` and all
+    three are names Go compiles.
+    """
+    goos = GOOS if goos is None else goos
+    goarch = GOARCH if goarch is None else goarch
+    if name.startswith('_') or name.startswith('.'):
+        return "a basename starting with `%s` is invisible to the Go build" % name[0]
+    stem = name.split('.', 1)[0]
+    cut = stem.find('_')
+    if cut < 0:
+        return None
+    words = stem[cut:].split('_')
+    if words[-1] == 'test':
+        words = words[:-1]
+    if len(words) >= 2 and words[-2] in GO_KNOWN_OS and words[-1] in GO_KNOWN_ARCH:
+        if (go_platform_tag_matches(words[-2], goos, goarch)
+                and go_platform_tag_matches(words[-1], goos, goarch)):
+            return None
+        return ("a `_%s_%s` suffix builds only on %s/%s, and this is %s/%s"
+                % (words[-2], words[-1], words[-2], words[-1], goos, goarch))
+    if words and (words[-1] in GO_KNOWN_OS or words[-1] in GO_KNOWN_ARCH):
+        if go_platform_tag_matches(words[-1], goos, goarch):
+            return None
+        return ("a `_%s` suffix builds only where GOOS or GOARCH is %s, and this is %s/%s"
+                % (words[-1], words[-1], goos, goarch))
+    return None
+
+
+# Go's two constraint forms differ in what may sit between the slashes and the directive, and the
+# gate has to differ with them or it refuses comments Go compiles. `//go:build` is recognised only
+# with no space after the slashes, so `// go:build is discussed here` is ordinary prose and its
+# file is built. The legacy `+build` form does allow the space, and every spelling of it is
+# honoured.
+GO_BUILD_CONSTRAINT = re.compile(r'^\s*//(?:go:build\b|\s*\+build\b)')
+
+# A step is read only from a function declaration. Go would also accept `var stepFoo = func(...)`,
+# and that form is deliberately not recognised: the drafting contract in
+# `.claude/skills/compile-gear/SKILL.md` is one function per step, and a gate that reads both forms
+# has two shapes to keep right instead of one. What the refusal must not do is call a
+# variable-bound step undefined, so the complaint says the step has to be declared as a function.
 STEP_DEFINITION = re.compile(r'^func\s+(step[A-Z]\w*)\s*[\[(]')
 
 TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)\s*\{\s*$')
 
+# `go test` runs any function named `Test` followed by a rune that is not a lowercase letter, and
+# it does not care how the testing package is spelled, so `Test_Foo`, `Test1x` and a header written
+# against an aliased import all run. The header shape above is narrower on purpose. This wider
+# pattern exists so a Test that Go runs but this gate cannot read is named as the header problem it
+# is: the run inside such a Test is often perfectly formed, and reporting the run would send the
+# drafter to the wrong line.
+TEST_FUNCTION = re.compile(r'^func\s+(Test\w*)\s*\(')
+
+TEST_HEADER_SHAPE = ('a proof Test is headed `func Test<Title>(t *testing.T) {`, with the testing '
+                     'package named in full')
+
+
+def go_runs_test(name):
+    """Whether `go test` would run a function of this name.
+
+    Go's rule is `Test` followed by a rune that is not a lowercase letter, with bare `Test`
+    allowed. Transcribed from the `testing` package's own `isTest`.
+    """
+    if not name.startswith('Test'):
+        return False
+    rest = name[len('Test'):]
+    return not rest or not rest[0].islower()
+
+
 # The build slot is a bare name, because it has to be `step<Title>` for a step to claim it. Every
 # other argument may be qualified, so a gate like `proofkit3d.RequireSolid` reads as one argument.
-# The suffix is tied to its namespace, because the four run methods are the four that exist:
-# `proofkit` defines only `Run`, and the `Solid` and `WithGate` variants belong to `proofkit3d`
-# alone. Letting the namespace and the suffix vary independently would credit a registration built
-# on `proofkit.RunSolid`, which no package defines and Go cannot compile.
+# The suffix is tied to its namespace, because the run methods that exist are the ones the two
+# harness packages declare: `proofkit` declares only `Run`, and the `Solid` and `WithGate` variants
+# belong to `proofkit3d` alone. Letting the namespace and the suffix vary independently would
+# credit a registration built on `proofkit.RunSolid`, which no package defines and Go cannot
+# compile.
 #
 # The argument count is tied to the method for the same reason. A tail of any length accepted a
 # three-argument `proofkit3d.RunWithGate` and a five-argument `proofkit.Run`, neither of which Go
-# compiles, so the shape read a step as registered by a call that never builds. The counts below
-# are the declared signatures: `proofkit.Run` takes the harness, the case table and the build;
-# every `proofkit3d` run adds the assertion, and `RunWithGate` the gate before it.
-PROOF_RUN_ARGUMENTS = {
-    'proofkit.Run': 3,
-    'proofkit3d.Run': 4,
-    'proofkit3d.RunSolid': 4,
-    'proofkit3d.RunWithGate': 5,
-}
+# compiles, so the shape read a step as registered by a call that never builds.
+#
+# Neither the method names nor the counts are written out here. They are derived from the harness
+# sources below, because a table typed into Python is a copy of a Go fact that nothing keeps
+# honest: a new run method, or a changed signature, would leave it wrong with every test still
+# green. Reading the `.go` files as text adds no toolchain dependency.
+PROOF_RUN_PACKAGES = ('proofkit', 'proofkit3d')
+
+GO_RUN_DECLARATION = re.compile(r'^func\s+(Run\w*)\s*\(', re.M)
+
+
+def go_balanced_span(text, start):
+    """The text between the bracket at `start` and its match, or None when unbalanced."""
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] in '([{':
+            depth += 1
+        elif text[index] in ')]}':
+            depth -= 1
+            if depth == 0:
+                return text[start + 1:index]
+    return None
+
+
+def go_parameter_count(parameters):
+    """The number of parameters one Go parameter list declares.
+
+    Go lets parameters share a type, so `a, b Case` is two parameters and the count is of
+    top-level commas. A comma nested inside brackets belongs to a type — a func type's own list,
+    a composite literal, a generic instantiation — and is not one of them.
+    """
+    if not parameters.strip():
+        return 0
+    depth = 0
+    commas = 0
+    for character in parameters:
+        if character in '([{':
+            depth += 1
+        elif character in ')]}':
+            depth -= 1
+        elif character == ',' and depth == 0:
+            commas += 1
+    return commas + 1
+
+
+def go_run_arities(package, path):
+    """Map `<package>.<Run…>` to its declared parameter count, for one harness source file.
+
+    Comments and literals are blanked first, so a signature quoted in a doc comment is not read
+    as a declaration.
+    """
+    table = {}
+    code = strip_go_comments_and_literals(read(path))
+    for match in GO_RUN_DECLARATION.finditer(code):
+        parameters = go_balanced_span(code, match.end() - 1)
+        if parameters is None:
+            continue
+        table['%s.%s' % (package, match.group(1))] = go_parameter_count(parameters)
+    return table
+
+
+def derive_proof_run_arguments():
+    """Every run method the harness packages declare, with the arguments each one takes."""
+    table = {}
+    for package in PROOF_RUN_PACKAGES:
+        directory = os.path.join(REPO_ROOT, 'proof', package)
+        if not os.path.isdir(directory):
+            continue
+        for entry in sorted(os.listdir(directory)):
+            path = os.path.join(directory, entry)
+            if not entry.endswith('.go') or entry.endswith('_test.go'):
+                continue
+            if not os.path.isfile(path):
+                continue
+            table.update(go_run_arities(package, path))
+    if not table:
+        raise RuntimeError(
+            'check_compile: no proof run methods found under %s; the registration shape is '
+            'derived from those packages and cannot be built without them'
+            % ', '.join(os.path.join('proof', name) for name in PROOF_RUN_PACKAGES))
+    return table
+
+
+def run_methods_by_package(methods):
+    """Group derived `<package>.<Run…>` names by the package that declares each one."""
+    grouped = {}
+    for qualified in methods:
+        package, name = qualified.split('.', 1)
+        grouped.setdefault(package, set()).add(name)
+    return grouped
+
+
+def go_name_alternation(names):
+    """A regex alternation over names, longest first so `RunSolid` is never cut short to `Run`."""
+    return '|'.join(re.escape(name) for name in sorted(names, key=lambda name: (-len(name), name)))
+
+
+PROOF_RUN_ARGUMENTS = derive_proof_run_arguments()
+
+PROOF_RUN_METHODS_BY_PACKAGE = run_methods_by_package(PROOF_RUN_ARGUMENTS)
 
 PROOF_RUN = re.compile(
-    r'^\s*(proofkit\s*\.\s*Run|proofkit3d\s*\.\s*Run(?:Solid|WithGate)?)\s*\('
-    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$')
+    r'^\s*(%s)\s*\('
+    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$'
+    % '|'.join(
+        r'%s\s*\.\s*(?:%s)' % (re.escape(package), go_name_alternation(names))
+        for package, names in sorted(PROOF_RUN_METHODS_BY_PACKAGE.items(),
+                                     key=lambda item: (-len(item[0]), item[0]))))
 
 # The mention pattern stays deliberately wider than the shape above: it is what turns a run the
-# shape refuses into a named complaint. A line calling `proofkit.RunSolid` has to be seen here, or
-# a registration on a method that does not exist would pass by going unnoticed instead of failing.
-PROOF_RUN_MENTION = re.compile(r'\bproofkit(?:3d)?\s*\.\s*Run(?:Solid|WithGate)?\s*\(')
+# shape refuses into a named complaint. It pairs every harness package with every run name either
+# package declares, so a line calling `proofkit.RunSolid` is seen here; otherwise a registration on
+# a method that does not exist would pass by going unnoticed instead of failing.
+PROOF_RUN_MENTION = re.compile(
+    r'\b(?:%s)\s*\.\s*(?:%s)\s*\('
+    % (go_name_alternation(PROOF_RUN_METHODS_BY_PACKAGE.keys()),
+       go_name_alternation({name for names in PROOF_RUN_METHODS_BY_PACKAGE.values()
+                            for name in names})))
 
 BLOCK_END = re.compile(r'^\}\s*$')
 
@@ -499,12 +738,17 @@ def scan_proof_file(path):
 
     A registration comes back as (line number, Test name, build argument) so a complaint can say
     where to go. Complaints here are the ones only this file can see: a build constraint in the
-    file header, a proof run written outside the registration shape, and a run whose argument
-    count is not the one its method declares.
+    file header, a Test header Go runs but this gate cannot read, a proof run written outside the
+    registration shape, and a run whose argument count is not the one its method declares.
+
+    Lines are cut at `\n` and nowhere else, because that is the only line ending Go recognises.
+    Python's own line splitting is wider, ending a line at a form feed, a vertical tab and
+    several more, so a header comment holding one of them was read as two lines: the tail became
+    a build constraint the file does not carry, and every line number after it was off by one.
     """
     src = read(path)
-    raw = src.splitlines()
-    code = strip_go_comments_and_literals(src).splitlines()
+    raw = src.split('\n')
+    code = strip_go_comments_and_literals(src).split('\n')
     defined = set()
     registrations = []
     complaints = []
@@ -516,6 +760,17 @@ def scan_proof_file(path):
             defined.add(match.group(1))
         header = TEST_HEADER.match(line)
         if not header:
+            named = TEST_FUNCTION.match(line)
+            if named and go_runs_test(named.group(1)):
+                complaints.append(
+                    "  %s:%d heads %s in a shape this gate does not read, so the registration "
+                    "under it cannot be checked; %s"
+                    % (path, index + 1, named.group(1), TEST_HEADER_SHAPE))
+                # The run under such a header is usually well formed, and the header is what did
+                # not match, so the run is not also reported as being off the registration shape.
+                if (index + 2 < len(code) and PROOF_RUN.match(code[index + 1])
+                        and BLOCK_END.match(code[index + 2])):
+                    read_runs.add(index + 1)
             continue
         run = PROOF_RUN.match(code[index + 1]) if index + 1 < len(code) else None
         closed = BLOCK_END.match(code[index + 2]) if index + 2 < len(code) else None
@@ -561,7 +816,7 @@ def scan_proof_file(path):
         if line.strip():
             header_end = index
             break
-    header_lines = blank_block_comments('\n'.join(raw[:header_end])).splitlines()
+    header_lines = blank_block_comments('\n'.join(raw[:header_end])).split('\n')
     for number, line in enumerate(header_lines, 1):
         if GO_BUILD_CONSTRAINT.match(line):
             complaints.append(
@@ -589,6 +844,16 @@ def proof_registrations(proof_dir):
         if not entry.endswith('.go'):
             continue
         path = os.path.join(proof_dir, entry)
+        # A directory may be named `*.go`. Go builds the package around it without complaint, and
+        # reading it as a file raises, so it is passed over the way Go passes over it.
+        if not os.path.isfile(path):
+            continue
+        unbuilt = go_ignores_file(entry)
+        if unbuilt is not None:
+            complaints.append(
+                "  %s is never compiled by Go, because %s, so nothing it registers is ever built; "
+                "rename it" % (path, unbuilt))
+            continue
         found, registrations, file_complaints = scan_proof_file(path)
         defined |= found
         complaints.extend(file_complaints)
@@ -660,8 +925,10 @@ def main(argv):
             problems.append("  %s is tagged [GO] but names no proof function" % sid)
         for fn in named:
             if fn not in functions:
-                problems.append("  %s names proof function %s, which %s/ does not define"
-                                % (sid, fn, proof_dir))
+                problems.append(
+                    "  %s names proof function %s, which %s/ does not declare as a function; "
+                    "write `func %s(...)`, since a step bound to a variable is not read"
+                    % (sid, fn, proof_dir, fn))
             elif fn not in registered:
                 problems.append("  %s names proof function %s, which Test%s does not build with; "
                                 "%s" % (sid, fn, fn[len('step'):], REGISTRATION_SHAPE))

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -38,8 +38,9 @@ Four checks gate, and one is reported:
 Usage:
     python3 check_compile.py <gear>            # e.g. spurgear
 
-Run from the repo root. Exit 0 = OK, 1 = BLOCKING, 2 = something is missing.
+Run from the repo root. Exit 0 = OK, 1 = BLOCKING, 2 = an input is missing or unreadable.
 """
+import collections
 import json
 import os
 import platform
@@ -625,7 +626,33 @@ def go_runs_test(name):
 # green. Reading the `.go` files as text adds no toolchain dependency.
 PROOF_RUN_PACKAGES = ('proofkit', 'proofkit3d')
 
-GO_RUN_DECLARATION = re.compile(r'^func\s+(Run\w*)\s*\(', re.M)
+# The declaration is read wherever it starts on its line, because Go's layout is free and nothing
+# here holds the harness to `gofmt`: `proof/run.sh` runs only `go work init/edit` and
+# `go test ./...`, and neither `.github/workflows/3d-proof.yml` nor `sketch-bench.yml` has a
+# gofmt, vet or lint step. Anchoring at column 1 meant one stray tab in front of `func RunSolid`
+# lost the method while `go build` and `go vet` stayed at exit 0, and every sound registration on
+# it was then reported as a call no harness package declares, sending the reader to the proof for
+# a defect in the harness.
+#
+# Allowing the indentation stays exact rather than becoming a guess. Go does not permit a named
+# function declaration inside a function body — an indented `func RunInner(x int) {}` there is
+# `syntax error: unexpected name RunInner, expected (` — so `func` followed by a name can only be
+# a package-level declaration, whatever column it sits in. A function literal has no name, so a
+# `func(` opening a continuation line never matches. A method is `func (r *T) Run…`, whose
+# parenthesis follows `func` directly, and the name required here already excludes it. Comments
+# and string literals are blanked to spaces by `strip_go_comments_and_literals` before this scan,
+# so a `func` quoted in either cannot match.
+#
+# The indentation set is Go's rather than Python's `\s`. Go's scanner skips space, tab, carriage
+# return and newline between tokens and nothing else, and a file indented with anything wider is
+# one Go refuses outright: a leading U+00A0 is `invalid character U+00A0 in identifier`, U+000B is
+# `invalid character U+000B`, U+000C is `illegal character U+000C`. Reading those would derive a
+# method from a file that never compiles, which is what every rule on this path exists to stop.
+# Newline is left out because a line is what this anchors to.
+GO_DECLARATION_INDENT = ' \t\r'
+
+GO_RUN_DECLARATION = re.compile(
+    r'^[%s]*func\s+(Run\w*)\s*\(' % re.escape(GO_DECLARATION_INDENT), re.M)
 
 
 def go_balanced_span(text, start):
@@ -936,26 +963,60 @@ def harness_source(path):
     return text
 
 
-PROOF_RUN_ARGUMENTS = derive_proof_run_arguments()
+def proof_run_shape(arguments):
+    """The registration shape, over the run methods the harness packages declare."""
+    return re.compile(
+        r'^\s*(%s)\s*\('
+        r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$'
+        % '|'.join(
+            r'%s\s*\.\s*(?:%s)' % (re.escape(package), go_name_alternation(names))
+            for package, names in sorted(run_methods_by_package(arguments).items(),
+                                         key=lambda item: (-len(item[0]), item[0]))))
 
-PROOF_RUN_METHODS_BY_PACKAGE = run_methods_by_package(PROOF_RUN_ARGUMENTS)
 
-PROOF_RUN = re.compile(
-    r'^\s*(%s)\s*\('
-    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$'
-    % '|'.join(
-        r'%s\s*\.\s*(?:%s)' % (re.escape(package), go_name_alternation(names))
-        for package, names in sorted(PROOF_RUN_METHODS_BY_PACKAGE.items(),
-                                     key=lambda item: (-len(item[0]), item[0]))))
+ProofRunShapes = collections.namedtuple('ProofRunShapes', 'arguments shape')
 
-# The mention pattern stays deliberately wider than the shape above. It is what turns a run the
-# shape refuses into a named complaint, and it is the only thing that sees a run on a method no
-# harness package declares — a name outside the derived set cannot appear in the shape above, so a
+_PROOF_RUN_SHAPES = None
+
+
+# The harness read happens on first use, not at import. Running it at import ran it before `main`
+# existed, so every raise from the derivation — a harness carrying a build constraint, one holding
+# a NUL byte, one `open()` cannot read, both harness directories gone — killed the command with an
+# uncaught traceback at exit 1. Exit 1 is this checker's code for findings in the artifact under
+# review, and the harness is not that artifact; a missing or broken input is exit 2, which `main`
+# already uses for a usage error, a missing step list, a step list with no steps and an
+# unavailable API database. Importing without reading anything also gives the usage check back:
+# with a broken harness in the tree, running the script with no arguments printed a traceback
+# instead of the usage line.
+#
+# One read per process is the whole answer, because the derived table is a pure function of the
+# on-disk harness sources and nothing mutates them between import and `main`.
+def proof_run_shapes():
+    """The derived run table and the registration shape built from it, read once per process.
+
+    Raises `RuntimeError` for a harness Go will not read and `OSError` for one this process
+    cannot open. `main` catches both and reports them as the broken input they are, so no caller
+    below needs to; every use site here is already downstream of that check.
+    """
+    global _PROOF_RUN_SHAPES
+    if _PROOF_RUN_SHAPES is None:
+        arguments = derive_proof_run_arguments()
+        _PROOF_RUN_SHAPES = ProofRunShapes(arguments, proof_run_shape(arguments))
+    return _PROOF_RUN_SHAPES
+
+
+# The mention pattern is built here rather than inside the accessor above, because it is not
+# derived and reads no file: both halves are literal, the package names written above and any
+# `Run`-prefixed name at all.
+#
+# That width is deliberate, and it is what makes the pattern useful. It turns a run the shape
+# refuses into a named complaint, and it is the only thing that sees a run on a method no harness
+# package declares — a name outside the derived set cannot appear in the shape above, so a
 # pattern built from that set alone is blind to exactly the call it exists to catch.
 #
-# So it pairs each harness package with any `Run`-prefixed name at all. `proofkit.RunSolid`, a
-# pairing neither package declares, and a plain misspelling such as `proofkit3d.RunTypa` are both
-# seen, and both are reported as the undeclared method Go calls `undefined`.
+# So `proofkit.RunSolid`, a pairing neither package declares, and a plain misspelling such as
+# `proofkit3d.RunTypa` are both seen, and both are reported as the undeclared method Go calls
+# `undefined`.
 #
 # The `Run\w*` boundary is what keeps the ordinary harness calls in a step body silent, and it
 # rests on a fact about the harness rather than on a rule Go enforces: no exported harness helper
@@ -994,6 +1055,10 @@ def scan_proof_file(path):
     src, refused = go_source(path)
     if refused is not None:
         return set(), [], [refused]
+    # The harness read is already done and cached by the time any proof file is scanned: `main`
+    # calls the accessor behind its own guard, so a broken harness is exit 2 there rather than a
+    # raise from the middle of a scan.
+    runs = proof_run_shapes()
     raw = src.split('\n')
     code = strip_go_comments_and_literals(src).split('\n')
     defined = set()
@@ -1015,16 +1080,16 @@ def scan_proof_file(path):
                     % (path, index + 1, named.group(1), TEST_HEADER_SHAPE))
                 # The run under such a header is usually well formed, and the header is what did
                 # not match, so the run is not also reported as being off the registration shape.
-                if (index + 2 < len(code) and PROOF_RUN.match(code[index + 1])
+                if (index + 2 < len(code) and runs.shape.match(code[index + 1])
                         and BLOCK_END.match(code[index + 2])):
                     read_runs.add(index + 1)
             continue
-        run = PROOF_RUN.match(code[index + 1]) if index + 1 < len(code) else None
+        run = runs.shape.match(code[index + 1]) if index + 1 < len(code) else None
         closed = BLOCK_END.match(code[index + 2]) if index + 2 < len(code) else None
         if not run or not closed:
             continue
         method, passed = proof_run_arguments(run)
-        declared = PROOF_RUN_ARGUMENTS[method]
+        declared = runs.arguments[method]
         # A run on the right method with the wrong count is named as that, rather than left to the
         # mention loop below, because "outside the shape" would send the drafter looking at the
         # three lines instead of at the one argument that is missing or spare.
@@ -1047,7 +1112,7 @@ def scan_proof_file(path):
         off_shape = False
         for mention in PROOF_RUN_MENTION.finditer(line):
             method = '%s.%s' % (mention.group(1), mention.group(2))
-            if method in PROOF_RUN_ARGUMENTS:
+            if method in runs.arguments:
                 off_shape = off_shape or index not in read_runs
             elif method not in undeclared:
                 undeclared.append(method)
@@ -1055,7 +1120,7 @@ def scan_proof_file(path):
             complaints.append(
                 "  %s:%d calls %s, which no harness package declares, so Go cannot compile "
                 "this proof; the run methods are %s"
-                % (path, index + 1, method, ', '.join(sorted(PROOF_RUN_ARGUMENTS))))
+                % (path, index + 1, method, ', '.join(sorted(runs.arguments))))
         if off_shape:
             complaints.append(
                 "  %s:%d runs a proof outside the shape this gate reads, so its build argument "
@@ -1142,6 +1207,27 @@ def main(argv):
     steps = steps_of(src)
     if not steps:
         print('check_compile: %s declares no steps' % steps_path, file=sys.stderr)
+        return 2
+
+    # The harness is an input to this run, not part of the artifact under review, so a harness the
+    # gate cannot read is reported here at exit 2 alongside the other broken inputs rather than
+    # counted as a finding at exit 1. Reading it up front also makes the exit code deterministic: the
+    # accessor caches, so every scan below sees the same table and none of them can raise.
+    #
+    # `RuntimeError` carries the derivation's own message, which already names the file, the line
+    # and what Go says about it, so it is printed as it stands. `OSError` comes from the operating
+    # system — `chmod 000` on a harness source raises `PermissionError` from `open()` — and says
+    # nothing about why this checker was reading the file, so it is named here.
+    try:
+        proof_run_shapes()
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print('check_compile: the harness sources under %s cannot be read, so the run methods a '
+              'registration is checked against cannot be derived: %s'
+              % (', '.join(os.path.join('proof', name) for name in PROOF_RUN_PACKAGES), exc),
+              file=sys.stderr)
         return 2
 
     problems = []

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -17,7 +17,8 @@ Four checks gate, and one is reported:
      does not name is a proof no step can reach. The registration is written in one fixed shape
      the gate matches by line ("Registration is read by SHAPE" below says why and states it); a
      run written any other way is reported rather than read, because an unread build argument is
-     an unchecked one.
+     an unchecked one. A call to a run method the harness does not declare is reported wherever it
+     is written, registration or not, because Go calls that `undefined` wherever it sits.
   3. API CALLS ARE REAL. Every Fusion call the step list names exists in the API database the
      `fusion` plugin ships. Catches a spec that names a method Fusion does not have.
   4. INPUTS HAVE NOT DRIFTED. The provenance table contains and matches the existing instructions,
@@ -664,11 +665,14 @@ def go_parameter_count(parameters):
 def go_run_arities(package, path):
     """Map `<package>.<Run…>` to its declared parameter count, for one harness source file.
 
+    The text comes from `harness_source`, so a file Go will not read, or one whose header decides
+    outside the file whether Go compiles it, is a named error rather than a silent contribution.
+
     Comments and literals are blanked first, so a signature quoted in a doc comment is not read
     as a declaration.
     """
     table = {}
-    code = strip_go_comments_and_literals(read(path))
+    code = strip_go_comments_and_literals(harness_source(path))
     for match in GO_RUN_DECLARATION.finditer(code):
         parameters = go_balanced_span(code, match.end() - 1)
         if parameters is None:
@@ -677,11 +681,20 @@ def go_run_arities(package, path):
     return table
 
 
-def derive_proof_run_arguments():
-    """Every run method the harness packages declare, with the arguments each one takes."""
+def derive_proof_run_arguments(root=REPO_ROOT):
+    """Every run method the harness packages declare, with the arguments each one takes.
+
+    The harness sources are held to the same Go rules as the proof files, because the derived set
+    is only as true as the reading it comes from: a file read here but not compiled by Go invents
+    a method that does not exist, and a file compiled by Go but not read here loses one that does.
+    `harness_source` states which rule is a skip, which is a named error, and why each is which.
+
+    `root` is the tree the harness is read from. The default is the repository this checker ships
+    in; a test passes its own so these rules can be exercised on fixtures.
+    """
     table = {}
     for package in PROOF_RUN_PACKAGES:
-        directory = os.path.join(REPO_ROOT, 'proof', package)
+        directory = os.path.join(root, 'proof', package)
         if not os.path.isdir(directory):
             continue
         for entry in sorted(os.listdir(directory)):
@@ -689,6 +702,8 @@ def derive_proof_run_arguments():
             if not entry.endswith('.go') or entry.endswith('_test.go'):
                 continue
             if not os.path.isfile(path):
+                continue
+            if go_ignores_file(entry) is not None:
                 continue
             table.update(go_run_arities(package, path))
     if not table:
@@ -712,28 +727,6 @@ def go_name_alternation(names):
     """A regex alternation over names, longest first so `RunSolid` is never cut short to `Run`."""
     return '|'.join(re.escape(name) for name in sorted(names, key=lambda name: (-len(name), name)))
 
-
-PROOF_RUN_ARGUMENTS = derive_proof_run_arguments()
-
-PROOF_RUN_METHODS_BY_PACKAGE = run_methods_by_package(PROOF_RUN_ARGUMENTS)
-
-PROOF_RUN = re.compile(
-    r'^\s*(%s)\s*\('
-    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$'
-    % '|'.join(
-        r'%s\s*\.\s*(?:%s)' % (re.escape(package), go_name_alternation(names))
-        for package, names in sorted(PROOF_RUN_METHODS_BY_PACKAGE.items(),
-                                     key=lambda item: (-len(item[0]), item[0]))))
-
-# The mention pattern stays deliberately wider than the shape above: it is what turns a run the
-# shape refuses into a named complaint. It pairs every harness package with every run name either
-# package declares, so a line calling `proofkit.RunSolid` is seen here; otherwise a registration on
-# a method that does not exist would pass by going unnoticed instead of failing.
-PROOF_RUN_MENTION = re.compile(
-    r'\b(?:%s)\s*\.\s*(?:%s)\s*\('
-    % (go_name_alternation(PROOF_RUN_METHODS_BY_PACKAGE.keys()),
-       go_name_alternation({name for names in PROOF_RUN_METHODS_BY_PACKAGE.values()
-                            for name in names})))
 
 BLOCK_END = re.compile(r'^\}\s*$')
 
@@ -900,6 +893,79 @@ def go_header_constraint_lines(lines):
     return numbers
 
 
+# The harness is read under Go's rules too, and which rule is a skip and which is an error is
+# decided here rather than by whichever reader was nearest.
+#
+# Go's filename rule carries over unchanged, and a file it excludes is skipped exactly as Go skips
+# it. The name is the whole reason, it is visible in a directory listing, and the method really
+# does not exist here: `go vet` answers a call to one with `undefined: proofkit.RunWindows`, which
+# is what the undeclared-method complaint below says at the call site.
+#
+# A build constraint is the opposite case and is a named error rather than a skip. Whether Go
+# compiles a constrained file is settled outside the file, so the derived set would depend on
+# where this gate runs. Skipping such a file would drop a method Go does build under a satisfied
+# constraint — `//go:build linux` read on a linux builder — and every sound registration on that
+# method would then be complained about as a call the harness does not declare, sending the reader
+# to the proof for a defect that is in the harness. So the harness carries no build constraint at
+# all, and a file that carries one is named as the harness problem it is.
+#
+# `go_header_constraint_lines` is the detector for that, and the breadth that makes it wrong for a
+# skip is what makes it right here: it refuses every `+build` spelling as well as the `//go:build`
+# ones Go reads, which is over-refusal against Go and is exactly the rule "no constraint in any
+# spelling". On this path it must stay a detector and never become a skip.
+def harness_source(path):
+    """One harness source's text, or a named error saying why no run method can be read from it.
+
+    Unlike the proof-file readers, this raises. A proof file the gate cannot read is one drafted
+    artifact among many and becomes a complaint about that file, while a harness the gate cannot
+    read leaves every registration in every proof checked against a run table that is missing
+    methods Go has — a wrong answer everywhere rather than a complaint in one place.
+    """
+    text, refused = go_source(path)
+    if refused is not None:
+        raise RuntimeError(
+            'check_compile: the harness source %s is one Go will not read, so the run methods it '
+            'declares cannot be derived: %s' % (path, refused.strip()))
+    numbers = go_header_constraint_lines(text.split('\n'))
+    if numbers:
+        raise RuntimeError(
+            'check_compile: %s:%d carries a build constraint, so which run methods the harness '
+            'declares would be decided outside the file and would depend on where this gate runs; '
+            'a harness source must carry no build constraint, so remove it'
+            % (path, numbers[0]))
+    return text
+
+
+PROOF_RUN_ARGUMENTS = derive_proof_run_arguments()
+
+PROOF_RUN_METHODS_BY_PACKAGE = run_methods_by_package(PROOF_RUN_ARGUMENTS)
+
+PROOF_RUN = re.compile(
+    r'^\s*(%s)\s*\('
+    r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*((?:,\s*[\w.]+\s*)*)\)\s*$'
+    % '|'.join(
+        r'%s\s*\.\s*(?:%s)' % (re.escape(package), go_name_alternation(names))
+        for package, names in sorted(PROOF_RUN_METHODS_BY_PACKAGE.items(),
+                                     key=lambda item: (-len(item[0]), item[0]))))
+
+# The mention pattern stays deliberately wider than the shape above. It is what turns a run the
+# shape refuses into a named complaint, and it is the only thing that sees a run on a method no
+# harness package declares — a name outside the derived set cannot appear in the shape above, so a
+# pattern built from that set alone is blind to exactly the call it exists to catch.
+#
+# So it pairs each harness package with any `Run`-prefixed name at all. `proofkit.RunSolid`, a
+# pairing neither package declares, and a plain misspelling such as `proofkit3d.RunTypa` are both
+# seen, and both are reported as the undeclared method Go calls `undefined`.
+#
+# The `Run\w*` boundary is what keeps the ordinary harness calls in a step body silent, and it
+# rests on a fact about the harness rather than on a rule Go enforces: no exported harness helper
+# other than the run methods has a name starting with `Run`. A test in `test_check_compile.py`
+# holds that fact against the harness sources, so a helper named `Run…` fails there rather than
+# turning every call to it into a false complaint here.
+PROOF_RUN_MENTION = re.compile(
+    r'\b(%s)\s*\.\s*(Run\w*)\s*\(' % go_name_alternation(PROOF_RUN_PACKAGES))
+
+
 def proof_run_arguments(match):
     """Return a matched proof run's method name and the number of arguments it passes."""
     method = re.sub(r'\s+', '', match.group(1))
@@ -912,7 +978,8 @@ def scan_proof_file(path):
     A registration comes back as (line number, Test name, build argument) so a complaint can say
     where to go. Complaints here are the ones only this file can see: a build constraint in the
     file header, a Test header Go runs but this gate cannot read, a proof run written outside the
-    registration shape, and a run whose argument count is not the one its method declares.
+    registration shape, a run whose argument count is not the one its method declares, and a call
+    to a run method no harness package declares.
 
     Lines are cut at `\n` and nowhere else, because that is the only line ending Go recognises.
     Python's own line splitting is wider, ending a line at a form feed, a vertical tab and
@@ -970,8 +1037,26 @@ def scan_proof_file(path):
             continue
         registrations.append((index + 2, header.group(1), run.group(2)))
 
+    # A run on a method the harness does not declare is named as that, wherever it is written. It
+    # is not the same defect as a run off the shape: the shape complaint sends the drafter to the
+    # three lines, and here the three lines may be perfect while the method does not exist. Inside
+    # a registration the two coincide, and the undeclared method is the one reported, because it
+    # is the one Go fails on.
     for index, line in enumerate(code):
-        if PROOF_RUN_MENTION.search(line) and index not in read_runs:
+        undeclared = []
+        off_shape = False
+        for mention in PROOF_RUN_MENTION.finditer(line):
+            method = '%s.%s' % (mention.group(1), mention.group(2))
+            if method in PROOF_RUN_ARGUMENTS:
+                off_shape = off_shape or index not in read_runs
+            elif method not in undeclared:
+                undeclared.append(method)
+        for method in undeclared:
+            complaints.append(
+                "  %s:%d calls %s, which no harness package declares, so Go cannot compile "
+                "this proof; the run methods are %s"
+                % (path, index + 1, method, ', '.join(sorted(PROOF_RUN_ARGUMENTS))))
+        if off_shape:
             complaints.append(
                 "  %s:%d runs a proof outside the shape this gate reads, so its build argument "
                 "cannot be checked; %s" % (path, index + 1, REGISTRATION_SHAPE))

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -424,10 +424,17 @@ TEST_HEADER = re.compile(r'^func\s+(Test[A-Z]\w*)\s*\(\s*\w+\s+\*testing\.T\s*\)
 
 # The build slot is a bare name, because it has to be `step<Title>` for a step to claim it. Every
 # other argument may be qualified, so a gate like `proofkit3d.RequireSolid` reads as one argument.
+# The suffix is tied to its namespace, because the four run methods are the four that exist:
+# `proofkit` defines only `Run`, and the `Solid` and `WithGate` variants belong to `proofkit3d`
+# alone. Letting the namespace and the suffix vary independently would credit a registration built
+# on `proofkit.RunSolid`, which no package defines and Go cannot compile.
 PROOF_RUN = re.compile(
-    r'^\s*proofkit(?:3d)?\s*\.\s*Run(?:Solid|WithGate)?\s*\('
+    r'^\s*(?:proofkit\s*\.\s*Run|proofkit3d\s*\.\s*Run(?:Solid|WithGate)?)\s*\('
     r'\s*[\w.]+\s*,\s*[\w.]+\s*,\s*(\w+)\s*(?:,\s*[\w.]+\s*)*\)\s*$')
 
+# The mention pattern stays deliberately wider than the shape above: it is what turns a run the
+# shape refuses into a named complaint. A line calling `proofkit.RunSolid` has to be seen here, or
+# a registration on a method that does not exist would pass by going unnoticed instead of failing.
 PROOF_RUN_MENTION = re.compile(r'\bproofkit(?:3d)?\s*\.\s*Run(?:Solid|WithGate)?\s*\(')
 
 BLOCK_END = re.compile(r'^\}\s*$')
@@ -443,8 +450,8 @@ def scan_proof_file(path):
     """Return one proof file's step definitions, registrations and complaints.
 
     A registration comes back as (line number, Test name, build argument) so a complaint can say
-    where to go. Complaints here are the ones only this file can see: a build constraint, and a
-    proof run written outside the registration shape.
+    where to go. Complaints here are the ones only this file can see: a build constraint in the
+    file header, and a proof run written outside the registration shape.
     """
     src = read(path)
     raw = src.splitlines()
@@ -477,7 +484,19 @@ def scan_proof_file(path):
     # The build constraint is read from the raw source, because blanking has already removed it
     # from the scrubbed copy. A constrained file decides outside itself whether it compiles, so
     # the gate would otherwise credit registrations Go never builds.
-    for number, line in enumerate(raw, 1):
+    #
+    # Only the header is read, because that is the only place Go reads one: a constraint is taken
+    # from the lines before the package clause, so the same text lower down is ordinary content,
+    # most often a line inside a raw string. Scanning the whole file on raw lines refused proofs Go
+    # builds happily. The blanked copy locates the package clause at no cost, since every header
+    # comment is already whitespace there, which leaves the first line carrying anything at all as
+    # the first line of real code.
+    header_end = len(raw)
+    for index, line in enumerate(code):
+        if line.strip():
+            header_end = index
+            break
+    for number, line in enumerate(raw[:header_end], 1):
         if GO_BUILD_CONSTRAINT.match(line):
             complaints.append(
                 "  %s:%d carries a build constraint, so whether Go ever compiles these "

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -56,6 +56,14 @@ from call_parser import call_shapes  # noqa: E402
 
 PATH_REF = r'[\w./-]+\.(?:md|go|py|json|sh)'
 PATH_TOKEN = re.compile(r'`(%s)`' % PATH_REF)
+
+# The edges here are not symmetric, and that is left as it is. The lookbehind excludes `.`, `/`
+# and `-` while `\b` on the right excludes only word characters, so a name that continues past the
+# extension yields the `.md` prefix inside it. What that costs is one extra path in the provenance
+# input set, which is a file the table must stamp; the complaint is BLOCKING and names the file,
+# so the failure is loud. Closing it by excluding `.` on the right would drop a reference at the
+# end of a sentence, and a reference dropped from that set is a source whose edit leaves a stale
+# step list looking healthy, which is the silent direction this gate must not fail in.
 DOCUMENT_REF = re.compile(r'(?<![\w./-])[\w./-]+\.md\b')
 INLINE_CITATION = re.compile(r'`(%s):(\d+)(?:\s*[-\u2013]\s*(\d+))?`' % PATH_REF)
 LINE_RANGE = re.compile(r'\bL(\d+)(?:\s*[-\u2013]\s*(\d+))?\b')
@@ -675,11 +683,24 @@ GO_IDENTIFIER = '%s%s*' % (GO_IDENTIFIER_START, GO_IDENTIFIER_PART)
 #   name        a whole Go identifier
 #   qualified   a Go name, optionally package qualified: `proofkit3d.RequireSolid`
 #   left        the left edge of a Go token: the rune before it is not one an identifier carries
+#   no_word_left, no_word_right
+#               the edges of a token that has to stand alone: nothing Python counts as a word
+#               character touches it on that side
 #
 # `left` is a lookbehind rather than `\b` because `\b` is defined by Python's `\w`, so a
 # neighbouring U+00B2 counts to Python as part of a word and to Go does not, and the match is
 # suppressed. That is the one place on this path where Python's class is too narrow rather than
 # too wide, and a match suppressed there silences a diagnostic instead of over-accepting.
+#
+# `no_word_left` and `no_word_right` are the opposite edge rule, and they are wider than Go's own
+# on purpose. Which of the two a pattern takes follows from what its match does. `left` belongs on
+# a pattern whose match raises a complaint, where a neighbouring rune Go refuses must not silence
+# it. A pattern whose match grants credit needs the reverse: a rune Go refuses glued to the token
+# means the token as written is not a Go name at all, so the whole match has to be suppressed
+# rather than truncated to the valid prefix it starts or ends with. Python's `\w` is the class
+# that spans both the identifier runes and the ones Go refuses, so it is the edge that suppresses.
+# `STEP_NAME_CLAIM` is the only pattern here whose match grants credit, and it is the only one
+# written from this pair.
 GO_TOKENS = {
     'sp': '[%s]*' % re.escape(GO_DECLARATION_INDENT),
     'sp1': '[%s]+' % re.escape(GO_DECLARATION_INDENT),
@@ -687,6 +708,8 @@ GO_TOKENS = {
     'name': GO_IDENTIFIER,
     'qualified': '%s(?:\\.%s)*' % (GO_IDENTIFIER, GO_IDENTIFIER),
     'left': '(?<!%s)' % GO_IDENTIFIER_PART,
+    'no_word_left': '(?<!\\w)',
+    'no_word_right': '(?!\\w)',
 }
 
 # The run of separation between two tokens, for stripping it out of a captured qualifier.
@@ -889,11 +912,23 @@ BLOCK_END = re.compile(r'^\}%(sp)s$' % GO_TOKENS)
 STEP_NAME = re.compile(r'step[A-Z]%(part)s*' % GO_TOKENS)
 
 # The step names one step's Markdown body claims. The subject is prose, but what the token names
-# is a Go identifier compared against the names read from the proof sources, so it follows Go's
-# rule too: a name Go cannot have is a name no proof can declare, and reading a wider one compares
-# a name that cannot exist against a set that cannot hold it. Both sides used Python's `\w`, which
-# agreed with itself and credited a step in a proof `go test` refuses.
-STEP_NAME_CLAIM = re.compile(r'%(left)s(step[A-Z]%(part)s*)' % GO_TOKENS)
+# is a Go identifier compared against the names read from the proof sources, so the body of the
+# name follows Go's rule too: a name Go cannot have is a name no proof can declare, and reading a
+# wider one compares a name that cannot exist against a set that cannot hold it. Both sides read
+# the body with Python's `\w`, which agreed with itself and credited a step in a proof `go test`
+# refuses.
+#
+# The edges are the other pair, `no_word_left` and `no_word_right`, and this is the site that pair
+# was written for. This is the one pattern here whose match grants credit rather than raising a
+# complaint, so it is the one where a wider match is a false OK rather than a louder report. With
+# no right edge the match stopped at the first rune outside the identifier class and handed back
+# the valid prefix, so a step claiming `stepOne²` was credited to a proof declaring `stepOne` and
+# the gate printed OK; with only `left` on the other side, `²stepOne` did the same. An edge
+# symmetric with `left` does not close either hole, because U+00B2 is not an identifier rune and
+# such a lookbehind or lookahead succeeds on it. The edge has to be the wider class, so that a
+# neighbour Go refuses suppresses the claim instead of trimming it.
+STEP_NAME_CLAIM = re.compile(
+    r'%(no_word_left)s(step[A-Z]%(part)s*)%(no_word_right)s' % GO_TOKENS)
 
 REGISTRATION_SHAPE = ('a registration is three lines and nothing else: '
                       '`func Test<Title>(t *testing.T) {`, one proof run whose third argument is '
@@ -1167,7 +1202,9 @@ def proof_run_shapes():
 # left edge is `left` from `GO_TOKENS` rather than `\b`, and this is the site that reason was
 # written for. `\b` is defined by Python's `\w`, so a character in front of the package name that
 # Python counts as part of a word and Go does not suppressed the whole mention, and with it the
-# only complaint that names an undeclared method.
+# only complaint that names an undeclared method. That is the complaint-side edge rule; the
+# credit-side one is the pair `STEP_NAME_CLAIM` is written from, and the comment on `GO_TOKENS`
+# says which match takes which.
 PROOF_RUN_MENTION = re.compile(
     r'%(left)s(%(packages)s)%(sp)s\.%(sp)s(Run%(part)s*)%(sp)s\('
     % dict(GO_TOKENS, packages=go_name_alternation(PROOF_RUN_PACKAGES)))

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -4,7 +4,10 @@ import contextlib
 import importlib.util
 import inspect
 import io
+import json
 import os
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -15,6 +18,137 @@ COMPILE_CHECKER_PATH = Path(__file__).with_name('check_compile.py')
 COMPILE_MODULE_SPEC = importlib.util.spec_from_file_location('check_compile', COMPILE_CHECKER_PATH)
 COMPILE_CHECKER = importlib.util.module_from_spec(COMPILE_MODULE_SPEC)
 COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
+
+
+# Every header spelling the gate has an opinion about, with what Go does to it and what the gate
+# does about that. The whole class of defect on this boundary is the gate disagreeing with Go
+# about a spelling, so a spelling is not settled until both halves are written down and both are
+# checked: `test_go_agrees_with_every_recorded_header_verdict` runs the Go toolchain over this
+# corpus and fails if a `go` column ever stops being true, and the two gate tests below run the
+# checker over the same corpus.
+#
+# A row carries the bytes above the package clause and nothing else; the file under test is that
+# header followed by a body. The `go` column is what Go does with the header:
+#
+#   ignored             the constraint is honoured and excludes the file — `IgnoredGoFiles`
+#   invalid-constraint  the constraint is read but does not parse — `InvalidGoFiles`
+#   no-constraint       no constraint is read, whatever else Go thinks of the file
+#
+# The `gate` column is `refuse` or `accept`. They agree everywhere except the `+build` near-misses
+# grouped at the end, which are refused deliberately; `PLUS_BUILD_DIRECTIVE` in the checker states
+# why.
+BOM = b'\xef\xbb\xbf'
+
+GO_HEADER_CASES = (
+    # name, header bytes, what Go does, what the gate does
+    ('a plain constraint', b'//go:build ignore\n\n', 'ignored', 'refuse'),
+    ('a tab separator', b'//go:build\tignore\n\n', 'ignored', 'refuse'),
+    ('an indented constraint', b'   //go:build ignore\n\n', 'ignored', 'refuse'),
+    ('a tab-indented constraint', b'\t//go:build ignore\n\n', 'ignored', 'refuse'),
+    ('a constraint on the second header line', b'// note\n//go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('no blank line before the package clause', b'//go:build ignore\n', 'ignored', 'refuse'),
+    ('CRLF line endings', b'//go:build ignore\r\n\r\n', 'ignored', 'refuse'),
+    ('lone CR line endings', b'//go:build ignore\r\r', 'invalid-constraint', 'refuse'),
+    ('a bare directive', b'//go:build\n\n', 'invalid-constraint', 'refuse'),
+    ('a directive followed only by spaces', b'//go:build   \n\n',
+     'invalid-constraint', 'refuse'),
+    ('a directive followed only by a tab', b'//go:build\t\n\n', 'invalid-constraint', 'refuse'),
+    ('a byte order mark above the directive', BOM + b'//go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('a byte order mark above an indented directive', BOM + b'   //go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('a byte order mark above the legacy form', BOM + b'// +build ignore\n\n',
+     'ignored', 'refuse'),
+    # Go trims the header line with `unicode.IsSpace`, which counts a non-breaking space.
+    ('a non-breaking space before the slashes', b'\xc2\xa0//go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('a closed block comment on the line above', b'/* note */\n//go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('a closed multi-line block comment above', b'/*\nnote\n*/\n//go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('a `/*` inside a line comment above', b'// /* note\n//go:build ignore\n\n',
+     'ignored', 'refuse'),
+    ('the legacy form', b'// +build ignore\n\n', 'ignored', 'refuse'),
+    ('the legacy form with no space', b'//+build ignore\n\n', 'ignored', 'refuse'),
+    ('the legacy form with two spaces', b'//  +build ignore\n\n', 'ignored', 'refuse'),
+    ('the legacy form with a tab', b'//\t+build ignore\n\n', 'ignored', 'refuse'),
+    ('the legacy form indented', b'  // +build ignore\n\n', 'ignored', 'refuse'),
+    ('a bare legacy directive', b'// +build\n\n', 'ignored', 'refuse'),
+
+    ('a space after the slashes', b'// go:build ignore\n\n', 'no-constraint', 'accept'),
+    ('prose about the directive', b'// go:build is discussed here, not used\n\n',
+     'no-constraint', 'accept'),
+    ('two spaces after the slashes', b'//  go:build ignore\n\n', 'no-constraint', 'accept'),
+    ('a space inside the directive', b'// go: build ignore\n\n', 'no-constraint', 'accept'),
+    ('a `!` straight after the directive', b'//go:build!ignore\n\n', 'no-constraint', 'accept'),
+    ('a `/` straight after the directive', b'//go:build/ignore\n\n', 'no-constraint', 'accept'),
+    ('a word run on to the directive', b'//go:buildignore\n\n', 'no-constraint', 'accept'),
+    ('a directive quoted inside a block comment', b'/*\n\t//go:build ignore\n*/\n',
+     'no-constraint', 'accept'),
+    ('a block comment closing on the directive line', b'/* note */ //go:build ignore\n\n',
+     'no-constraint', 'accept'),
+    ('a byte order mark and no constraint', BOM, 'no-constraint', 'accept'),
+    ('two byte order marks above the directive', BOM + BOM + b'//go:build ignore\n\n',
+     'no-constraint', 'accept'),
+    ('a byte order mark below the first line', b'// note\n' + BOM + b'//go:build ignore\n\n',
+     'no-constraint', 'accept'),
+    # Leading bytes Go rejects rather than strips. None of them is whitespace to Go, so the line
+    # does not begin with `//` and no constraint is read; Go's own complaint about the byte
+    # arrives later, from the parser, and is not this gate's to make.
+    ('a UTF-16 byte order mark', b'\xff\xfe//go:build ignore\n\n', 'no-constraint', 'accept'),
+    ('a NUL byte', b'\x00//go:build ignore\n\n', 'no-constraint', 'accept'),
+    ('a zero width space', b'\xe2\x80\x8b//go:build ignore\n\n', 'no-constraint', 'accept'),
+    ('a file separator U+001C', b'\x1c//go:build ignore\n\n', 'no-constraint', 'accept'),
+
+    # Refused by decision rather than by Go's rule.
+    ('a `!` straight after the legacy directive', b'// +build!ignore\n\n',
+     'no-constraint', 'refuse'),
+    ('a `/` straight after the legacy directive', b'// +build/ignore\n\n',
+     'no-constraint', 'refuse'),
+    ('a word run on to the legacy directive', b'// +buildignore\n\n', 'no-constraint', 'refuse'),
+    ('the legacy form with no blank line after it', b'// +build ignore\n',
+     'no-constraint', 'refuse'),
+)
+
+
+def go_verdicts(headers, body=b'package p\n\nfunc F() {}\n'):
+    """Ask the Go toolchain what it does with each header, in one `go list` run.
+
+    Every header becomes its own package directory holding the header plus `body`, alongside a
+    file that carries the package on its own so a header Go excludes still leaves a package to
+    report. `go list -e` classifies a file without compiling it, which is exactly the question:
+    `IgnoredGoFiles` means a constraint excluded the file, and a `parsing //go:build line` error
+    means one was read and would not parse.
+    """
+    root = Path(tempfile.mkdtemp(prefix='go-header-'))
+    try:
+        (root / 'go.mod').write_text('module headerprobe\n\ngo 1.21\n')
+        for index, header in enumerate(headers):
+            package = root / ('c%d' % index)
+            package.mkdir()
+            (package / 'x.go').write_bytes(header + body)
+            (package / 'keep.go').write_text('package p\n\nfunc Keep() {}\n')
+        listed = subprocess.run(['go', 'list', '-e', '-json', './...'],
+                                cwd=root, capture_output=True, text=True)
+        decoder = json.JSONDecoder()
+        verdicts = {}
+        text = listed.stdout.strip()
+        offset = 0
+        while offset < len(text):
+            info, offset = decoder.raw_decode(text, offset)
+            while offset < len(text) and text[offset] in ' \t\r\n':
+                offset += 1
+            name = info['ImportPath'].rsplit('/', 1)[-1]
+            if 'x.go' in (info.get('IgnoredGoFiles') or []):
+                verdicts[name] = 'ignored'
+            elif 'parsing //go:build line' in ((info.get('Error') or {}).get('Err') or ''):
+                verdicts[name] = 'invalid-constraint'
+            else:
+                verdicts[name] = 'no-constraint'
+        return [verdicts.get('c%d' % index) for index in range(len(headers))]
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
 
 
 class CheckCompileTest(unittest.TestCase):
@@ -57,7 +191,12 @@ class CheckCompileTest(unittest.TestCase):
                 provenance = self.provenance_rows(root, paths)
             if proof_body is None:
                 proof_body = self.registration('TestOne', 'proofkit.Run', 'stepOne')
-            (root / 'proof' / 'gear' / proof_filename).write_text(proof_body)
+            # A header case may turn on bytes no `str` survives a round trip through — a byte
+            # order mark, a UTF-16 mark, a NUL — so a fixture may hand over the file as bytes.
+            if isinstance(proof_body, bytes):
+                (root / 'proof' / 'gear' / proof_filename).write_bytes(proof_body)
+            else:
+                (root / 'proof' / 'gear' / proof_filename).write_text(proof_body)
             for name in proof_directories:
                 (root / 'proof' / 'gear' / name).mkdir()
             table = '\n'.join((
@@ -432,6 +571,43 @@ class CheckCompileTest(unittest.TestCase):
             'proof/gear/proof_test.go:1 carries a build constraint, so whether Go ever compiles '
             'these registrations is decided outside the file', output)
 
+    def test_a_byte_order_mark_does_not_hide_a_constraint(self):
+        """Go strips one leading mark, so `EF BB BF` above `//go:build ignore` still excludes.
+
+        `go list` reports such a file in `IgnoredGoFiles` with no `TestGoFiles` at all. Reading
+        the bytes as they sit left line 1 beginning with U+FEFF, which no `//` match reaches, so
+        the gate credited every registration in a file Go never compiles. The mark is removed as
+        a character rather than as a line, so the constraint is still reported at line 1.
+        """
+        proof_body = b'\xef\xbb\xbf//go:build ignore\n\n' + self.PROOF_BODY
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:1 carries a build constraint', output)
+
+    def test_a_byte_order_mark_does_not_shift_the_lines_below_it(self):
+        """Removing the mark costs no line, so a constraint on line 2 is reported at line 2."""
+        proof_body = b'\xef\xbb\xbf// note\n//go:build ignore\n\n' + self.PROOF_BODY
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:2 carries a build constraint', output)
+
+    def test_a_constraint_below_a_closed_block_comment_is_reported_at_its_own_line(self):
+        """Go reads it — the block comment closed, so the directive line is a `//` line again.
+
+        `go list` reports this file in `IgnoredGoFiles`, and the complaint names line 4, which is
+        where the directive sits.
+        """
+        proof_body = b'/*\nnote\n*/\n//go:build ignore\n\n' + self.PROOF_BODY
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:4 carries a build constraint', output)
+
     def test_build_constraint_text_inside_a_raw_string_is_accepted(self):
         """Go reads a constraint only above the package clause, so lower down it is just text.
 
@@ -561,41 +737,87 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(result, 0, output)
         self.assertIn('compile check: OK', output)
 
-    # The two `//` constraint forms differ in what may sit before the directive.
+    # The build-constraint boundary, one row per spelling. `GO_HEADER_CASES` at the top of this
+    # file records what Go does with each header and what the gate does about it; these three
+    # tests are the two halves of every row and the toolchain run that keeps the `go` column
+    # honest.
+
+    PROOF_BODY = (b'package gear_test\n\n'
+                  b'func TestOne(t *testing.T) {\n'
+                  b'\tproofkit.Run(t, profileCases, stepOne)\n'
+                  b'}\n\n'
+                  b'func stepOne() {}\n')
 
     def constrained(self, header):
-        return (
-            '%s\n\n'
-            'package gear_test\n\n'
-            'func TestOne(t *testing.T) {\n'
-            '\tproofkit.Run(t, profileCases, stepOne)\n'
-            '}\n\n'
-            'func stepOne() {}\n' % header)
+        return header + self.PROOF_BODY
 
-    def test_every_spelling_go_reads_as_a_constraint_is_refused(self):
-        """`//go:build` takes no space after the slashes; the legacy form takes any."""
-        for header in ('//go:build ignore', '  //go:build ignore', '\t//go:build ignore',
-                       '// +build ignore', '//+build ignore', '//  +build ignore',
-                       '//\t+build ignore', '  // +build ignore'):
-            with self.subTest(header=header):
+    def test_every_header_go_reads_as_a_constraint_is_refused(self):
+        """Every spelling Go excludes or cannot parse fails the check, plus four by decision.
+
+        Go honours `//go:build` only with nothing between the slashes and the directive and with
+        whitespace or the end of the line after it, and honours the legacy `+build` form more
+        loosely. The four rows Go builds are refused anyway: a proof file needs no build
+        constraint in any form, so a `+build` near-miss costs one message rather than a silent
+        credit.
+        """
+        for name, header, verdict, gate in GO_HEADER_CASES:
+            if gate != 'refuse':
+                continue
+            with self.subTest(case=name, go=verdict):
                 result, output = self.run_checker(proof_body=self.constrained(header))
 
                 self.assertEqual(result, 1, output)
                 self.assertIn('carries a build constraint', output)
 
-    def test_comment_go_does_not_read_as_a_constraint_is_accepted(self):
-        """`// go:build …` is prose to Go: the file lands in `GoFiles` and its tests run.
+    def test_every_header_go_builds_as_written_is_accepted(self):
+        """Every spelling Go reads no constraint from passes, so the gate refuses no built file.
 
-        Allowing whitespace between the slashes and `go:build` refused a header comment that
-        merely discusses the directive, in a file Go builds.
+        These are the near-misses and the disguises: a space after the slashes, a `!` or a `/`
+        straight after the directive, a directive quoted inside a leading block comment, and a
+        leading byte Go rejects rather than strips. `go list` reports all of them in `GoFiles`,
+        with no constraint read, and a gate that refused any of them would be failing a proof Go
+        compiles.
         """
-        for header in ('// go:build ignore', '// go:build is discussed here, not used',
-                       '//  go:build ignore', '// go: build ignore'):
-            with self.subTest(header=header):
+        for name, header, verdict, gate in GO_HEADER_CASES:
+            if gate != 'accept':
+                continue
+            with self.subTest(case=name, go=verdict):
                 result, output = self.run_checker(proof_body=self.constrained(header))
 
                 self.assertEqual(result, 0, output)
                 self.assertIn('compile check: OK', output)
+
+    def test_a_directive_inside_an_unterminated_block_comment_is_not_a_constraint(self):
+        """The comment never closes, so Go is still inside it at the directive and reads none.
+
+        `go list` puts such a file in `GoFiles` and reports `comment not terminated`: it is
+        broken, but not by a build constraint, and saying so would send the drafter to the wrong
+        line. It sits outside `GO_HEADER_CASES` because the open comment swallows the
+        registrations too, so the check has other things to say about the file.
+        """
+        proof_body = b'/*\n//go:build ignore\n' + self.PROOF_BODY
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertNotIn('carries a build constraint', output)
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
+    def test_go_agrees_with_every_recorded_header_verdict(self):
+        """The `go` column of every row is what the toolchain actually does with that header.
+
+        The gate's rules are transcribed from `go/build`, and a transcription is only worth what
+        keeps it true. This runs `go list -e -json` over the whole corpus and reconciles it row
+        by row, so a Go release that changed the boundary, or a row written from memory, fails
+        here rather than in a proof nobody can explain.
+        """
+        headers = [header for _, header, _, _ in GO_HEADER_CASES]
+
+        observed = go_verdicts(headers)
+
+        for (name, _, verdict, _), actual in zip(GO_HEADER_CASES, observed):
+            with self.subTest(case=name):
+                self.assertEqual(actual, verdict)
 
     # Lines are cut where Go cuts them, at `\n` and nowhere else.
 

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -211,6 +212,15 @@ def go_verdicts(headers, body=b'package p\n\nfunc F() {}\n'):
         shutil.rmtree(root, ignore_errors=True)
 
 
+def foreign_goos():
+    """A GOOS this machine is not, so a `_GOOS` suffix carrying it is genuinely unsatisfied."""
+    for name in sorted(COMPILE_CHECKER.GO_KNOWN_OS):
+        if not COMPILE_CHECKER.go_platform_tag_matches(
+                name, COMPILE_CHECKER.GOOS, COMPILE_CHECKER.GOARCH):
+            return name
+    raise AssertionError('every known GOOS matches this machine')
+
+
 class CheckCompileTest(unittest.TestCase):
     SOURCE_PATHS = (
         'spec/gear/instructions.md',
@@ -356,6 +366,10 @@ class CheckCompileTest(unittest.TestCase):
         A gate that let the namespace and the suffix vary on their own credited a step whose
         registration Go cannot compile, which is the one direction a compile gate must never fail
         in.
+
+        The complaint names the method rather than the shape, because the three lines here are
+        well formed and it is the method that does not exist. Go says the same of this pairing:
+        `undefined: proofkit.RunSolid`.
         """
         proof_body = self.registration('TestOne', 'proofkit.RunSolid', 'stepOne',
                                        extra=', assertOne')
@@ -363,10 +377,63 @@ class CheckCompileTest(unittest.TestCase):
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
-        self.assertIn('proof/gear/proof_test.go:2 runs a proof outside the shape this gate reads',
-                      output)
+        self.assertIn('proof/gear/proof_test.go:2 calls proofkit.RunSolid, which no harness '
+                      'package declares', output)
         self.assertIn(
             'S1 names proof function stepOne, which TestOne does not build with', output)
+
+    def test_call_to_a_harness_method_that_does_not_exist_is_named(self):
+        """A run method that does not exist, called outside a registration, was invisible.
+
+        The mention pattern was built from the derived set, so a name outside that set could not
+        match it, and the pattern meant to catch a run written outside the accepted shape was
+        blind to exactly the case its own comment named. `go vet` reports this file
+        `undefined: proofkit3d.RunTypo`.
+
+        The same typo written inside the three-line shape was already caught indirectly, because
+        the step then goes unregistered. The hole was the call that is not itself a step's sole
+        registration.
+        """
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func helper(t *testing.T) {\n'
+            '\tproofkit3d.RunTypo(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:6 calls proofkit3d.RunTypo, which no harness '
+                      'package declares', output)
+        # The three lines are not the defect and are not reported as one.
+        self.assertEqual(output.count('proof/gear/proof_test.go:6'), 1, output)
+
+    def test_harness_calls_that_are_not_runs_stay_silent(self):
+        """The `Run` prefix is the whole boundary, so every other harness call must pass through.
+
+        These five helpers appear throughout ordinary step bodies. A pattern that reached them
+        would turn every proof in the repository into a wall of complaints about calls Go
+        compiles.
+        """
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne(t *testing.T) {\n'
+            '\tproofkit.Step(t, "one")\n'
+            '\tproofkit.Unmodelled(t, "two")\n'
+            '\tproofkit.RequireSound(t, s)\n'
+            '\tproofkit3d.RequireSolid(t, doc, bodies)\n'
+            '\tproofkit3d.BodyReport(t, doc, body)\n'
+            '}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
 
     # Each run takes the arguments its own signature declares, and no others.
 
@@ -751,14 +818,6 @@ class CheckCompileTest(unittest.TestCase):
 
     # Only files Go actually compiles are credited.
 
-    def foreign_goos(self):
-        """A GOOS this machine is not, so a `_GOOS` suffix here is genuinely unsatisfied."""
-        for name in sorted(COMPILE_CHECKER.GO_KNOWN_OS):
-            if not COMPILE_CHECKER.go_platform_tag_matches(
-                    name, COMPILE_CHECKER.GOOS, COMPILE_CHECKER.GOARCH):
-                return name
-        raise AssertionError('every known GOOS matches this machine')
-
     def test_file_go_never_compiles_is_named_not_credited(self):
         """A proof file Go drops still parsed as a proof, so its steps were credited unbuilt.
 
@@ -766,7 +825,7 @@ class CheckCompileTest(unittest.TestCase):
         suffix this machine does not satisfy lands the file in `IgnoredGoFiles`. In all three
         cases `go test` reports no test files, so nothing here registers anything.
         """
-        foreign = self.foreign_goos()
+        foreign = foreign_goos()
         for filename in ('_x_test.go', '.x_test.go', 'proof_%s_test.go' % foreign,
                          'proof_%s_amd64_test.go' % foreign):
             with self.subTest(filename=filename):
@@ -1302,6 +1361,233 @@ class ProofRunArityDerivationTest(unittest.TestCase):
                     self.assertIsNotNone(match)
                     self.assertEqual(COMPILE_CHECKER.proof_run_arguments(match),
                                      (method, declared))
+
+
+def harness_file(package, name='RunExtra'):
+    """One harness source declaring a single run method, for the named package."""
+    return b'package %s\n\nfunc %s(a, b, c int) {}\n' % (package.encode(), name.encode())
+
+
+def go_harness_verdict(name, source):
+    """What Go does with one file dropped into a package, and whether its method can be called.
+
+    Returns `(placement, callable)`. `placement` is where the file lands — `compiled` for
+    `GoFiles`, `ignored` for `IgnoredGoFiles`, `unreadable` when Go refuses its bytes — and
+    `callable` is whether another package can build against the method it declares, which is the
+    question the derived run table is answering.
+
+    The call lives in a second package on purpose. A method Go does not compile is not a
+    compilation error in the harness; it is an `undefined` at every use, which is what a proof
+    registration on it would be.
+
+    The probe package is named `proofkit` so the fixture bytes are the same ones the gate is given.
+    """
+    root = Path(tempfile.mkdtemp(prefix='go-harness-'))
+    try:
+        (root / 'go.mod').write_text('module harnessprobe\n\ngo 1.21\n')
+        (root / 'proofkit').mkdir()
+        (root / 'proofkit' / 'proofkit.go').write_bytes(harness_file('proofkit', 'Run'))
+        (root / 'proofkit' / name).write_bytes(source)
+        (root / 'user').mkdir()
+        (root / 'user' / 'user.go').write_text(
+            'package user\n\n'
+            'import "harnessprobe/proofkit"\n\n'
+            'func call() { proofkit.RunExtra(1, 2, 3) }\n')
+        built = subprocess.run(['go', 'build', './proofkit'],
+                               cwd=root, capture_output=True, text=True)
+        listed = subprocess.run(['go', 'list', '-e', '-json', './proofkit'],
+                                cwd=root, capture_output=True, text=True)
+        info = json.JSONDecoder().raw_decode(listed.stdout.strip())[0]
+        if any(message in built.stderr for message in GO_UNREADABLE_MESSAGES):
+            placement = 'unreadable'
+        elif name in (info.get('IgnoredGoFiles') or []):
+            placement = 'ignored'
+        else:
+            placement = 'compiled'
+        used = subprocess.run(['go', 'build', './user'], cwd=root, capture_output=True, text=True)
+        return placement, used.returncode == 0
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+class HarnessSourceRuleTest(unittest.TestCase):
+    """The harness sources are read under the Go rules the proof files are already held to.
+
+    Every run method the gate accepts is derived from `proof/proofkit/` and `proof/proofkit3d/`,
+    so the derivation is where a Go rule missing from the read does its damage: a file read here
+    but not compiled by Go invents a method that does not exist, and every registration on it is
+    then credited although `go vet` calls it `undefined`.
+
+    Which rule is a skip and which is a named error differs, and `HARNESS_FILE_CASES` records what
+    Go does with each input alongside what the gate does about it.
+    """
+
+    # name, file bytes below the package clause, what Go does, what the gate does.
+    #
+    #   compiled/ignored/unreadable  where Go puts the file, and `callable` below says whether the
+    #                                method it declares can be used from another package at all
+    #   read                         the gate derives the method from it
+    #   skipped                      the gate passes over the file exactly as Go does
+    #   error                        the gate raises a named error rather than deriving anything
+    @staticmethod
+    def cases():
+        goos = COMPILE_CHECKER.GOOS
+        body = harness_file('proofkit')
+        return (
+            ('an ordinary name', 'runmore.go', body, 'compiled', 'read'),
+            ('a satisfied GOOS suffix', 'run_%s.go' % goos, body, 'compiled', 'read'),
+            ('an unsatisfied GOOS suffix', 'run_%s.go' % foreign_goos(), body, 'ignored',
+             'skipped'),
+            ('an unsatisfiable constraint', 'runconstrained.go',
+             b'//go:build never\n\n' + body, 'ignored', 'error'),
+            # The row the loud option exists for. Go compiles this file here, so a gate that
+            # skipped it would drop a method that does exist and report every sound registration
+            # on it as a call the harness does not declare.
+            ('a satisfied constraint', 'runconstrained.go',
+             ('//go:build %s\n\n' % goos).encode() + body, 'compiled', 'error'),
+            ('a legacy constraint', 'runconstrained.go',
+             b'// +build never\n\n' + body, 'ignored', 'error'),
+            ('a NUL byte', 'runnul.go', body[:-1] + b'\x00\n', 'unreadable', 'error'),
+        )
+
+    def derive(self, name=None, source=None):
+        """The run table derived from a harness tree holding one extra file under `proofkit`."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for package in COMPILE_CHECKER.PROOF_RUN_PACKAGES:
+                (root / 'proof' / package).mkdir(parents=True)
+                (root / 'proof' / package / ('%s.go' % package)).write_bytes(
+                    harness_file(package, 'Run'))
+            if name is not None:
+                (root / 'proof' / 'proofkit' / name).write_bytes(source)
+            return COMPILE_CHECKER.derive_proof_run_arguments(root=str(root))
+
+    def test_the_fixture_tree_derives_what_it_declares(self):
+        """The control. Without it a derivation that read nothing would pass every case below."""
+        self.assertEqual(self.derive(), {'proofkit.Run': 3, 'proofkit3d.Run': 3})
+
+    def test_a_harness_file_go_compiles_is_read(self):
+        for name, filename, source, _, gate in self.cases():
+            if gate != 'read':
+                continue
+            with self.subTest(case=name):
+                self.assertEqual(self.derive(filename, source).get('proofkit.RunExtra'), 3)
+
+    def test_a_harness_file_go_excludes_by_name_is_not_read(self):
+        """Go decides this from the name alone, and the gate already holds proof files to it.
+
+        A `proof/proofkit/run_windows.go` declaring `RunWindows` was read on linux and its method
+        accepted in a registration, while `go list` reported the file in `IgnoredGoFiles` and
+        `go vet` reported `undefined: proofkit.RunWindows`.
+
+        Skipping is the right answer here rather than an error: the name is the whole reason, Go
+        does the same, and the method really does not exist on this machine, so a proof that calls
+        it is told so at the call.
+        """
+        for name, filename, source, _, gate in self.cases():
+            if gate != 'skipped':
+                continue
+            with self.subTest(case=name):
+                table = self.derive(filename, source)
+
+                self.assertNotIn('proofkit.RunExtra', table)
+                self.assertIn('proofkit.Run', table)
+
+    def test_a_harness_file_carrying_a_build_constraint_is_a_named_error(self):
+        """A constraint is settled outside the file, so the harness carries none in any spelling.
+
+        `//go:build never` excludes the file and `//go:build linux` on a linux builder does not,
+        and nothing in the file says which of the two the reader is holding. Skipping both would
+        drop a method Go does build and turn every sound registration on it into a complaint about
+        the proof, which is the wrong file entirely. So both are refused, loudly, naming the
+        harness file and line.
+        """
+        for name, filename, source, _, gate in self.cases():
+            if gate != 'error':
+                continue
+            if b'//go:build' not in source and b'+build' not in source:
+                continue
+            with self.subTest(case=name):
+                with self.assertRaises(RuntimeError) as raised:
+                    self.derive(filename, source)
+
+                message = str(raised.exception)
+                self.assertIn('%s:1 carries a build constraint' % filename, message)
+                self.assertIn('a harness source must carry no build constraint', message)
+
+    def test_a_harness_file_go_will_not_read_is_a_named_error(self):
+        """The byte refusals reach the harness too, and name the harness file when they bite.
+
+        A `proof/proofkit/runnul.go` holding a NUL byte was read with a plain `read()` and its
+        method accepted, while `go vet ./proofkit/` refused the file outright. Reading it through
+        `go_source`, as the proof files are read, turns it into an error that names the file, the
+        byte and what Go says about it.
+        """
+        for name, filename, source, _, gate in self.cases():
+            if gate != 'error' or b'\x00' not in source:
+                continue
+            with self.subTest(case=name):
+                with self.assertRaises(RuntimeError) as raised:
+                    self.derive(filename, source)
+
+                message = str(raised.exception)
+                self.assertIn(filename, message)
+                self.assertIn('is one Go will not read', message)
+                self.assertIn('holds a NUL byte', message)
+
+    def test_no_harness_file_is_credited_with_a_method_go_does_not_have(self):
+        """The whole class, in one line: read or refused, never quietly wrong.
+
+        A file Go does not compile must never contribute a method, whether the gate skips it or
+        errors on it.
+        """
+        for name, filename, source, placement, _ in self.cases():
+            if placement == 'compiled':
+                continue
+            with self.subTest(case=name):
+                try:
+                    table = self.derive(filename, source)
+                except RuntimeError:
+                    continue
+                self.assertNotIn('proofkit.RunExtra', table)
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
+    def test_go_agrees_with_the_recorded_harness_verdicts(self):
+        """The `go` column of every row is what the toolchain actually does with that input.
+
+        A row written from memory, or a Go release that moved the boundary, fails here rather
+        than in a harness read nobody can explain. `callable` is checked with it, because that is
+        the consequence the rows are really about: a method from a file Go does not compile is an
+        `undefined` at every use.
+        """
+        for name, filename, source, placement, _ in self.cases():
+            with self.subTest(case=name):
+                self.assertEqual(go_harness_verdict(filename, source),
+                                 (placement, placement == 'compiled'))
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes this API')
+    def test_no_exported_harness_helper_but_a_run_method_is_named_run(self):
+        """`PROOF_RUN_MENTION` reads any `Run`-prefixed name, and this is what makes that safe.
+
+        The boundary is a fact about the harness, not a rule Go enforces: were a helper called
+        `RunReport` added beside `RequireSound`, every call to it in a step body would become a
+        complaint about a method the harness does declare. `go doc` is asked rather than the
+        source, so the answer is the package's real exported API.
+        """
+        root = Path(__file__).parents[3] / 'proof'
+        for package in COMPILE_CHECKER.PROOF_RUN_PACKAGES:
+            with self.subTest(package=package):
+                listed = subprocess.run(['go', 'doc', './%s' % package],
+                                        cwd=root, capture_output=True, text=True)
+                self.assertEqual(listed.returncode, 0, listed.stderr)
+                exported = set(re.findall(r'^(?:func|type|var|const)\s+(\w+)',
+                                          listed.stdout, re.M))
+
+                self.assertEqual(
+                    {name for name in exported if name.startswith('Run')},
+                    {method.split('.', 1)[1]
+                     for method in COMPILE_CHECKER.PROOF_RUN_ARGUMENTS
+                     if method.startswith('%s.' % package)})
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -146,6 +146,26 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 0, output)
 
+    # Only the four run methods that exist are read as registrations.
+
+    def test_run_method_no_package_defines_is_refused(self):
+        """`proofkit` defines only `Run`; the two variants live in `proofkit3d` alone.
+
+        A gate that let the namespace and the suffix vary on their own credited a step whose
+        registration Go cannot compile, which is the one direction a compile gate must never fail
+        in.
+        """
+        proof_body = self.registration('TestOne', 'proofkit.RunSolid', 'stepOne',
+                                       extra=', assertOne')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:2 runs a proof outside the shape this gate reads',
+                      output)
+        self.assertIn(
+            'S1 names proof function stepOne, which TestOne does not build with', output)
+
     # The build argument must be the step of the Test's own title.
 
     def test_misnamed_build_argument_is_blocking(self):
@@ -338,6 +358,7 @@ class CheckCompileTest(unittest.TestCase):
     def test_build_constraint_is_blocking(self):
         proof_body = (
             '//go:build ignore\n\n'
+            'package gear_test\n\n'
             'func TestOne(t *testing.T) {\n'
             '\tproofkit.Run(t, profileCases, stepOne)\n'
             '}\n\n'
@@ -349,6 +370,26 @@ class CheckCompileTest(unittest.TestCase):
         self.assertIn(
             'proof/gear/proof_test.go:1 carries a build constraint, so whether Go ever compiles '
             'these registrations is decided outside the file', output)
+
+    def test_build_constraint_text_inside_a_raw_string_is_accepted(self):
+        """Go reads a constraint only above the package clause, so lower down it is just text.
+
+        Scanning every raw line refused this file, which `gofmt` and `go test` both accept.
+        """
+        proof_body = (
+            'package gear_test\n\n'
+            'var sample = `\n'
+            '//go:build ignore\n'
+            '`\n\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
 
     def test_registration_outside_a_test_file_is_blocking(self):
         result, output = self.run_checker(proof_filename='proof.go')

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1185,6 +1185,169 @@ class CheckCompileTest(unittest.TestCase):
             'write `func stepOne(...)`, since a step bound to a variable is not read', output)
         self.assertNotIn('which proof/gear/ does not define', output)
 
+    # Where a declaration may start on its line, pattern by pattern.
+    #
+    # Go's layout is free and nothing in this repository holds a proof file to `gofmt`, so every
+    # line below can arrive indented and Go still compiles it. Two of the four patterns that read
+    # such a line are widened to match Go, and two keep a column-1 anchor because their line is
+    # part of the registration shape `.claude/skills/compile-gear/SKILL.md` states to the drafter.
+    # `ProofDeclarationColumnTest` holds the Go half of each pairing; these hold the gate half, so
+    # neither decision can be reversed without a failure here.
+
+    def test_an_indented_step_definition_is_read(self):
+        """The step definition is not part of the registration shape, so it follows Go.
+
+        Go compiles an indented `func stepOne`, `go test` runs the registration built on it, and
+        the step is genuinely declared as a function. Anchored at column 1 the definition was
+        invisible and the step was reported as one the proof directory does not declare as a
+        function, which sends the reader to a proof that is already right and says nothing about
+        the whitespace that is the real difference.
+        """
+        for indent in ('\t', '    ', '\r'):
+            with self.subTest(indent=repr(indent)):
+                proof_body = (
+                    'func TestOne(t *testing.T) {\n'
+                    '\tproofkit.Run(t, profileCases, stepOne)\n'
+                    '}\n\n'
+                    '%sfunc stepOne() {}\n' % indent)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 0, output)
+                self.assertIn('compile check: OK', output)
+
+    def test_a_step_definition_behind_whitespace_go_refuses_is_not_read(self):
+        """The indentation set is Go's own, so a file Go will not compile defines nothing.
+
+        U+00A0, U+000B and U+000C are not whitespace to Go's scanner: each makes the file illegal
+        at that line, `go test` reports `illegal character U+00A0` and the package never builds.
+        Reading them would credit a step definition in a proof that never compiles, which is the
+        one direction this gate must not fail in, so Python's wider `\\s` is not used here.
+        """
+        for indent, character in (('\u00a0', 'U+00A0'), ('\x0b', 'U+000B'), ('\x0c', 'U+000C')):
+            with self.subTest(character=character):
+                proof_body = (
+                    'func TestOne(t *testing.T) {\n'
+                    '\tproofkit.Run(t, profileCases, stepOne)\n'
+                    '}\n\n'
+                    '%sfunc stepOne() {}\n' % indent)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 1, output)
+                self.assertIn('S1 names proof function stepOne, which proof/gear/ does not '
+                              'declare as a function', output)
+
+    def test_a_quoted_step_definition_is_still_not_a_definition(self):
+        """Accepting leading whitespace must not turn a `func` in a comment or a string into one.
+
+        `strip_go_comments_and_literals` blanks both to spaces before the scan, so a quoted
+        declaration leaves a line of whitespace and nothing to match. Indented or not, it is text.
+        """
+        for name, quoted in (
+                ('a block comment', '/*\n\tfunc stepTwo() {}\n*/\n'),
+                ('a line comment', '\t// func stepTwo() {}\n'),
+                ('a raw string', 'var sample = `\n\tfunc stepTwo() {}\n`\n')):
+            with self.subTest(case=name):
+                proof_body = (
+                    'func TestOne(t *testing.T) {\n'
+                    '\tproofkit.Run(t, profileCases, stepOne)\n'
+                    '}\n\n'
+                    '%s\n'
+                    'func stepOne() {}\n' % quoted)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 0, output)
+                self.assertIn('compile check: OK (1 steps, 1 proof functions', output)
+
+    def test_an_indented_test_header_is_refused_and_named_as_the_header(self):
+        """`TEST_HEADER` keeps its anchor, and `TEST_FUNCTION` makes the refusal land on it.
+
+        The three-line shape is a contract, so an indented header is refused although `go test`
+        runs it. What the refusal must not do is blame the run beneath, which is well formed; the
+        wider diagnostic pattern reads the indented header and names the header instead.
+        """
+        for indent in ('\t', '    '):
+            with self.subTest(indent=repr(indent)):
+                proof_body = (
+                    '%sfunc TestOne(t *testing.T) {\n'
+                    '\tproofkit.Run(t, profileCases, stepOne)\n'
+                    '}\n\n'
+                    'func stepOne() {}\n' % indent)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 1, output)
+                self.assertIn(
+                    'proof/gear/proof_test.go:1 heads TestOne in a shape this gate does not read, '
+                    'so the registration under it cannot be checked; a proof Test is headed '
+                    '`func Test<Title>(t *testing.T) {`, with the testing package named in full',
+                    output)
+                self.assertNotIn('runs a proof outside the shape this gate reads', output)
+
+    def test_an_indented_closing_brace_is_refused_as_a_run_off_the_shape(self):
+        """`BLOCK_END` keeps its anchor too, and the refusal quotes the shape it belongs to.
+
+        Go compiles an indented `}`, so this is the gate holding its own contract. The complaint
+        is the off-shape one, which names all three lines of the registration, and the step is
+        reported unregistered rather than quietly credited.
+        """
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '\t}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('proof/gear/proof_test.go:2 runs a proof outside the shape this gate reads',
+                      output)
+        self.assertIn('S1 names proof function stepOne, which TestOne does not build with', output)
+
+    def test_the_drafting_contract_states_the_column_the_gate_holds(self):
+        """The checker and the contract the drafter is given have to say the same thing.
+
+        `TEST_HEADER` and `BLOCK_END` refuse a line Go compiles, so the rule is this repository's
+        and has to be written down where the drafter reads it. Without this, the two patterns could
+        keep an anchor no document mentions, which is how the same defect arose on the step side.
+        """
+        contract = (Path(__file__).parents[3] / '.claude' / 'skills' / 'compile-gear'
+                    / 'SKILL.md').read_text(encoding='utf-8')
+
+        self.assertIn('The header and the closing `}` each', contract)
+        self.assertIn('start at column 1', contract)
+        self.assertIn('The step function is not part of', contract)
+
+    def test_each_pattern_answers_the_column_question_as_its_site_says(self):
+        """The four decisions, pinned on the patterns themselves.
+
+        The messages above can be reworded; these cannot drift. Two patterns read a declaration
+        wherever it starts, and two require column 1 because their line is the drafting contract.
+        """
+        widened = (
+            ('STEP_DEFINITION', COMPILE_CHECKER.STEP_DEFINITION, 'func stepOne() {}'),
+            ('TEST_FUNCTION', COMPILE_CHECKER.TEST_FUNCTION, 'func TestOne(t *testing.T) {'),
+        )
+        for name, pattern, line in widened:
+            with self.subTest(pattern=name):
+                self.assertTrue(pattern.match(line))
+                for indent in (' ', '\t', '\r'):
+                    self.assertTrue(pattern.match(indent + line), indent)
+                for indent in ('\u00a0', '\x0b', '\x0c'):
+                    self.assertIsNone(pattern.match(indent + line), indent)
+
+        anchored = (
+            ('TEST_HEADER', COMPILE_CHECKER.TEST_HEADER, 'func TestOne(t *testing.T) {'),
+            ('BLOCK_END', COMPILE_CHECKER.BLOCK_END, '}'),
+        )
+        for name, pattern, line in anchored:
+            with self.subTest(pattern=name):
+                self.assertTrue(pattern.match(line))
+                for indent in (' ', '\t', '\r'):
+                    self.assertIsNone(pattern.match(indent + line), indent)
+
     # A Test header Go runs but this gate cannot read is named as a header problem.
 
     def test_test_header_go_runs_but_the_gate_cannot_read_names_the_header(self):
@@ -1233,6 +1396,115 @@ class CheckCompileTest(unittest.TestCase):
         self.assertIn('proof/gear/proof_test.go:6 runs a proof outside the shape this gate reads',
                       output)
         self.assertNotIn('in a shape this gate does not read', output)
+
+
+# The proof-side probe. The gate's answers about where a line may start are only worth anything
+# next to what Go does with the same file, so each case below is a real proof file handed to the
+# real toolchain.
+PROOF_PROBE_HARNESS = ('package proofkit\n\n'
+                       'import "testing"\n\n'
+                       'func Run(t *testing.T, cases []int, build func()) {\n'
+                       '\t_ = cases\n'
+                       '\tbuild()\n'
+                       '}\n')
+
+
+def go_proof_verdict(body):
+    """What the Go toolchain does with one proof file body.
+
+    Returns `(compiled, ran)`: whether `go test` builds the package at all, and whether it ran a
+    test named `TestOne`. The two are separate questions — a file can compile while its Test never
+    runs, which is what a header Go does not recognise as a test looks like.
+
+    The package is shaped like a real proof: an external `gear_test` package importing a `proofkit`
+    stub, so `body` is the same text the gate is given.
+    """
+    root = Path(tempfile.mkdtemp(prefix='go-proof-'))
+    try:
+        (root / 'go.mod').write_text('module proofprobe\n\ngo 1.21\n')
+        (root / 'proofkit').mkdir()
+        (root / 'proofkit' / 'proofkit.go').write_text(PROOF_PROBE_HARNESS)
+        (root / 'gear').mkdir()
+        (root / 'gear' / 'gear.go').write_text('package gear\n')
+        (root / 'gear' / 'proof_test.go').write_text(
+            'package gear_test\n\n'
+            'import (\n\t"testing"\n\n\t"proofprobe/proofkit"\n)\n\n'
+            'var profileCases = []int{1}\n\n' + body)
+        run = subprocess.run(['go', 'test', '-v', '-run', 'TestOne', './gear'],
+                             cwd=root, capture_output=True, text=True)
+        return run.returncode == 0, '--- PASS: TestOne' in run.stdout
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+class ProofDeclarationColumnTest(unittest.TestCase):
+    """Go's half of the column question, for every line of a proof the gate reads by pattern.
+
+    `gofmt` writes all three lines of a registration at column 1, and nothing in this repository
+    runs `gofmt`: `proof/run.sh` runs only `go work init/edit` and `go test ./...`, and neither
+    `.github/workflows/3d-proof.yml` nor `sketch-bench.yml` has a gofmt, vet or lint step. So an
+    indented line is an ordinary proof file rather than a malformed one, and what the gate does
+    about each is a decision recorded at its site rather than an accident of a pattern.
+
+    The cases here say what Go does. `CheckCompileTest` says what the gate does about it.
+    """
+
+    # name, the proof body, whether Go compiles it, whether `go test` runs TestOne.
+    CASES = (
+        ('the shape at column 1',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         'func stepOne() {}\n', True, True),
+        ('a tab-indented step definition',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         '\tfunc stepOne() {}\n', True, True),
+        ('a space-indented step definition',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         '    func stepOne() {}\n', True, True),
+        ('a carriage return before the step definition',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         '\rfunc stepOne() {}\n', True, True),
+        ('an indented Test header',
+         '\tfunc TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         'func stepOne() {}\n', True, True),
+        ('an indented closing brace',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '\t}\n\n'
+         'func stepOne() {}\n', True, True),
+        # The whitespace Go does not have. Each of these makes the file illegal where it sits, so
+        # nothing in it is declared, registered or run.
+        ('a non-breaking space before the step definition',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         '\u00a0func stepOne() {}\n', False, False),
+        ('a vertical tab before the step definition',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         '\x0bfunc stepOne() {}\n', False, False),
+        ('a form feed before the step definition',
+         'func TestOne(t *testing.T) {\n'
+         '\tproofkit.Run(t, profileCases, stepOne)\n'
+         '}\n\n'
+         '\x0cfunc stepOne() {}\n', False, False),
+    )
+
+    def test_go_agrees_with_every_recorded_proof_verdict(self):
+        """Without this the table above is a claim about Go rather than a reading of it."""
+        for name, body, compiled, ran in self.CASES:
+            with self.subTest(case=name):
+                self.assertEqual(go_proof_verdict(body), (compiled, ran))
 
 
 class GoFilenameRuleTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -24,7 +24,7 @@ COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
 # does about that. The whole class of defect on this boundary is the gate disagreeing with Go
 # about a spelling, so a spelling is not settled until both halves are written down and both are
 # checked: `test_go_agrees_with_every_recorded_header_verdict` runs the Go toolchain over this
-# corpus and fails if a `go` column ever stops being true, and the two gate tests below run the
+# corpus and fails if a `go` column ever stops being true, and the three gate tests below run the
 # checker over the same corpus.
 #
 # A row carries the bytes above the package clause and nothing else; the file under test is that
@@ -33,48 +33,58 @@ COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
 #   ignored             the constraint is honoured and excludes the file — `IgnoredGoFiles`
 #   invalid-constraint  the constraint is read but does not parse — `InvalidGoFiles`
 #   no-constraint       no constraint is read, whatever else Go thinks of the file
+#   unreadable          Go refuses the file's bytes, so `go build` never compiles it and the
+#                       constraint question never arises
 #
-# The `gate` column is `refuse` or `accept`. They agree everywhere except the `+build` near-misses
-# grouped at the end, which are refused deliberately; `PLUS_BUILD_DIRECTIVE` in the checker states
-# why.
+# The `gate` column says what the checker does and, when it refuses, which complaint it makes:
+#
+#   accept              the file is read and scanned
+#   refuse-constraint   "carries a build constraint"
+#   refuse-unreadable   "so Go refuses the file", because Go cannot read those bytes
+#
+# Go and the gate agree everywhere except the `+build` near-misses grouped at the end, which are
+# refused deliberately — `PLUS_BUILD_DIRECTIVE` in the checker states why — and the two
+# `illegal character` rows, which are the known edge named where they sit.
 BOM = b'\xef\xbb\xbf'
 
 GO_HEADER_CASES = (
     # name, header bytes, what Go does, what the gate does
-    ('a plain constraint', b'//go:build ignore\n\n', 'ignored', 'refuse'),
-    ('a tab separator', b'//go:build\tignore\n\n', 'ignored', 'refuse'),
-    ('an indented constraint', b'   //go:build ignore\n\n', 'ignored', 'refuse'),
-    ('a tab-indented constraint', b'\t//go:build ignore\n\n', 'ignored', 'refuse'),
+    ('a plain constraint', b'//go:build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('a tab separator', b'//go:build\tignore\n\n', 'ignored', 'refuse-constraint'),
+    ('an indented constraint', b'   //go:build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('a tab-indented constraint', b'\t//go:build ignore\n\n', 'ignored', 'refuse-constraint'),
     ('a constraint on the second header line', b'// note\n//go:build ignore\n\n',
-     'ignored', 'refuse'),
-    ('no blank line before the package clause', b'//go:build ignore\n', 'ignored', 'refuse'),
-    ('CRLF line endings', b'//go:build ignore\r\n\r\n', 'ignored', 'refuse'),
-    ('lone CR line endings', b'//go:build ignore\r\r', 'invalid-constraint', 'refuse'),
-    ('a bare directive', b'//go:build\n\n', 'invalid-constraint', 'refuse'),
+     'ignored', 'refuse-constraint'),
+    ('no blank line before the package clause', b'//go:build ignore\n', 'ignored',
+     'refuse-constraint'),
+    ('CRLF line endings', b'//go:build ignore\r\n\r\n', 'ignored', 'refuse-constraint'),
+    ('lone CR line endings', b'//go:build ignore\r\r', 'invalid-constraint', 'refuse-constraint'),
+    ('a bare directive', b'//go:build\n\n', 'invalid-constraint', 'refuse-constraint'),
     ('a directive followed only by spaces', b'//go:build   \n\n',
-     'invalid-constraint', 'refuse'),
-    ('a directive followed only by a tab', b'//go:build\t\n\n', 'invalid-constraint', 'refuse'),
+     'invalid-constraint', 'refuse-constraint'),
+    ('a directive followed only by a tab', b'//go:build\t\n\n', 'invalid-constraint',
+     'refuse-constraint'),
     ('a byte order mark above the directive', BOM + b'//go:build ignore\n\n',
-     'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
     ('a byte order mark above an indented directive', BOM + b'   //go:build ignore\n\n',
-     'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
     ('a byte order mark above the legacy form', BOM + b'// +build ignore\n\n',
-     'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
     # Go trims the header line with `unicode.IsSpace`, which counts a non-breaking space.
     ('a non-breaking space before the slashes', b'\xc2\xa0//go:build ignore\n\n',
-     'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
     ('a closed block comment on the line above', b'/* note */\n//go:build ignore\n\n',
-     'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
     ('a closed multi-line block comment above', b'/*\nnote\n*/\n//go:build ignore\n\n',
-     'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
     ('a `/*` inside a line comment above', b'// /* note\n//go:build ignore\n\n',
-     'ignored', 'refuse'),
-    ('the legacy form', b'// +build ignore\n\n', 'ignored', 'refuse'),
-    ('the legacy form with no space', b'//+build ignore\n\n', 'ignored', 'refuse'),
-    ('the legacy form with two spaces', b'//  +build ignore\n\n', 'ignored', 'refuse'),
-    ('the legacy form with a tab', b'//\t+build ignore\n\n', 'ignored', 'refuse'),
-    ('the legacy form indented', b'  // +build ignore\n\n', 'ignored', 'refuse'),
-    ('a bare legacy directive', b'// +build\n\n', 'ignored', 'refuse'),
+     'ignored', 'refuse-constraint'),
+    ('the legacy form', b'// +build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('the legacy form with no space', b'//+build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('the legacy form with two spaces', b'//  +build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('the legacy form with a tab', b'//\t+build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('the legacy form indented', b'  // +build ignore\n\n', 'ignored', 'refuse-constraint'),
+    ('a bare legacy directive', b'// +build\n\n', 'ignored', 'refuse-constraint'),
 
     ('a space after the slashes', b'// go:build ignore\n\n', 'no-constraint', 'accept'),
     ('prose about the directive', b'// go:build is discussed here, not used\n\n',
@@ -89,37 +99,79 @@ GO_HEADER_CASES = (
     ('a block comment closing on the directive line', b'/* note */ //go:build ignore\n\n',
      'no-constraint', 'accept'),
     ('a byte order mark and no constraint', BOM, 'no-constraint', 'accept'),
+
+    # Bytes Go refuses to read. Every one of these makes `go build` fail, so the file is never
+    # compiled and nothing it registers is ever built; crediting one is a false pass. The
+    # constraint written under them is beside the point — Go never gets far enough to read it —
+    # which is why the `go` column says `unreadable` rather than `no-constraint`.
+    ('a UTF-16 byte order mark', b'\xff\xfe//go:build ignore\n\n', 'unreadable',
+     'refuse-unreadable'),
+    ('a big-endian UTF-16 byte order mark', b'\xfe\xff//go:build ignore\n\n', 'unreadable',
+     'refuse-unreadable'),
+    ('a stray 0xFF in a header comment', b'// no\xffte\n\n', 'unreadable', 'refuse-unreadable'),
+    ('a NUL byte', b'\x00//go:build ignore\n\n', 'unreadable', 'refuse-unreadable'),
+    ('a NUL byte in a header comment', b'// no\x00te\n\n', 'unreadable', 'refuse-unreadable'),
     ('two byte order marks above the directive', BOM + BOM + b'//go:build ignore\n\n',
-     'no-constraint', 'accept'),
+     'unreadable', 'refuse-unreadable'),
     ('a byte order mark below the first line', b'// note\n' + BOM + b'//go:build ignore\n\n',
-     'no-constraint', 'accept'),
-    # Leading bytes Go rejects rather than strips. None of them is whitespace to Go, so the line
-    # does not begin with `//` and no constraint is read; Go's own complaint about the byte
-    # arrives later, from the parser, and is not this gate's to make.
-    ('a UTF-16 byte order mark', b'\xff\xfe//go:build ignore\n\n', 'no-constraint', 'accept'),
-    ('a NUL byte', b'\x00//go:build ignore\n\n', 'no-constraint', 'accept'),
-    ('a zero width space', b'\xe2\x80\x8b//go:build ignore\n\n', 'no-constraint', 'accept'),
-    ('a file separator U+001C', b'\x1c//go:build ignore\n\n', 'no-constraint', 'accept'),
+     'unreadable', 'refuse-unreadable'),
+    ('a byte order mark inside a header comment', b'// no' + BOM + b'te\n\n', 'unreadable',
+     'refuse-unreadable'),
+
+    # The known edge, recorded rather than hidden. Go refuses these two as well, reporting
+    # `illegal character U+200B` and `illegal character U+001C`, and the gate still credits them.
+    # They are not one of the four byte patterns `go_refused_bytes` knows: both are well-formed
+    # UTF-8 holding a character Go's scanner will not start a token with, and that rule is Go's
+    # whole lexer rather than a byte pattern a reader can check. Widening the gate to cover it
+    # means transcribing that lexer, which is a bigger change than the one these rows document.
+    ('a zero width space', b'\xe2\x80\x8b//go:build ignore\n\n', 'unreadable', 'accept'),
+    ('a file separator U+001C', b'\x1c//go:build ignore\n\n', 'unreadable', 'accept'),
 
     # Refused by decision rather than by Go's rule.
     ('a `!` straight after the legacy directive', b'// +build!ignore\n\n',
-     'no-constraint', 'refuse'),
+     'no-constraint', 'refuse-constraint'),
     ('a `/` straight after the legacy directive', b'// +build/ignore\n\n',
-     'no-constraint', 'refuse'),
-    ('a word run on to the legacy directive', b'// +buildignore\n\n', 'no-constraint', 'refuse'),
+     'no-constraint', 'refuse-constraint'),
+    ('a word run on to the legacy directive', b'// +buildignore\n\n', 'no-constraint',
+     'refuse-constraint'),
     ('the legacy form with no blank line after it', b'// +build ignore\n',
-     'no-constraint', 'refuse'),
+     'no-constraint', 'refuse-constraint'),
+)
+
+
+# What Go says when it refuses a file's bytes. Which message arrives depends on which stage
+# catches the file: the reader `go/build` uses for a file's header names a NUL `unexpected NUL in
+# input` and a stray mark `illegal byte order mark`, while the compiler, reached only when the
+# reader got through, names the same two `invalid NUL character` and `invalid BOM in the middle of
+# the file`. Any of them means the file is not compiled, which is the only distinction that
+# matters here.
+GO_UNREADABLE_MESSAGES = (
+    'illegal UTF-8 encoding',
+    'invalid UTF-8 encoding',
+    'unexpected NUL in input',
+    'invalid NUL character',
+    'illegal character NUL',
+    'illegal byte order mark',
+    'invalid BOM in the middle of the file',
+    'illegal character U+',
 )
 
 
 def go_verdicts(headers, body=b'package p\n\nfunc F() {}\n'):
-    """Ask the Go toolchain what it does with each header, in one `go list` run.
+    """Ask the Go toolchain what it does with each header, in one `go list` run and a build each.
 
     Every header becomes its own package directory holding the header plus `body`, alongside a
     file that carries the package on its own so a header Go excludes still leaves a package to
-    report. `go list -e` classifies a file without compiling it, which is exactly the question:
-    `IgnoredGoFiles` means a constraint excluded the file, and a `parsing //go:build line` error
-    means one was read and would not parse.
+    report. `go list -e` classifies a file without compiling it, which is exactly the constraint
+    question: `IgnoredGoFiles` means a constraint excluded the file, and a `parsing //go:build
+    line` error means one was read and would not parse.
+
+    A file whose bytes Go refuses is settled first and reported `unreadable`, because for such a
+    file there is no constraint question: Go never reads one. That verdict comes from `go build`
+    rather than from `go list`, because `go list -e` reports only what it hit while scanning a
+    file's header, and a second byte order mark is caught later, by the compiler. The builds run
+    one package at a time on purpose: `go build ./...` stops at the load errors and never compiles
+    the packages whose refusal only the compiler sees.
     """
     root = Path(tempfile.mkdtemp(prefix='go-header-'))
     try:
@@ -129,6 +181,12 @@ def go_verdicts(headers, body=b'package p\n\nfunc F() {}\n'):
             package.mkdir()
             (package / 'x.go').write_bytes(header + body)
             (package / 'keep.go').write_text('package p\n\nfunc Keep() {}\n')
+        unreadable = set()
+        for index in range(len(headers)):
+            built = subprocess.run(['go', 'build', './c%d' % index],
+                                   cwd=root, capture_output=True, text=True)
+            if any(message in built.stderr for message in GO_UNREADABLE_MESSAGES):
+                unreadable.add('c%d' % index)
         listed = subprocess.run(['go', 'list', '-e', '-json', './...'],
                                 cwd=root, capture_output=True, text=True)
         decoder = json.JSONDecoder()
@@ -140,7 +198,9 @@ def go_verdicts(headers, body=b'package p\n\nfunc F() {}\n'):
             while offset < len(text) and text[offset] in ' \t\r\n':
                 offset += 1
             name = info['ImportPath'].rsplit('/', 1)[-1]
-            if 'x.go' in (info.get('IgnoredGoFiles') or []):
+            if name in unreadable:
+                verdicts[name] = 'unreadable'
+            elif 'x.go' in (info.get('IgnoredGoFiles') or []):
                 verdicts[name] = 'ignored'
             elif 'parsing //go:build line' in ((info.get('Error') or {}).get('Err') or ''):
                 verdicts[name] = 'invalid-constraint'
@@ -761,7 +821,7 @@ class CheckCompileTest(unittest.TestCase):
         credit.
         """
         for name, header, verdict, gate in GO_HEADER_CASES:
-            if gate != 'refuse':
+            if gate != 'refuse-constraint':
                 continue
             with self.subTest(case=name, go=verdict):
                 result, output = self.run_checker(proof_body=self.constrained(header))
@@ -769,14 +829,36 @@ class CheckCompileTest(unittest.TestCase):
                 self.assertEqual(result, 1, output)
                 self.assertIn('carries a build constraint', output)
 
+    def test_every_header_whose_bytes_go_refuses_is_refused(self):
+        """A file Go will not read registers nothing, so crediting one is a false pass.
+
+        Four byte patterns do it and each row above names which: a UTF-16 mark, any other bytes
+        that are not UTF-8, a NUL, and a byte order mark below the first character. Reading such a
+        file as text credited every registration in it with no complaint at all, and for the
+        UTF-16 mark it also hid the build constraint underneath, because the two replacement
+        characters pushed the line off its `//` start. The complaint wording and the position it
+        points at are pinned one pattern at a time below.
+        """
+        for name, header, verdict, gate in GO_HEADER_CASES:
+            if gate != 'refuse-unreadable':
+                continue
+            with self.subTest(case=name, go=verdict):
+                result, output = self.run_checker(proof_body=self.constrained(header))
+
+                self.assertEqual(result, 1, output)
+                self.assertIn('so Go refuses the file', output)
+                self.assertNotIn('compile check: OK', output)
+
     def test_every_header_go_builds_as_written_is_accepted(self):
         """Every spelling Go reads no constraint from passes, so the gate refuses no built file.
 
         These are the near-misses and the disguises: a space after the slashes, a `!` or a `/`
-        straight after the directive, a directive quoted inside a leading block comment, and a
-        leading byte Go rejects rather than strips. `go list` reports all of them in `GoFiles`,
-        with no constraint read, and a gate that refused any of them would be failing a proof Go
-        compiles.
+        straight after the directive, and a directive quoted inside a leading block comment.
+        `go list` reports all of them in `GoFiles`, with no constraint read, and a gate that
+        refused any of them would be failing a proof Go compiles.
+
+        Two rows here are accepted while Go refuses the file, for an illegal character rather than
+        for a byte pattern; the corpus comment says why the gate does not reach them.
         """
         for name, header, verdict, gate in GO_HEADER_CASES:
             if gate != 'accept':
@@ -807,9 +889,10 @@ class CheckCompileTest(unittest.TestCase):
         """The `go` column of every row is what the toolchain actually does with that header.
 
         The gate's rules are transcribed from `go/build`, and a transcription is only worth what
-        keeps it true. This runs `go list -e -json` over the whole corpus and reconciles it row
-        by row, so a Go release that changed the boundary, or a row written from memory, fails
-        here rather than in a proof nobody can explain.
+        keeps it true. This runs `go build` and `go list -e -json` over the whole corpus and
+        reconciles it row by row, so a Go release that changed the boundary, or a row written from
+        memory, fails here rather than in a proof nobody can explain. It is what keeps `unreadable`
+        honest as well: that column claims Go refuses the file, and this is the run that shows it.
         """
         headers = [header for _, header, _, _ in GO_HEADER_CASES]
 
@@ -818,6 +901,148 @@ class CheckCompileTest(unittest.TestCase):
         for (name, _, verdict, _), actual in zip(GO_HEADER_CASES, observed):
             with self.subTest(case=name):
                 self.assertEqual(actual, verdict)
+
+    # Bytes Go refuses to read, one pattern at a time: what the complaint says and where it
+    # points. The corpus above carries every one of these as a header row, reconciled against the
+    # toolchain; what a header row cannot carry is the wording, the position, and a pattern that
+    # only appears below the package clause, which is what these add.
+
+    UNREADABLE_TAIL = ('so Go refuses the file: `go test` never compiles it, and nothing it '
+                       'registers is ever built; write the file ')
+
+    def assert_refused(self, proof_body, position, reason, remedy):
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('proof/gear/proof_test.go:%s %s, %s%s'
+                      % (position, reason, self.UNREADABLE_TAIL, remedy), output)
+        self.assertNotIn('compile check: OK', output)
+        return output
+
+    def test_a_utf16_byte_order_mark_is_refused_at_the_first_byte(self):
+        """`go build` fails with `illegal UTF-8 encoding (got UTF-16)` at 1:1, and nothing builds.
+
+        Reading the bytes with `errors='replace'` credited the registrations in such a file, and
+        the two replacement characters also pushed the header off its `//` start, so the build
+        constraint under the mark went unreported as well. Both marks are named, since a file
+        saved as UTF-16 opens with whichever one the editor writes.
+        """
+        for mark in (b'\xff\xfe', b'\xfe\xff'):
+            with self.subTest(mark=mark):
+                self.assert_refused(
+                    mark + b'//go:build ignore\n\n' + self.PROOF_BODY, '1:1',
+                    'opens with a UTF-16 byte order mark, which Go reports as `illegal UTF-8 '
+                    'encoding (got UTF-16)`', 'as UTF-8 rather than UTF-16')
+
+    def test_bytes_that_are_not_utf8_are_refused_where_they_sit(self):
+        """A stray `0xFF` is `illegal UTF-8 encoding` to Go, in a comment and in a literal alike.
+
+        The literal case is here rather than in `GO_HEADER_CASES`, whose rows are headers above
+        the package clause: this byte sits below it, and Go still refuses the file.
+        """
+        self.assert_refused(
+            b'// no\xffte\n' + self.PROOF_BODY, '1:6',
+            'holds bytes that are not UTF-8, which Go reports as `illegal UTF-8 encoding`',
+            'as UTF-8')
+        self.assert_refused(
+            self.PROOF_BODY + b'\nvar note = "no\xffte"\n', '9:15',
+            'holds bytes that are not UTF-8, which Go reports as `illegal UTF-8 encoding`',
+            'as UTF-8')
+
+    def test_a_nul_byte_is_refused_wherever_it_sits(self):
+        """A NUL decodes as valid UTF-8, so a strict decode alone credits the file.
+
+        Go refuses it either way, reporting `unexpected NUL in input` from the reader that walks a
+        file's header and `invalid NUL character` from the compiler for one further down. The
+        literal case is here rather than in `GO_HEADER_CASES` because it sits below the package
+        clause, which a header row cannot express.
+        """
+        self.assert_refused(
+            b'// no\x00te\n' + self.PROOF_BODY, '1:6',
+            'holds a NUL byte, which Go reports as `unexpected NUL in input`',
+            'without that byte')
+        self.assert_refused(
+            self.PROOF_BODY + b'\nvar note = "no\x00te"\n', '9:15',
+            'holds a NUL byte, which Go reports as `unexpected NUL in input`',
+            'without that byte')
+
+    def test_a_byte_order_mark_below_the_first_character_is_refused(self):
+        """Only the very first mark is stripped; any other one is `illegal byte order mark`.
+
+        A mark below the first character decodes as valid UTF-8 too, so this is the second case a
+        strict decode does not catch. The scan starts below a stripped leading mark, so a second
+        mark is reported at column 4, which is where Go reports it.
+        """
+        self.assert_refused(
+            BOM + BOM + b'//go:build ignore\n\n' + self.PROOF_BODY, '1:4',
+            'holds a byte order mark below the first character, which Go reports as `illegal '
+            'byte order mark`', 'without that mark')
+        self.assert_refused(
+            b'// note\n' + BOM + b'//go:build ignore\n\n' + self.PROOF_BODY, '2:1',
+            'holds a byte order mark below the first character, which Go reports as `illegal '
+            'byte order mark`', 'without that mark')
+
+    def test_the_first_refused_pattern_in_the_file_is_the_one_reported(self):
+        """One complaint per file, pointing at the earliest bytes Go stops on."""
+        output = self.assert_refused(
+            b'// note\x00and\xffmore\n' + self.PROOF_BODY, '1:8',
+            'holds a NUL byte, which Go reports as `unexpected NUL in input`',
+            'without that byte')
+
+        self.assertNotIn('not UTF-8', output)
+
+    def test_a_leading_byte_order_mark_is_still_stripped_and_the_file_scanned(self):
+        """The one mark Go strips stays stripped, and the file under it is read normally.
+
+        `test_a_byte_order_mark_does_not_hide_a_constraint` and the test below it hold the line
+        numbers; this holds the acceptance, so refusing every other mark did not take this one
+        with it.
+        """
+        result, output = self.run_checker(proof_body=BOM + self.PROOF_BODY)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_no_byte_pattern_raises_out_of_the_gate(self):
+        """Every refusal is a complaint, never a traceback.
+
+        `errors='replace'` was put in to stop a UTF-16 mark raising `UnicodeDecodeError` and
+        crashing the run, and decoding strictly without catching the failure would bring that
+        crash back. The gate has to survive an arbitrary byte anywhere, so this walks a file with
+        one byte of every value in it, at three positions, and asks that the read either hands
+        back text or hands back a complaint. It goes through `go_source` rather than through the
+        whole checker because that is the one place a byte is decoded, and 768 whole runs cost
+        more than the suite should pay to say the same thing.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, 'proof_test.go')
+            for value in range(256):
+                byte = bytes([value])
+                for where, data in (('above', byte + self.PROOF_BODY),
+                                    ('in a comment', b'// note ' + byte + b'\n' + self.PROOF_BODY),
+                                    ('in a literal',
+                                     self.PROOF_BODY + b'\nvar note = "x' + byte + b'"\n')):
+                    with self.subTest(value=value, where=where):
+                        with open(path, 'wb') as handle:
+                            handle.write(data)
+
+                        text, refused = COMPILE_CHECKER.go_source(path)
+
+                        self.assertEqual(text is None, refused is not None)
+
+    def test_an_undecodable_file_is_one_complaint_and_no_registration(self):
+        """The whole run returns, with the file named and nothing in it credited.
+
+        Reading the same bytes as text returned the file's registrations with no complaint, which
+        is the false pass; before that, decoding them strictly crashed the run.
+        """
+        result, output = self.run_checker(proof_body=b'\xff\xfe' + self.PROOF_BODY)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('compile check: BLOCKING (2)', output)
+        self.assertIn('proof/gear/proof_test.go:1:1 opens with a UTF-16 byte order mark', output)
+        self.assertIn('S1 names proof function stepOne, which proof/gear/ does not declare as a '
+                      'function', output)
 
     # Lines are cut where Go cuts them, at `\n` and nowhere else.
 

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -2,6 +2,7 @@
 """Regression tests for the compile-stage gate."""
 import contextlib
 import importlib.util
+import inspect
 import io
 import os
 import tempfile
@@ -32,7 +33,7 @@ class CheckCompileTest(unittest.TestCase):
     def run_checker(self, provenance=None, from_line='**From:** `spec/gear/instructions.md` L1',
                     proof_body=None, proof_filename='proof_test.go', step_body=None,
                     include_fusion=True, auxiliary=False, mutate_auxiliary=False,
-                    api_lookup=None, unverified_findings=None):
+                    api_lookup=None, unverified_findings=None, proof_directories=()):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / 'spec' / 'gear').mkdir(parents=True)
@@ -57,6 +58,8 @@ class CheckCompileTest(unittest.TestCase):
             if proof_body is None:
                 proof_body = self.registration('TestOne', 'proofkit.Run', 'stepOne')
             (root / 'proof' / 'gear' / proof_filename).write_text(proof_body)
+            for name in proof_directories:
+                (root / 'proof' / 'gear' / name).mkdir()
             table = '\n'.join((
                 '| Source | Blob hash |',
                 '|---|---|',
@@ -452,8 +455,14 @@ class CheckCompileTest(unittest.TestCase):
     def test_build_constraint_text_inside_a_header_block_comment_is_accepted(self):
         """Go takes a constraint only from a `//` line comment, so block-comment prose is text.
 
-        A file whose leading `/* */` note quotes a constraint builds, vets and formats clean, and
-        `go list` reports it unconstrained. Reading every raw header line refused it.
+        A file whose leading `/* */` note quotes a constraint indented inside it builds, vets and
+        formats clean, and `go list` reports it unconstrained. Reading every raw header line
+        refused it.
+
+        The quote is indented because that is the form Go genuinely accepts. Written at column 1
+        inside a leading block comment, `go/build` still ignores it, but `go vet` calls the
+        directive misplaced and `go test` fails, so this gate accepting it would agree with no
+        real toolchain and that case is deliberately not asserted here.
         """
         proof_body = (
             '/*\n'
@@ -502,6 +511,350 @@ class CheckCompileTest(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertIn('proof/gear/proof_test.go:6 runs a proof', output)
         self.assertIn('proof/gear/proof_test.go:10 runs a proof', output)
+
+
+    # Only files Go actually compiles are credited.
+
+    def foreign_goos(self):
+        """A GOOS this machine is not, so a `_GOOS` suffix here is genuinely unsatisfied."""
+        for name in sorted(COMPILE_CHECKER.GO_KNOWN_OS):
+            if not COMPILE_CHECKER.go_platform_tag_matches(
+                    name, COMPILE_CHECKER.GOOS, COMPILE_CHECKER.GOARCH):
+                return name
+        raise AssertionError('every known GOOS matches this machine')
+
+    def test_file_go_never_compiles_is_named_not_credited(self):
+        """A proof file Go drops still parsed as a proof, so its steps were credited unbuilt.
+
+        `_x_test.go` and `.x_test.go` are invisible to `go/build`, and a `_GOOS` or `_GOARCH`
+        suffix this machine does not satisfy lands the file in `IgnoredGoFiles`. In all three
+        cases `go test` reports no test files, so nothing here registers anything.
+        """
+        foreign = self.foreign_goos()
+        for filename in ('_x_test.go', '.x_test.go', 'proof_%s_test.go' % foreign,
+                         'proof_%s_amd64_test.go' % foreign):
+            with self.subTest(filename=filename):
+                result, output = self.run_checker(proof_filename=filename)
+
+                self.assertEqual(result, 1, output)
+                self.assertIn('proof/gear/%s is never compiled by Go' % filename, output)
+                self.assertIn(
+                    'S1 names proof function stepOne, which proof/gear/ does not declare as a '
+                    'function', output)
+
+    def test_file_go_does_compile_is_still_credited(self):
+        """The exclusion must not reach a satisfied suffix or an ordinary trailing word."""
+        for filename in ('proof_helper_test.go', 'proof_solid_test.go', 'a_unix_test.go',
+                         'a_Windows_test.go', 'windows_test.go',
+                         'proof_%s_test.go' % COMPILE_CHECKER.GOOS,
+                         'proof_%s_test.go' % COMPILE_CHECKER.GOARCH):
+            with self.subTest(filename=filename):
+                result, output = self.run_checker(proof_filename=filename)
+
+                self.assertEqual(result, 0, output)
+                self.assertIn('compile check: OK', output)
+
+    def test_directory_named_go_does_not_crash_the_gate(self):
+        """Go builds a package around a directory called `*.go`; reading it as a file raises."""
+        result, output = self.run_checker(proof_directories=('bundle.go', 'nested_test.go'))
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    # The two `//` constraint forms differ in what may sit before the directive.
+
+    def constrained(self, header):
+        return (
+            '%s\n\n'
+            'package gear_test\n\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n' % header)
+
+    def test_every_spelling_go_reads_as_a_constraint_is_refused(self):
+        """`//go:build` takes no space after the slashes; the legacy form takes any."""
+        for header in ('//go:build ignore', '  //go:build ignore', '\t//go:build ignore',
+                       '// +build ignore', '//+build ignore', '//  +build ignore',
+                       '//\t+build ignore', '  // +build ignore'):
+            with self.subTest(header=header):
+                result, output = self.run_checker(proof_body=self.constrained(header))
+
+                self.assertEqual(result, 1, output)
+                self.assertIn('carries a build constraint', output)
+
+    def test_comment_go_does_not_read_as_a_constraint_is_accepted(self):
+        """`// go:build …` is prose to Go: the file lands in `GoFiles` and its tests run.
+
+        Allowing whitespace between the slashes and `go:build` refused a header comment that
+        merely discusses the directive, in a file Go builds.
+        """
+        for header in ('// go:build ignore', '// go:build is discussed here, not used',
+                       '//  go:build ignore', '// go: build ignore'):
+            with self.subTest(header=header):
+                result, output = self.run_checker(proof_body=self.constrained(header))
+
+                self.assertEqual(result, 0, output)
+                self.assertIn('compile check: OK', output)
+
+    # Lines are cut where Go cuts them, at `\n` and nowhere else.
+
+    def test_form_feed_in_a_header_comment_does_not_invent_a_constraint(self):
+        """Go ends a line only at `\\n`, so this header is one comment and the file is built.
+
+        Python's `splitlines` also ends a line at a form feed, which split this comment in two
+        and refused the tail as a build constraint the file does not carry.
+        """
+        proof_body = (
+            '// see \x0c//go:build ignore\n'
+            'package gear_test\n\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_form_feed_does_not_shift_the_header_a_constraint_is_read_from(self):
+        """A real constraint stays reported, at its own line, after a form feed above it.
+
+        Splitting the raw source more finely than the blanked copy slid the two out of step, so
+        the header slice stopped at the comment and a genuine `//go:build` below it went unseen.
+        """
+        proof_body = (
+            '// note \x0c and more\n'
+            '//go:build ignore\n'
+            'package gear_test\n\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('proof/gear/proof_test.go:2 carries a build constraint', output)
+
+    def test_the_proof_scanner_cuts_lines_only_at_a_newline(self):
+        """Every line the gate numbers is cut at `\n`, the only line ending Go recognises.
+
+        Python's `splitlines` also cuts at a form feed, a vertical tab, U+001C to U+001E, U+0085,
+        U+2028 and U+2029. The two tests above show the difference through the gate's output,
+        because a `//` comment survives into the copy the header is read from. The scrubbed copy
+        the registrations are read from cannot show it, since every one of those characters is
+        illegal in Go source outside a comment or a literal and both are blanked before the
+        split. It is pinned here anyway: a reader that numbers lines differently from Go cannot
+        be trusted to point at the line it names, and every `path:line` complaint rests on that
+        arithmetic.
+        """
+        body = inspect.getsource(COMPILE_CHECKER.scan_proof_file).split('"""')[-1]
+
+        self.assertNotIn('splitlines', body)
+        self.assertIn("split('\\n')", body)
+
+    # A step is read from a function declaration, and the refusal says so.
+
+    def test_step_bound_to_a_variable_is_reported_as_not_a_function(self):
+        """Go compiles `var stepFoo = func(…)`, so calling the directory undefining it misleads.
+
+        The gate keeps requiring the `func` form, matching the one-function-per-step contract in
+        `.claude/skills/compile-gear/SKILL.md`. Only the message changed, to name the shape the
+        step has to be written in.
+        """
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'var stepOne = func(t *testing.T) {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn(
+            'S1 names proof function stepOne, which proof/gear/ does not declare as a function; '
+            'write `func stepOne(...)`, since a step bound to a variable is not read', output)
+        self.assertNotIn('which proof/gear/ does not define', output)
+
+    # A Test header Go runs but this gate cannot read is named as a header problem.
+
+    def test_test_header_go_runs_but_the_gate_cannot_read_names_the_header(self):
+        """`Test_Foo`, `Test1x` and an aliased `testing` import all run under `go test`.
+
+        Each was refused with "runs a proof outside the shape this gate reads", which points at a
+        run call that is perfectly formed. The header is what did not match, so that is what the
+        complaint names.
+        """
+        for header in ('func Test_Two(t *testing.T) {', 'func Test1x(t *testing.T) {',
+                       'func TestTwo(t *tst.T) {', 'func Test(t *testing.T) {'):
+            with self.subTest(header=header):
+                proof_body = (
+                    'func TestOne(t *testing.T) {\n'
+                    '\tproofkit.Run(t, profileCases, stepOne)\n'
+                    '}\n\n'
+                    '%s\n'
+                    '\tproofkit.Run(t, profileCases, stepTwo)\n'
+                    '}\n\n'
+                    'func stepOne() {}\n' % header)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 1, output)
+                self.assertIn(
+                    'proof/gear/proof_test.go:5 heads %s in a shape this gate does not read, so '
+                    'the registration under it cannot be checked; a proof Test is headed '
+                    '`func Test<Title>(t *testing.T) {`, with the testing package named in full'
+                    % header.split()[1].split('(')[0], output)
+                self.assertNotIn('runs a proof outside the shape this gate reads', output)
+
+    def test_name_go_would_not_run_is_still_reported_as_an_off_shape_run(self):
+        """`Testé` is not a test to Go, so its run is a stray call, not a mis-shaped header."""
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func Testé(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepTwo)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('proof/gear/proof_test.go:6 runs a proof outside the shape this gate reads',
+                      output)
+        self.assertNotIn('in a shape this gate does not read', output)
+
+
+class GoFilenameRuleTest(unittest.TestCase):
+    """`go_ignores_file` against a fixed linux/amd64, so every case is the one Go was asked.
+
+    Running the suite elsewhere would change which suffixes are satisfied, so the platform is
+    passed in rather than taken from the machine. The integration tests above use the live one.
+    """
+
+    IGNORED = (
+        ('_x_test.go', 'invisible'),
+        ('.x_test.go', 'invisible'),
+        ('x_windows_test.go', 'suffix'),
+        ('x_arm64_test.go', 'suffix'),
+        ('x_windows_amd64_test.go', 'suffix'),
+    )
+
+    COMPILED = (
+        'proof_helper_test.go',
+        'proof_solid_test.go',
+        'a_unix_test.go',
+        'a_Windows_test.go',
+        'windows_test.go',
+        'proof_linux_test.go',
+        'proof_amd64_test.go',
+        'proof_test.go',
+        'proof.go',
+    )
+
+    def test_names_go_never_compiles(self):
+        for name, reason in self.IGNORED:
+            with self.subTest(name=name):
+                self.assertIn(
+                    reason,
+                    COMPILE_CHECKER.go_ignores_file(name, goos='linux', goarch='amd64') or '')
+
+    def test_names_go_does_compile(self):
+        for name in self.COMPILED:
+            with self.subTest(name=name):
+                self.assertIsNone(
+                    COMPILE_CHECKER.go_ignores_file(name, goos='linux', goarch='amd64'))
+
+    def test_go_aliases_a_few_platforms(self):
+        """`android` takes `linux` files, `illumos` takes `solaris`, and `ios` takes `darwin`."""
+        for goos, tag in (('android', 'linux'), ('illumos', 'solaris'), ('ios', 'darwin')):
+            with self.subTest(goos=goos):
+                self.assertIsNone(COMPILE_CHECKER.go_ignores_file(
+                    'proof_%s_test.go' % tag, goos=goos, goarch='amd64'))
+
+    def test_this_machine_is_named_the_way_go_names_it(self):
+        """The live platform must be a name Go knows, or every suffix check is nonsense."""
+        self.assertIn(COMPILE_CHECKER.GOOS, COMPILE_CHECKER.GO_KNOWN_OS)
+        self.assertIn(COMPILE_CHECKER.GOARCH, COMPILE_CHECKER.GO_KNOWN_ARCH)
+
+
+class ProofRunArityDerivationTest(unittest.TestCase):
+    """The run table is read from the harness sources rather than typed out beside them."""
+
+    def test_derived_table_matches_the_harness_signatures(self):
+        """The tripwire for the derivation, and the one place a run signature is pinned.
+
+        Deriving the counts means a hand-copy cannot drift, but a derivation that quietly read
+        nothing would look just as healthy. This pins what `proof/proofkit` and `proof/proofkit3d`
+        declare today, so adding a run method or changing an arity fails here and gets reviewed.
+        """
+        self.assertEqual(COMPILE_CHECKER.PROOF_RUN_ARGUMENTS, {
+            'proofkit.Run': 3,
+            'proofkit3d.Run': 4,
+            'proofkit3d.RunSolid': 4,
+            'proofkit3d.RunWithGate': 5,
+        })
+
+    def test_parameter_count_is_of_parameters_not_commas_in_the_source(self):
+        """Go lets parameters share a type, and a nested comma belongs to the type it sits in."""
+        cases = (
+            ('', 0),
+            ('t *testing.T', 1),
+            ('t *testing.T, cases []Case, build Build', 3),
+            ('t *testing.T, a, b Case', 3),
+            ('t *testing.T, build func(*testing.T, []Case) error', 2),
+            ('t *testing.T, table map[string]Case, seed [2]float64', 3),
+        )
+        for parameters, expected in cases:
+            with self.subTest(parameters=parameters):
+                self.assertEqual(COMPILE_CHECKER.go_parameter_count(parameters), expected)
+
+    def test_arities_are_read_from_source_text_comments_excluded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'harness.go'
+            path.write_text(
+                'package harness\n\n'
+                '// RunTwice would be written\n'
+                '//\n'
+                '//\tfunc RunTwice(t *testing.T, a, b, c, d Case) {}\n'
+                '//\n'
+                '// but it is not.\n'
+                'func Run(t *testing.T, cases []Case, build Build) {}\n\n'
+                'func RunWithGate(t *testing.T, cases []Case, build Build, gate Gate,\n'
+                '\tassert Assert) {\n'
+                '}\n\n'
+                'func helper(t *testing.T) {}\n')
+
+            table = COMPILE_CHECKER.go_run_arities('harness', str(path))
+
+        self.assertEqual(table, {'harness.Run': 3, 'harness.RunWithGate': 5})
+
+    def test_both_run_patterns_are_built_from_the_derived_table(self):
+        """Every derived method is read as a registration; no other pairing is read as one.
+
+        The mention pattern stays wider on purpose, so a call on a method no package declares —
+        `proofkit.RunSolid` — is still seen and complained about rather than passing unnoticed.
+        """
+        packages = sorted({method.split('.')[0] for method in COMPILE_CHECKER.PROOF_RUN_ARGUMENTS})
+        names = sorted({method.split('.')[1] for method in COMPILE_CHECKER.PROOF_RUN_ARGUMENTS})
+        for package in packages:
+            for name in names:
+                method = '%s.%s' % (package, name)
+                declared = COMPILE_CHECKER.PROOF_RUN_ARGUMENTS.get(method)
+                arguments = ['t', 'profileCases', 'stepOne'] + ['assertOne'] * 2
+                line = '\t%s(%s)' % (method, ', '.join(arguments[:declared or 3]))
+                with self.subTest(method=method):
+                    self.assertTrue(COMPILE_CHECKER.PROOF_RUN_MENTION.search(line))
+                    match = COMPILE_CHECKER.PROOF_RUN.match(line)
+                    if declared is None:
+                        self.assertIsNone(match)
+                        continue
+                    self.assertIsNotNone(match)
+                    self.assertEqual(COMPILE_CHECKER.proof_run_arguments(match),
+                                     (method, declared))
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -391,6 +391,16 @@ class CheckCompileTest(unittest.TestCase):
             '}\n\n'
             'func stepOne() {}\n' % (test, call, cases, build, extra))
 
+    def claim_step(self, claim):
+        """One `[GO]` step whose title carries `claim`, with citation and body canonical.
+
+        The title is where the committed step lists write the proof function, so a fixture that
+        only differs in what is claimed reads as exactly that difference.
+        """
+        return ('## S1 `[GO]` One — `%s`\n\n'
+                'Build the thing.\n\n'
+                '**From:** `spec/gear/instructions.md` L1\n\n' % claim)
+
     def body(self, statements, test='TestTwo'):
         """A proof whose first registration is canonical and whose second Test is `statements`."""
         return (
@@ -1337,16 +1347,64 @@ class CheckCompileTest(unittest.TestCase):
         both and the gate credited the step, while `go test` reported `illegal character U+00B2`.
         The name is a Go identifier wherever it is written, so a name Go cannot have is one no
         proof declares and no step claims.
-        """
-        step_body = ('## S1 `[GO]` One — `step%s`\n\n'
-                     'Build the thing.\n\n'
-                     '**From:** `spec/gear/instructions.md` L1\n\n' % NON_GO_STEP)
 
-        result, output = self.run_checker(proof_body=NON_GO_PROOF, step_body=step_body)
+        The complaint names the step rather than the name, because the claim is read whole or not
+        at all: nothing here is a step name, so there is no name to quote. The earlier wording
+        quoted a truncated identifier the drafter never wrote.
+        """
+        result, output = self.run_checker(proof_body=NON_GO_PROOF,
+                                          step_body=self.claim_step('step' + NON_GO_STEP))
 
         self.assertEqual(result, 1, output)
         self.assertNotIn('compile check: OK', output)
-        self.assertIn('proof/gear/ does not declare as a function', output)
+        self.assertIn('S1 is tagged [GO] but names no proof function', output)
+
+    def test_a_claim_trailing_a_rune_go_refuses_is_not_credited_to_its_prefix(self):
+        """A claim is credited whole or not at all, and the right edge is what makes that true.
+
+        With no right-edge assertion the pattern stopped at the first rune outside the Go
+        identifier class and handed back the valid prefix, so a step claiming `stepOne²` was
+        credited to a proof declaring plain `stepOne` and the gate printed OK at exit 0. The
+        drafter wrote a name `go test` refuses, and the gate has to say so.
+        """
+        result, output = self.run_checker(step_body=self.claim_step('stepOne²'))
+
+        self.assertEqual(result, 1, output)
+        self.assertNotIn('compile check: OK', output)
+        self.assertIn('S1 is tagged [GO] but names no proof function', output)
+
+    def test_a_claim_behind_a_rune_go_refuses_is_not_credited_to_its_suffix(self):
+        """The same hole on the left edge, which a Go-strict lookbehind does not close.
+
+        `left` excludes only the runes a Go identifier carries, and U+00B2 is not one of them, so
+        it succeeds in front of `²stepOne` and the valid suffix was credited to a proof declaring
+        plain `stepOne`. The edge that closes this is the wider Python class: the neighbouring
+        rune is what proves the token is not a Go name, so it has to suppress the claim.
+        """
+        result, output = self.run_checker(step_body=self.claim_step('²stepOne'))
+
+        self.assertEqual(result, 1, output)
+        self.assertNotIn('compile check: OK', output)
+        self.assertIn('S1 is tagged [GO] but names no proof function', output)
+
+    def test_a_claim_beside_ordinary_punctuation_is_still_read(self):
+        """Suppressing a glued rune must not suppress the punctuation a step list writes.
+
+        A claim is written inside backticks, inside bold, in a parenthesis and mid-sentence, and
+        none of those neighbours is a word character. A name that carries a Unicode letter, a
+        trailing letter or a trailing digit is one identifier and is read whole.
+        """
+        for claim, credited in (('`stepOne`', 'stepOne'),
+                                ('stepOne, and', 'stepOne'),
+                                ('stepOne. Next', 'stepOne'),
+                                ('(stepOne)', 'stepOne'),
+                                ('**stepOne**', 'stepOne'),
+                                ('the `stepOne` step', 'stepOne'),
+                                ('stepOnes', 'stepOnes'),
+                                ('stepPrüfung', 'stepPrüfung'),
+                                ('stepOne2', 'stepOne2')):
+            with self.subTest(claim=claim):
+                self.assertEqual(COMPILE_CHECKER.STEP_NAME_CLAIM.findall(claim), [credited])
 
     def test_a_unicode_letter_in_a_step_name_is_still_read(self):
         """Go identifiers include Unicode letters, so tightening must not refuse one.
@@ -1355,11 +1413,8 @@ class CheckCompileTest(unittest.TestCase):
         `ProofDeclarationColumnTest` checks with the toolchain. A gate that read only ASCII names
         would report a step the proof does declare as one it does not.
         """
-        step_body = ('## S1 `[GO]` One — `step%s`\n\n'
-                     'Build the thing.\n\n'
-                     '**From:** `spec/gear/instructions.md` L1\n\n' % GO_LETTER_STEP)
-
-        result, output = self.run_checker(proof_body=GO_LETTER_PROOF, step_body=step_body)
+        result, output = self.run_checker(proof_body=GO_LETTER_PROOF,
+                                          step_body=self.claim_step('step' + GO_LETTER_STEP))
 
         self.assertEqual(result, 0, output)
         self.assertIn('compile check: OK', output)
@@ -1702,6 +1757,88 @@ RE_PATTERN_CALLS = frozenset(
 
 PYTHON_CHARACTER_CLASS = re.compile(r'\\[bBdDsSwW]')
 
+# The `GO_TOKENS` slots that put a Go identifier into a pattern. A pattern that fills one of these
+# is one that reads a name, whatever else it reads.
+GO_IDENTIFIER_SLOTS = ('%(part)s', '%(name)s', '%(qualified)s')
+
+
+def re_pattern_calls(tree):
+    """Every `re.*` call in `tree` that takes a pattern, as (method, pattern argument node).
+
+    One enumeration, because two checks read it. `GoPatternClassTest` reads the literals that
+    reach the pattern argument; `GoIdentifierEdgeTest` reads the patterns those calls compile and
+    probes their edges. A pattern the enumeration misses is invisible to both, so there is one
+    place to get it right.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if not (isinstance(function, ast.Attribute) and function.attr in RE_PATTERN_CALLS
+                and isinstance(function.value, ast.Name) and function.value.id == 're'):
+            continue
+        pattern = node.args[0] if node.args else next(
+            (keyword.value for keyword in node.keywords if keyword.arg == 'pattern'), None)
+        if pattern is not None:
+            yield function.attr, pattern
+
+
+# One entry of the registry below: the `re` methods the module calls the pattern through, and the
+# literal written at its own `re.compile` call, slots and all.
+PatternUse = collections.namedtuple('PatternUse', 'methods written')
+
+
+def go_identifier_patterns(source):
+    """Every compiled pattern in `source` that reads a Go identifier, and how it is used.
+
+    Returns {name: PatternUse}: the name the pattern is bound to, against the `re` methods the
+    module calls it through and the literal it was compiled from. The name is the assignment
+    target, or the function that returns the pattern when it is built rather than assigned, since
+    a derived pattern has no other name to report. A pattern whose uses this scan cannot see comes
+    back with an empty method set, which is not the same as one used only through `fullmatch`;
+    unseen is a reason to probe it, not to trust it.
+
+    A pattern reads a Go identifier when the literal written at its own `re.compile` call fills
+    one of the `GO_TOKENS` identifier slots. Only that literal is read, unlike `pattern_literals`
+    above: the slots are filled from `GO_TOKENS`, which carries a whole Go identifier in it, so
+    following names here would make every pattern in the module look like a name reader.
+    """
+    tree = ast.parse(source)
+
+    def written_pattern(node):
+        """The literal a call compiles, when the call compiles one that reads a Go identifier."""
+        for method, pattern in re_pattern_calls(node):
+            if method != 'compile':
+                continue
+            written = ''.join(sub.value for sub in ast.walk(pattern)
+                              if isinstance(sub, ast.Constant) and isinstance(sub.value, str))
+            if any(slot in written for slot in GO_IDENTIFIER_SLOTS):
+                return written
+        return None
+
+    found = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(
+                node.targets[0], ast.Name) and isinstance(node.value, ast.Call):
+            written = written_pattern(node.value)
+            if written is not None:
+                found[node.targets[0].id] = [set(), written]
+        elif isinstance(node, ast.FunctionDef):
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Return) and isinstance(sub.value, ast.Call):
+                    written = written_pattern(sub.value)
+                    if written is not None:
+                        found[node.name] = [set(), written]
+
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr in RE_PATTERN_CALLS
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in found):
+            found[node.func.value.id][0].add(node.func.attr)
+    return {name: PatternUse(frozenset(methods), written)
+            for name, (methods, written) in found.items()}
+
 
 def pattern_literals(source):
     """Every (line, text) string literal that reaches the pattern argument of an `re.*` call.
@@ -1735,17 +1872,8 @@ def pattern_literals(source):
                 for value in bindings.get(sub.id, ()):
                     visit(value, seen | {sub.id})
 
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        function = node.func
-        if not (isinstance(function, ast.Attribute) and function.attr in RE_PATTERN_CALLS
-                and isinstance(function.value, ast.Name) and function.value.id == 're'):
-            continue
-        pattern = node.args[0] if node.args else next(
-            (keyword.value for keyword in node.keywords if keyword.arg == 'pattern'), None)
-        if pattern is not None:
-            visit(pattern, frozenset())
+    for _, pattern in re_pattern_calls(tree):
+        visit(pattern, frozenset())
     return found
 
 
@@ -1823,9 +1951,24 @@ class GoPatternClassTest(unittest.TestCase):
         r'[^\W%s]': 'GO_IDENTIFIER_PART, a word character that is not a numeral Go refuses',
     }
 
+    # The two edges of a token that has to stand alone. They are the one place on this path where
+    # the wider Python class is the correct rule rather than an approximation of Go's, and the
+    # reason is what the match is for. Every other pattern here matches to raise a complaint,
+    # where a wider read is a louder report; `STEP_NAME_CLAIM` matches to grant a step credit for
+    # a proof function, where a wider read is a false OK. A rune Go refuses glued to the token
+    # proves the token as written is not a Go name at all, so it must suppress the whole match
+    # rather than leave the valid prefix or suffix credited — and a Go-strict edge cannot do that,
+    # because such a rune is not a Go identifier rune and every Go-strict edge succeeds beside it.
+    # `GoIdentifierEdgeTest` holds the behaviour these two exist for.
+    GO_CLAIM_EDGES = {
+        r'(?<!\w)': 'no_word_left, the left edge of a claim that must stand alone',
+        r'(?!\w)': 'no_word_right, the right edge of a claim that must stand alone',
+    }
+
     def allowed(self):
         allowed = dict(self.MARKDOWN_PATTERNS)
         allowed.update(self.GO_CLASS_DEFINITIONS)
+        allowed.update(self.GO_CLAIM_EDGES)
         return allowed
 
     def findings(self, source):
@@ -1884,6 +2027,135 @@ class GoPatternClassTest(unittest.TestCase):
     def test_a_class_written_in_the_subject_is_not_a_finding(self):
         """Only the pattern argument is a rule. A class in the searched text is characters."""
         self.assertEqual(self.findings(CLASS_IN_THE_SUBJECT_MODULE), [])
+
+
+# An invented pattern, not one from this repository, and nothing in the tree is spelled this way.
+# It reads a name with neither edge asserted, which is what the probe below has to be able to see.
+OPEN_EDGED_PATTERN = re.compile(r'(gate[A-Z]\w*)')
+
+# One canonical sample per pattern that reads a Go identifier: the line it is read from, with a
+# `%s` where the name sits, and the name. The probe glues a rune Go refuses to one side of the
+# name and then the other, so the sample has to put the name where the pattern expects it and
+# nothing else about the line may be off the shape.
+GO_IDENTIFIER_SAMPLES = {
+    'STEP_DEFINITION': ('func %s() {}', 'stepOne'),
+    'TEST_HEADER': ('func %s(t *testing.T) {', 'TestOne'),
+    'TEST_FUNCTION': ('\tfunc %s(t *testing.T) {', 'TestOne'),
+    'GO_RUN_DECLARATION': ('func %s(t *testing.T, cases []Case, build func()) {', 'RunSolid'),
+    'STEP_NAME_CLAIM': ('The step builds the profile with `%s`.', 'stepOne'),
+    'PROOF_RUN_MENTION': ('\tproofkit3d.%s(t, profileCases, stepOne)', 'RunSolid'),
+    'proof_run_shape': ('\tproofkit.Run(t, profileCases, %s)', 'stepOne'),
+}
+
+# The patterns that need no edge at all, with the reason each one does not. `fullmatch` makes the
+# whole subject the name, so there is no neighbour to glue anything to. The claim is checked
+# against the scan rather than taken on trust: an entry here whose pattern is used through
+# anything else is a pattern nobody is probing.
+GO_IDENTIFIER_WHOLE_SUBJECT = {
+    'STEP_NAME': 'the build argument a registration passed, tested whole against the step '
+                 'naming rule',
+}
+
+
+class GoIdentifierEdgeTest(unittest.TestCase):
+    """A pattern that reads a Go identifier must refuse a name with a refused rune glued to it.
+
+    `GoPatternClassTest` above reads the character classes a pattern spells, and the defect this
+    class exists for spells none: `STEP_NAME_CLAIM` had no right-edge assertion at all, so the
+    match stopped at the first rune outside the identifier class and handed back the valid prefix.
+    A missing assertion is nothing for a scan of written classes to see, so this is the
+    behavioural half of the same rule.
+
+    Every pattern in the registry gets its canonical sample with one refused rune glued to the
+    left of the name, and again to the right, and must match neither. Which patterns those are is
+    enumerated from the checker rather than listed by hand, so a new pattern that reads a name
+    fails here until someone gives it a sample or writes down why the whole subject is the name.
+
+    Suppressing rather than truncating is what a credit-granting match needs, and truncation is
+    what the other patterns are already safe from by accident: each is closed by a required
+    character such as `(` or `.` that a refused rune displaces. Their edges are checked here too,
+    because that safety is a property of how they happen to be written and nothing was holding it.
+    """
+
+    # The rune the probe glues on. `GoIdentifierClassTest` holds the checker's classes against
+    # Go's own tables and `go_proof_verdict` shows the toolchain refusing a proof carrying this
+    # one, so what makes it the right probe is checked in three places rather than asserted here.
+    GLUED = '²'
+
+    def registry(self):
+        return go_identifier_patterns(COMPILE_CHECKER_PATH.read_text())
+
+    def pattern_for(self, name):
+        """The compiled pattern a registry entry names.
+
+        Most are module constants. The registration shape is not: it is derived from the harness
+        sources, so it is reached through the accessor that builds it.
+        """
+        found = getattr(COMPILE_CHECKER, name, None)
+        if isinstance(found, re.Pattern):
+            return found
+        if name == 'proof_run_shape':
+            return COMPILE_CHECKER.proof_run_shapes().shape
+        self.fail('%s is in the registry but this test cannot reach the pattern it compiles'
+                  % name)
+
+    def edges(self, pattern, template, name):
+        """Whether the pattern still matches with the refused rune glued to each side of `name`."""
+        return tuple(bool(pattern.search(template % glued))
+                     for glued in (self.GLUED + name, name + self.GLUED))
+
+    def test_every_pattern_that_reads_a_go_identifier_is_probed_or_classified(self):
+        """The registry is the checker's, so a new name reader cannot arrive unexamined."""
+        registry = self.registry()
+
+        self.assertEqual(sorted(registry),
+                         sorted(set(GO_IDENTIFIER_SAMPLES) | set(GO_IDENTIFIER_WHOLE_SUBJECT)))
+        for name, reason in sorted(GO_IDENTIFIER_WHOLE_SUBJECT.items()):
+            with self.subTest(name=name, reason=reason):
+                self.assertEqual(registry[name].methods, frozenset(('fullmatch',)))
+
+    def test_only_the_claim_pattern_is_written_from_the_credit_side_edges(self):
+        """`GO_TOKENS` says the wider pair belongs to the one match that grants credit.
+
+        That sentence is a rule about which pattern may take which edge, and a rule nothing checks
+        is one the next pattern can quietly break, so the count is held here.
+        """
+        written = sorted(name for name, use in self.registry().items()
+                         if '%(no_word_left)s' in use.written
+                         or '%(no_word_right)s' in use.written)
+
+        self.assertEqual(written, ['STEP_NAME_CLAIM'])
+
+    def test_a_refused_rune_glued_to_a_name_suppresses_the_match(self):
+        """The property itself, on both edges of every pattern that reads a name.
+
+        The sample matching is asserted first, because a probe whose sample never matched would
+        report both edges closed on a pattern it had not exercised at all.
+        """
+        for name, (template, identifier) in sorted(GO_IDENTIFIER_SAMPLES.items()):
+            with self.subTest(pattern=name):
+                pattern = self.pattern_for(name)
+
+                match = pattern.search(template % identifier)
+
+                self.assertIsNotNone(match, template % identifier)
+                self.assertIn(identifier, match.groups())
+                self.assertEqual(self.edges(pattern, template, identifier), (False, False))
+
+    def test_the_probe_sees_a_pattern_with_open_edges(self):
+        """The control. A probe that reported every pattern closed would prove nothing.
+
+        The invented pattern above asserts neither edge, which is the shape the defect had, and
+        the probe has to report both sides open.
+        """
+        self.assertEqual(self.edges(OPEN_EDGED_PATTERN, 'builds `%s` here', 'gateOne'),
+                         (True, True))
+
+    def test_the_glued_rune_is_a_word_character_go_refuses(self):
+        """The probe rests on Python and Go disagreeing about this rune, so state both halves."""
+        self.assertTrue(re.fullmatch(r'\w', self.GLUED))
+        self.assertIsNone(
+            re.compile(COMPILE_CHECKER.GO_IDENTIFIER_PART).fullmatch(self.GLUED))
 
 
 GO_UNICODE_TABLE_PROBE = (

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -1297,7 +1298,7 @@ class ProofRunArityDerivationTest(unittest.TestCase):
         nothing would look just as healthy. This pins what `proof/proofkit` and `proof/proofkit3d`
         declare today, so adding a run method or changing an arity fails here and gets reviewed.
         """
-        self.assertEqual(COMPILE_CHECKER.PROOF_RUN_ARGUMENTS, {
+        self.assertEqual(COMPILE_CHECKER.proof_run_shapes().arguments, {
             'proofkit.Run': 3,
             'proofkit3d.Run': 4,
             'proofkit3d.RunSolid': 4,
@@ -1318,7 +1319,16 @@ class ProofRunArityDerivationTest(unittest.TestCase):
             with self.subTest(parameters=parameters):
                 self.assertEqual(COMPILE_CHECKER.go_parameter_count(parameters), expected)
 
-    def test_arities_are_read_from_source_text_comments_excluded(self):
+    def test_arities_are_read_from_code_only_never_a_comment_or_a_literal(self):
+        """The declaration is read wherever it starts on its line, but only in code.
+
+        The derivation allows leading whitespace, because Go compiles and exports an indented
+        package-level declaration and nothing here runs gofmt. That width must not reach the two
+        places a `func` is text rather than a declaration, and both are written here: the doc
+        comment holds a whole indented signature, and the raw string holds one at column 1.
+        `strip_go_comments_and_literals` blanks each to spaces before the scan, so neither is
+        derived, and `RunTwice` and `RunQuoted` appearing in the table would say that broke.
+        """
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / 'harness.go'
             path.write_text(
@@ -1328,7 +1338,11 @@ class ProofRunArityDerivationTest(unittest.TestCase):
                 '//\tfunc RunTwice(t *testing.T, a, b, c, d Case) {}\n'
                 '//\n'
                 '// but it is not.\n'
+                'const usage = `\n'
+                'func RunQuoted(t *testing.T, a, b, c, d, e Case) {}\n'
+                '`\n\n'
                 'func Run(t *testing.T, cases []Case, build Build) {}\n\n'
+                '\tfunc RunSolid(t *testing.T, cases []Case, build Build, assert Assert) {}\n\n'
                 'func RunWithGate(t *testing.T, cases []Case, build Build, gate Gate,\n'
                 '\tassert Assert) {\n'
                 '}\n\n'
@@ -1336,7 +1350,8 @@ class ProofRunArityDerivationTest(unittest.TestCase):
 
             table = COMPILE_CHECKER.go_run_arities('harness', str(path))
 
-        self.assertEqual(table, {'harness.Run': 3, 'harness.RunWithGate': 5})
+        self.assertEqual(table,
+                         {'harness.Run': 3, 'harness.RunSolid': 4, 'harness.RunWithGate': 5})
 
     def test_both_run_patterns_are_built_from_the_derived_table(self):
         """Every derived method is read as a registration; no other pairing is read as one.
@@ -1344,17 +1359,18 @@ class ProofRunArityDerivationTest(unittest.TestCase):
         The mention pattern stays wider on purpose, so a call on a method no package declares —
         `proofkit.RunSolid` — is still seen and complained about rather than passing unnoticed.
         """
-        packages = sorted({method.split('.')[0] for method in COMPILE_CHECKER.PROOF_RUN_ARGUMENTS})
-        names = sorted({method.split('.')[1] for method in COMPILE_CHECKER.PROOF_RUN_ARGUMENTS})
+        runs = COMPILE_CHECKER.proof_run_shapes()
+        packages = sorted({method.split('.')[0] for method in runs.arguments})
+        names = sorted({method.split('.')[1] for method in runs.arguments})
         for package in packages:
             for name in names:
                 method = '%s.%s' % (package, name)
-                declared = COMPILE_CHECKER.PROOF_RUN_ARGUMENTS.get(method)
+                declared = COMPILE_CHECKER.proof_run_shapes().arguments.get(method)
                 arguments = ['t', 'profileCases', 'stepOne'] + ['assertOne'] * 2
                 line = '\t%s(%s)' % (method, ', '.join(arguments[:declared or 3]))
                 with self.subTest(method=method):
                     self.assertTrue(COMPILE_CHECKER.PROOF_RUN_MENTION.search(line))
-                    match = COMPILE_CHECKER.PROOF_RUN.match(line)
+                    match = runs.shape.match(line)
                     if declared is None:
                         self.assertIsNone(match)
                         continue
@@ -1363,9 +1379,15 @@ class ProofRunArityDerivationTest(unittest.TestCase):
                                      (method, declared))
 
 
-def harness_file(package, name='RunExtra'):
-    """One harness source declaring a single run method, for the named package."""
-    return b'package %s\n\nfunc %s(a, b, c int) {}\n' % (package.encode(), name.encode())
+def harness_file(package, name='RunExtra', indent=b''):
+    """One harness source declaring a single run method, for the named package.
+
+    `indent` is the whitespace in front of the declaration. Go's layout is free and nothing in
+    this repository holds the harness to `gofmt`, so an indented declaration is an ordinary file
+    the derivation has to read, not a malformed one.
+    """
+    return b'package %s\n\n%sfunc %s(a, b, c int) {}\n' % (package.encode(), indent,
+                                                          name.encode())
 
 
 def go_harness_verdict(name, source):
@@ -1448,6 +1470,14 @@ class HarnessSourceRuleTest(unittest.TestCase):
             ('a legacy constraint', 'runconstrained.go',
              b'// +build never\n\n' + body, 'ignored', 'error'),
             ('a NUL byte', 'runnul.go', body[:-1] + b'\x00\n', 'unreadable', 'error'),
+            # Go's layout is free, and `proof/run.sh` and both workflows run no gofmt, vet or
+            # lint, so nothing stops an indented declaration reaching the harness. Anchoring the
+            # derivation at column 1 lost the method while Go still compiled and exported it, and
+            # every registration on it was then reported as a call no harness package declares.
+            ('a tab-indented declaration', 'runindenttab.go',
+             harness_file('proofkit', indent=b'\t'), 'compiled', 'read'),
+            ('a space-indented declaration', 'runindentspaces.go',
+             harness_file('proofkit', indent=b'    '), 'compiled', 'read'),
         )
 
     def derive(self, name=None, source=None):
@@ -1586,8 +1616,153 @@ class HarnessSourceRuleTest(unittest.TestCase):
                 self.assertEqual(
                     {name for name in exported if name.startswith('Run')},
                     {method.split('.', 1)[1]
-                     for method in COMPILE_CHECKER.PROOF_RUN_ARGUMENTS
+                     for method in COMPILE_CHECKER.proof_run_shapes().arguments
                      if method.startswith('%s.' % package)})
+
+
+class BrokenHarnessExitCodeTest(unittest.TestCase):
+    """A harness this gate cannot read is a broken input: exit 2, named, and never a traceback.
+
+    The run table used to be derived at import, before `main` existed, so every raise from the
+    derivation killed the command with an uncaught traceback and exit 1. Exit 1 is this checker's
+    code for findings in the artifact under review, and the harness is not that artifact: sending
+    a reader to look for findings in a proof that has none, with a Python stack instead of a
+    message, is the wrong file and the wrong shape of answer. Exit 2 is the documented code for a
+    missing or broken input, and `main` already uses it for a usage error, a missing step list, a
+    step list with no steps and an unavailable API database.
+
+    Each case is run as a real subprocess, because the defect was in what the command does at
+    import and only a fresh process shows that.
+    """
+
+    SKILL_DIR = Path(__file__).parent
+
+    STEP_LIST = '## S1 `[PROSE]` Title\n\n**From:** `spec/gear/instructions.md` L1\n'
+
+    def harness_tree(self):
+        """A tree the checker reads as a repository, with a sound harness and one step list.
+
+        The skill directory is linked rather than copied, so the checker under test is this one
+        and not a stale copy. `check_compile.py` takes the repository root from its own path
+        without resolving links, so the link is what puts the harness below in its reach.
+        """
+        root = Path(tempfile.mkdtemp(prefix='harness-exit-'))
+        self.addCleanup(shutil.rmtree, str(root), True)
+        (root / '.claude' / 'skills').mkdir(parents=True)
+        (root / '.claude' / 'skills' / 'generate-gear').symlink_to(self.SKILL_DIR)
+        for package in COMPILE_CHECKER.PROOF_RUN_PACKAGES:
+            (root / 'proof' / package).mkdir(parents=True)
+            (root / 'proof' / package / ('%s.go' % package)).write_bytes(
+                harness_file(package, 'Run'))
+        (root / 'spec' / 'gear').mkdir(parents=True)
+        (root / 'spec' / 'gear' / 'steps.md').write_text(self.STEP_LIST)
+        return root
+
+    def check(self, root, *arguments):
+        return subprocess.run(
+            [sys.executable,
+             str(root / '.claude' / 'skills' / 'generate-gear' / 'check_compile.py')]
+            + list(arguments),
+            cwd=str(root), capture_output=True, text=True)
+
+    def assertNoTraceback(self, result):
+        self.assertNotIn('Traceback', result.stderr)
+        self.assertNotIn('Traceback', result.stdout)
+
+    def test_a_sound_harness_is_read_and_the_run_goes_on_to_the_artifact(self):
+        """The control. Without it every case below would pass on a checker that always exits 2.
+
+        The exit code is not pinned, because what the run finds past the harness depends on
+        whether the Fusion API database is installed. What is pinned is that the harness was read:
+        the run got somewhere the harness never named, and it did not stop at the derivation.
+        """
+        result = self.check(self.harness_tree(), 'gear')
+
+        self.assertNoTraceback(result)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn('harness', result.stderr)
+        self.assertNotIn('run methods', result.stderr)
+
+    def test_a_harness_carrying_a_build_constraint_exits_two(self):
+        """Whether Go compiles a constrained file is settled outside it, so this is an input fault.
+
+        `//go:build linux` is the case that makes the point: on a linux builder Go does compile
+        the file, so skipping it would drop a method that exists and turn every sound registration
+        on it into a complaint about the proof.
+        """
+        root = self.harness_tree()
+        (root / 'proof' / 'proofkit' / 'runconstrained.go').write_bytes(
+            b'//go:build linux\n\n' + harness_file('proofkit'))
+
+        result = self.check(root, 'gear')
+
+        self.assertNoTraceback(result)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn('runconstrained.go:1 carries a build constraint', result.stderr)
+
+    def test_a_harness_go_will_not_read_exits_two(self):
+        root = self.harness_tree()
+        (root / 'proof' / 'proofkit' / 'runnul.go').write_bytes(
+            harness_file('proofkit')[:-1] + b'\x00\n')
+
+        result = self.check(root, 'gear')
+
+        self.assertNoTraceback(result)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn('is one Go will not read', result.stderr)
+        self.assertIn('holds a NUL byte', result.stderr)
+
+    @unittest.skipIf(getattr(os, 'geteuid', lambda: 1)() == 0,
+                     'root reads a mode 000 file, so there is nothing to refuse')
+    def test_a_harness_this_process_cannot_open_exits_two(self):
+        """The `OSError` path, and the reason catching `RuntimeError` alone leaves a hole.
+
+        Every other refusal here is the gate's own `RuntimeError`. A harness source at mode 000
+        raises `PermissionError` from `open()` instead, which is an `OSError`, and the operating
+        system's message says nothing about why this checker was reading the file, so `main` names
+        the harness itself.
+        """
+        root = self.harness_tree()
+        unreadable = root / 'proof' / 'proofkit' / 'proofkit.go'
+        unreadable.chmod(0o000)
+        self.addCleanup(unreadable.chmod, 0o644)
+
+        result = self.check(root, 'gear')
+
+        self.assertNoTraceback(result)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn('the harness sources under proof/proofkit, proof/proofkit3d cannot be read',
+                      result.stderr)
+        self.assertIn('Permission denied', result.stderr)
+
+    def test_a_missing_harness_exits_two(self):
+        root = self.harness_tree()
+        for package in COMPILE_CHECKER.PROOF_RUN_PACKAGES:
+            shutil.rmtree(str(root / 'proof' / package))
+
+        result = self.check(root, 'gear')
+
+        self.assertNoTraceback(result)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn('no proof run methods found under proof/proofkit, proof/proofkit3d',
+                      result.stderr)
+
+    def test_the_usage_message_survives_a_broken_harness(self):
+        """Reading the harness at import ran it before the arguments were looked at.
+
+        With a harness the gate refuses, `check_compile.py` with no arguments printed a Python
+        stack instead of the one line that says how to call it.
+        """
+        root = self.harness_tree()
+        (root / 'proof' / 'proofkit' / 'runconstrained.go').write_bytes(
+            b'//go:build linux\n\n' + harness_file('proofkit'))
+
+        result = self.check(root)
+
+        self.assertNoTraceback(result)
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn('usage: check_compile.py <gear>', result.stderr)
+        self.assertNotIn('build constraint', result.stderr)
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -55,13 +55,7 @@ class CheckCompileTest(unittest.TestCase):
                     paths = (*paths[:-1], 'spec/gear/trace.md', paths[-1])
                 provenance = self.provenance_rows(root, paths)
             if proof_body is None:
-                proof_body = (
-                    'func TestOne(t *testing.T) {\n'
-                    '    proofkit.Run(t, cases(\n'
-                    '        gear{name: "one"},\n'
-                    '    ), stepOne)\n'
-                    '}\n\n'
-                    'func stepOne() {}\n')
+                proof_body = self.registration('TestOne', 'proofkit.Run', 'stepOne')
             (root / 'proof' / 'gear' / proof_filename).write_text(proof_body)
             table = '\n'.join((
                 '| Source | Blob hash |',
@@ -97,222 +91,291 @@ class CheckCompileTest(unittest.TestCase):
                 os.chdir(prior)
             return result, output.getvalue()
 
-    def solid_proof(self, run_call):
-        """A proof whose 2D run is in order and whose solid run is run_call."""
+    def registration(self, test, call, build, cases='profileCases', extra=''):
+        """The canonical three-line registration, plus the step definition it names.
+
+        Every argument is a knob a test turns to step one way off the shape, so a fixture that
+        only differs in the build argument reads as exactly that difference.
+        """
+        return (
+            'func %s(t *testing.T) {\n'
+            '\t%s(t, %s, %s%s)\n'
+            '}\n\n'
+            'func stepOne() {}\n' % (test, call, cases, build, extra))
+
+    def body(self, statements, test='TestTwo'):
+        """A proof whose first registration is canonical and whose second Test is `statements`."""
         return (
             'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
             '}\n\n'
-            'func TestSolid(t *testing.T) {\n'
-            '    %s\n'
+            'func %s(t *testing.T) {\n'
+            '%s\n'
             '}\n\n'
-            'func stepOne() {}\n' % run_call)
+            'func stepOne() {}\n' % (test, statements))
 
-    def test_step_named_build_argument_is_accepted(self):
-        proof_body = (
-            'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
-            '}\n\n'
-            'func TestSolid(t *testing.T) {\n'
-            '    proofkit3d.Run(t, solidCases, stepOne, assertSolid)\n'
-            '}\n\n'
-            'func stepOne() {}\n')
+    # The canonical shape, in each of the four run forms.
 
-        result, output = self.run_checker(proof_body=proof_body)
+    def test_canonical_2d_registration_is_accepted(self):
+        result, output = self.run_checker()
 
         self.assertEqual(result, 0, output)
         self.assertIn('compile check: OK', output)
 
+    def test_canonical_3d_registrations_are_accepted(self):
+        for call, extra in (('proofkit3d.Run', ', assertOne'),
+                            ('proofkit3d.RunSolid', ', assertOne'),
+                            ('proofkit3d.RunWithGate', ', proofkit3d.RequireSolid, assertOne')):
+            with self.subTest(call=call):
+                proof_body = self.registration('TestOne', call, 'stepOne', extra=extra)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 0, output)
+                self.assertIn('compile check: OK', output)
+
+    def test_gofmt_spacing_is_not_required(self):
+        """The shape is matched by line, not by byte, so spacing inside the call is free."""
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '    proofkit . Run( t ,  profileCases ,  stepOne )\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+
+    # The build argument must be the step of the Test's own title.
+
     def test_misnamed_build_argument_is_blocking(self):
-        proof_body = self.solid_proof(
-            'proofkit3d.Run(t, solidCases, buildSolid, assertSolid)')
+        proof_body = self.body('\tproofkit3d.Run(t, solidCases, buildSolid, assertSolid)')
 
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'proof/gear/proof_test.go registers buildSolid as a proof run\'s build argument, '
+            'proof/gear/proof_test.go:6 registers buildSolid as a proof run\'s build argument, '
             'but that argument must be a step<Title> function so a step can claim it', output)
 
-    def test_misnamed_build_argument_in_run_solid_is_blocking(self):
-        proof_body = self.solid_proof(
-            'proofkit3d.RunSolid(t, solidCases, buildSolid, assertSolid)')
-
-        result, output = self.run_checker(proof_body=proof_body)
-
-        self.assertEqual(result, 1)
-        self.assertIn('registers buildSolid as a proof run\'s build argument', output)
-
-    def test_misnamed_build_argument_in_run_with_gate_is_blocking(self):
-        proof_body = self.solid_proof(
-            'proofkit3d.RunWithGate(t, solidCases, buildSolid, proofkit3d.RequireSolid, '
-            'assertSolid)')
-
-        result, output = self.run_checker(proof_body=proof_body)
-
-        self.assertEqual(result, 1)
-        self.assertIn('registers buildSolid as a proof run\'s build argument', output)
-
-    def test_misnamed_2d_build_argument_is_blocking(self):
+    def test_crossed_registration_is_blocking(self):
+        """A Test that builds with some other step is the failure name-matching exists to catch."""
         proof_body = (
             'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\tproofkit.Run(t, profileCases, stepTwo)\n'
             '}\n\n'
-            'func TestTwo(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "two"}), buildProfile)\n'
-            '}\n\n'
-            'func stepOne() {}\n')
-
-        result, output = self.run_checker(proof_body=proof_body)
-
-        self.assertEqual(result, 1)
-        self.assertIn('registers buildProfile as a proof run\'s build argument', output)
-
-    def test_one_misnamed_build_is_reported_once_per_file(self):
-        proof_body = (
-            'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
-            '}\n\n'
-            'func TestSolid(t *testing.T) {\n'
-            '    proofkit3d.Run(t, solidCases, buildSolid, assertSolid)\n'
-            '}\n\n'
-            'func TestBore(t *testing.T) {\n'
-            '    proofkit3d.RunSolid(t, boreCases, buildSolid, assertSolid)\n'
-            '}\n\n'
-            'func stepOne() {}\n')
-
-        result, output = self.run_checker(proof_body=proof_body)
-
-        self.assertEqual(result, 1)
-        self.assertEqual(output.count('registers buildSolid'), 1)
-
-    def test_unreachable_misnamed_build_argument_is_not_counted(self):
-        proof_body = self.solid_proof(
-            'if false {\n'
-            '        proofkit3d.RunSolid(t, solidCases, buildSolid, assertSolid)\n'
-            '    }')
-
-        result, output = self.run_checker(proof_body=proof_body)
-
-        self.assertEqual(result, 0, output)
-        self.assertNotIn('buildSolid', output)
-
-    def test_early_returned_misnamed_build_argument_is_not_counted(self):
-        proof_body = self.solid_proof(
-            'if t != nil { return }\n'
-            '    proofkit3d.Run(t, solidCases, buildSolid, assertSolid)')
-
-        result, output = self.run_checker(proof_body=proof_body)
-
-        self.assertEqual(result, 0, output)
-        self.assertNotIn('buildSolid', output)
-
-    def test_assertion_and_gate_arguments_are_not_step_functions(self):
-        src = (
-            'func TestSolid(t *testing.T) {\n'
-            '    proofkit3d.RunWithGate(t, solidCases, stepSolid, proofkit3d.RequireSolid, '
-            'assertSolid)\n'
-            '}\n')
-
-        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
-
-        self.assertEqual(registered, {'stepSolid'})
-        self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, [])
-
-    def test_build_argument_expression_is_labelled_on_one_line(self):
-        src = (
-            'func TestSolid(t *testing.T) {\n'
-            '    proofkit3d.Run(t, solidCases, func(t *testing.T) []*decad.Body {\n'
-            '        return nil\n'
-            '    }, assertSolid)\n'
-            '}\n')
-
-        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
-
-        self.assertEqual(registered, set())
-        self.assertEqual(unreadable, [])
-        self.assertEqual(len(misnamed), 1)
-        self.assertNotIn('\n', misnamed[0])
-        self.assertTrue(misnamed[0].startswith('func(t *testing.T) []*decad.Body {'))
-
-    # A run whose argument list the parse cannot read to the build slot is reported, because
-    # such a run can compile: Go lets one multi-value call supply a whole argument list, so
-    # proofkit3d.Run(runArgs(t)) vets clean and still parses to a single argument here.
-    # Skipping it silently would let its build argument escape the step<Title> check.
-
-    def test_multi_value_forwarded_run_is_blocking(self):
-        proof_body = self.solid_proof('proofkit3d.Run(runArgs(t))')
+            'func stepOne() {}\n\n'
+            'func stepTwo() {}\n')
 
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
         self.assertIn(
-            'proof/gear/proof_test.go runs proofkit3d.Run(runArgs(t)), whose arguments could '
-            'not be read, so its build argument cannot be checked', output)
+            'proof/gear/proof_test.go:2 registers stepTwo inside TestOne, but a step is '
+            'registered by the Test of its own title, so this build belongs in TestTwo', output)
 
-    def test_multi_value_forwarded_2d_run_is_blocking(self):
+    def test_step_the_matching_test_does_not_build_is_blocking(self):
         proof_body = (
             'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
             '}\n\n'
-            'func TestTwo(t *testing.T) {\n'
-            '    proofkit.Run(runArgs(t))\n'
+            'func stepOne() {}\n\n'
+            'func stepTwo() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof function stepTwo is not claimed by any step', output)
+
+    def test_claimed_step_with_no_registration_is_blocking(self):
+        proof_body = 'func stepOne() {}\n'
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'S1 names proof function stepOne, which TestOne does not build with', output)
+
+    # Everything off the shape is refused rather than read. These are the shapes that cost the
+    # brace-matching reader its rounds; here each one is one line of expected output.
+
+    def test_run_in_a_condition_is_refused(self):
+        proof_body = self.body(
+            '\tif solid {\n'
+            '\t\tproofkit3d.Run(t, solidCases, stepTwo, assertTwo)\n'
+            '\t}')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:7 runs a proof outside the shape this gate reads',
+                      output)
+
+    def test_run_in_a_loop_is_refused(self):
+        proof_body = self.body(
+            '\tfor _, c := range []struct{ n int }{{1}} {\n'
+            '\t\tproofkit3d.Run(t, solidCases, stepTwo, assertTwo)\n'
+            '\t}')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('runs a proof outside the shape this gate reads', output)
+
+    def test_run_in_a_closure_is_refused(self):
+        proof_body = self.body(
+            '\tt.Run("one", func(t *testing.T) {\n'
+            '\t\tproofkit3d.Run(t, solidCases, stepTwo, assertTwo)\n'
+            '\t})')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('runs a proof outside the shape this gate reads', output)
+
+    def test_forwarded_argument_list_is_refused(self):
+        proof_body = self.body('\tproofkit3d.Run(runArgs(t))')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:6 runs a proof outside the shape this gate reads, '
+                      'so its build argument cannot be checked', output)
+
+    def test_case_table_built_in_place_is_refused(self):
+        """The table is a named variable, so the run stays one line the gate can match."""
+        proof_body = self.body(
+            '\tproofkit.Run(t, cases(\n'
+            '\t\tgear{name: "two"},\n'
+            '\t), stepTwo)')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('runs a proof outside the shape this gate reads', output)
+
+    def test_extra_statement_in_the_test_body_is_refused(self):
+        proof_body = self.body(
+            '\tt.Parallel()\n'
+            '\tproofkit.Run(t, profileCases, stepTwo)')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('runs a proof outside the shape this gate reads', output)
+
+    def test_run_outside_any_test_is_refused(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func register(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepTwo)\n'
             '}\n\n'
             'func stepOne() {}\n')
 
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
-        self.assertIn('runs proofkit.Run(runArgs(t)), whose arguments could not be read', output)
+        self.assertIn('proof/gear/proof_test.go:6 runs a proof outside the shape this gate reads',
+                      output)
 
-    def test_unclosed_run_call_is_reported_not_dropped(self):
-        """The argument list that never closes is reported too.
+    def test_test_name_go_would_not_run_is_refused(self):
+        """`go test` runs Test followed by a non-lower rune, and this gate never has to know that.
 
-        No Go source reaches this through the checker: a Test body is only read when its
-        delimiters nest, which already gives every open paren inside it a close. The branch
-        stays as the parse's own guard, and this test holds it to reporting rather than
-        skipping by making the paren lookup fail.
+        It looks for the title it expects instead of classifying the name it finds, so a name Go
+        rejects simply fails to be a registration and its run is reported.
         """
-        src = (
-            'func TestSolid(t *testing.T) {\n'
-            '    proofkit3d.Run(t, solidCases, stepSolid, assertSolid)\n'
-            '}\n')
-        real_match = COMPILE_CHECKER.matching_delimiter
-
-        def no_close_paren(text, start):
-            return None if text[start] == '(' else real_match(text, start)
-
-        with mock.patch.object(COMPILE_CHECKER, 'matching_delimiter', no_close_paren):
-            registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
-
-        self.assertEqual(registered, set())
-        self.assertEqual(misnamed, [])
-        self.assertEqual(len(unreadable), 1)
-        self.assertTrue(unreadable[0].startswith('proofkit3d.Run(t, solidCases, stepSolid'))
-
-    def test_unreachable_unreadable_run_is_not_counted(self):
-        proof_body = self.solid_proof(
-            'if false {\n'
-            '        proofkit3d.Run(runArgs(t))\n'
-            '    }')
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func Testé(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepTwo)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
 
         result, output = self.run_checker(proof_body=proof_body)
 
-        self.assertEqual(result, 0, output)
-        self.assertNotIn('could not be read', output)
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:6 runs a proof outside the shape this gate reads',
+                      output)
 
-    def test_short_argument_list_is_reported_not_registered(self):
-        src = (
-            'func TestSolid(t *testing.T) {\n'
-            '    proofkit3d.Run(runArgs(t))\n'
-            '}\n')
+    # Comments and literals are blanked first, so a quoted registration is not a real one.
 
-        registered, misnamed, unreadable = COMPILE_CHECKER.registered_step_functions(src)
+    def test_registration_inside_a_comment_does_not_count(self):
+        proof_body = (
+            '/*\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n'
+            '*/\n\n'
+            'func stepOne() {}\n')
 
-        self.assertEqual(registered, set())
-        self.assertEqual(misnamed, [])
-        self.assertEqual(unreadable, ['proofkit3d.Run(runArgs(t))'])
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'S1 names proof function stepOne, which TestOne does not build with', output)
+
+    def test_registration_inside_a_raw_string_does_not_count(self):
+        proof_body = (
+            'var sample = `\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n'
+            '`\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'S1 names proof function stepOne, which TestOne does not build with', output)
+
+    # Two rules Go owns that no reader of source text can infer, refused rather than copied.
+
+    def test_build_constraint_is_blocking(self):
+        proof_body = (
+            '//go:build ignore\n\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'proof/gear/proof_test.go:1 carries a build constraint, so whether Go ever compiles '
+            'these registrations is decided outside the file', output)
+
+    def test_registration_outside_a_test_file_is_blocking(self):
+        result, output = self.run_checker(proof_filename='proof.go')
+
+        self.assertEqual(result, 1)
+        self.assertIn(
+            'proof/gear/proof.go:2 registers stepOne, but `go test` only runs tests in a '
+            '_test.go file, so nothing here ever builds it', output)
+
+    def test_each_off_shape_run_is_reported_at_its_own_line(self):
+        proof_body = (
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func TestTwo(t *testing.T) {\n'
+            '\tproofkit3d.Run(runArgs(t))\n'
+            '}\n\n'
+            'func TestThree(t *testing.T) {\n'
+            '\tproofkit3d.RunSolid(runArgs(t))\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertIn('proof/gear/proof_test.go:6 runs a proof', output)
+        self.assertIn('proof/gear/proof_test.go:10 runs a proof', output)
 
 
 class CommittedStepListProofPathsTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Regression tests for the compile-stage gate."""
+import ast
+import collections
 import contextlib
 import importlib.util
 import inspect
@@ -11,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import unicodedata
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -147,6 +150,11 @@ GO_HEADER_CASES = (
 # reader got through, names the same two `invalid NUL character` and `invalid BOM in the middle of
 # the file`. Any of them means the file is not compiled, which is the only distinction that
 # matters here.
+#
+# A character Go's scanner will not start a token with is named the same way and is refused just
+# as completely, so it belongs in this list although no reader ever looked at the bytes: the
+# compiler says `invalid character U+000B` and `invalid character U+00A0 in identifier`, and
+# `go vet` says `illegal character U+000B` for the same file.
 GO_UNREADABLE_MESSAGES = (
     'illegal UTF-8 encoding',
     'invalid UTF-8 encoding',
@@ -156,6 +164,7 @@ GO_UNREADABLE_MESSAGES = (
     'illegal byte order mark',
     'invalid BOM in the middle of the file',
     'illegal character U+',
+    'invalid character U+',
 )
 
 
@@ -213,6 +222,10 @@ def go_verdicts(headers, body=b'package p\n\nfunc F() {}\n'):
         shutil.rmtree(root, ignore_errors=True)
 
 
+# Every code point, as one string, so a class can be read over the whole range in one pass.
+ALL_CODE_POINTS = ''.join(chr(code) for code in range(sys.maxunicode + 1))
+
+
 def foreign_goos():
     """A GOOS this machine is not, so a `_GOOS` suffix carrying it is genuinely unsatisfied."""
     for name in sorted(COMPILE_CHECKER.GO_KNOWN_OS):
@@ -220,6 +233,68 @@ def foreign_goos():
                 name, COMPILE_CHECKER.GOOS, COMPILE_CHECKER.GOARCH):
             return name
     raise AssertionError('every known GOOS matches this machine')
+
+
+# A vertical tab at each of the five positions inside a registration. Go's scanner skips space,
+# tab, carriage return and newline between tokens and nothing else, so every one of these files is
+# illegal where the tab sits: `go test` reports `illegal character U+000B` and `[setup failed]`,
+# and the package never builds. Python's `\s` matches U+000B, so the gate read all five as
+# ordinary separation and credited a registration Go never compiles.
+#
+# `ProofDeclarationColumnTest` says what Go does with each body and `CheckCompileTest` says what
+# the gate does about it, which is the split every rule on this boundary is recorded under.
+VERTICAL_TAB = '\x0b'
+
+REGISTRATION_WHITESPACE_CASES = (
+    ('after `func` in the Test header',
+     'func%sTestOne(t *testing.T) {\n'
+     '\tproofkit.Run(t, profileCases, stepOne)\n'
+     '}\n\n'
+     'func stepOne() {}\n' % VERTICAL_TAB),
+    ('after the header\'s opening brace',
+     'func TestOne(t *testing.T) {%s\n'
+     '\tproofkit.Run(t, profileCases, stepOne)\n'
+     '}\n\n'
+     'func stepOne() {}\n' % VERTICAL_TAB),
+    ('inside the run call',
+     'func TestOne(t *testing.T) {\n'
+     '\tproofkit.Run(t, profileCases,%sstepOne)\n'
+     '}\n\n'
+     'func stepOne() {}\n' % VERTICAL_TAB),
+    ('after the run\'s closing parenthesis',
+     'func TestOne(t *testing.T) {\n'
+     '\tproofkit.Run(t, profileCases, stepOne)%s\n'
+     '}\n\n'
+     'func stepOne() {}\n' % VERTICAL_TAB),
+    ('after the closing brace',
+     'func TestOne(t *testing.T) {\n'
+     '\tproofkit.Run(t, profileCases, stepOne)\n'
+     '}%s\n\n'
+     'func stepOne() {}\n' % VERTICAL_TAB),
+)
+
+# A name carrying a Unicode letter, which Go's identifier rule allows and this gate must read.
+# Tightening the patterns to Go is about refusing what Go refuses, and a proof that compiles,
+# registers and runs under `go test` has to stay credited.
+GO_LETTER_STEP = 'Prüfung'
+
+GO_LETTER_PROOF = (
+    'func Test%(title)s(t *testing.T) {\n'
+    '\tproofkit.Run(t, profileCases, step%(title)s)\n'
+    '}\n\n'
+    'func step%(title)s() {}\n' % {'title': GO_LETTER_STEP})
+
+# A name carrying U+00B2, which Python counts as a word character and Go refuses outright:
+# `invalid character U+00B2 in identifier` from the compiler, `illegal character U+00B2` from
+# `go test`. The step list and the proof agreed with each other about this name because both
+# sides read it with Python's `\w`, and the registration was credited.
+NON_GO_STEP = 'One\u00b2'
+
+NON_GO_PROOF = (
+    'func Test%(title)s(t *testing.T) {\n'
+    '\tproofkit.Run(t, profileCases, step%(title)s)\n'
+    '}\n\n'
+    'func step%(title)s() {}\n' % {'title': NON_GO_STEP})
 
 
 class CheckCompileTest(unittest.TestCase):
@@ -1238,6 +1313,76 @@ class CheckCompileTest(unittest.TestCase):
                 self.assertIn('S1 names proof function stepOne, which proof/gear/ does not '
                               'declare as a function', output)
 
+    def test_whitespace_go_refuses_inside_a_registration_is_never_credited(self):
+        """Every gap in the three lines is Go's separation set, not Python's `\\s`.
+
+        A vertical tab at any of these five positions makes the file illegal where it sits, so
+        `go test` reports `[setup failed]` and the registration never builds. The gate read all
+        five as separation, printed `compile check: OK` at exit 0 and credited the step.
+
+        What the complaint says depends on which line stopped matching, so the assertion is the
+        one thing that must hold at every position: the run is not credited and the gate blocks.
+        """
+        for position, proof_body in REGISTRATION_WHITESPACE_CASES:
+            with self.subTest(position=position):
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 1, output)
+                self.assertNotIn('compile check: OK', output)
+
+    def test_a_step_name_go_cannot_have_is_never_credited(self):
+        """The step list and the proof agreeing with each other is not the question.
+
+        Both sides read the name with Python's `\\w`, so a U+00B2 suffix written into both matched
+        both and the gate credited the step, while `go test` reported `illegal character U+00B2`.
+        The name is a Go identifier wherever it is written, so a name Go cannot have is one no
+        proof declares and no step claims.
+        """
+        step_body = ('## S1 `[GO]` One — `step%s`\n\n'
+                     'Build the thing.\n\n'
+                     '**From:** `spec/gear/instructions.md` L1\n\n' % NON_GO_STEP)
+
+        result, output = self.run_checker(proof_body=NON_GO_PROOF, step_body=step_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertNotIn('compile check: OK', output)
+        self.assertIn('proof/gear/ does not declare as a function', output)
+
+    def test_a_unicode_letter_in_a_step_name_is_still_read(self):
+        """Go identifiers include Unicode letters, so tightening must not refuse one.
+
+        This proof compiles, registers and runs under `go test`, which
+        `ProofDeclarationColumnTest` checks with the toolchain. A gate that read only ASCII names
+        would report a step the proof does declare as one it does not.
+        """
+        step_body = ('## S1 `[GO]` One — `step%s`\n\n'
+                     'Build the thing.\n\n'
+                     '**From:** `spec/gear/instructions.md` L1\n\n' % GO_LETTER_STEP)
+
+        result, output = self.run_checker(proof_body=GO_LETTER_PROOF, step_body=step_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_a_mention_is_not_silenced_by_a_neighbouring_character_go_refuses(self):
+        """`PROOF_RUN_MENTION` is the only thing that sees a run on a method nothing declares.
+
+        Its left edge was `\\b`, which is defined by Python's `\\w`: a preceding U+00B2 counts to
+        Python as part of a word and to Go does not, so the mention went silent and the
+        undeclared method was never named. That is this pattern failing in the opposite direction
+        from the rest, and the edge is written as Go's own rather than dropped — a preceding Go
+        identifier rune still suppresses it, because there the text is one longer name.
+        """
+        self.assertTrue(COMPILE_CHECKER.PROOF_RUN_MENTION.search('\u00b2proofkit3d.RunTypa('))
+        self.assertIsNone(COMPILE_CHECKER.PROOF_RUN_MENTION.search('xproofkit3d.RunTypa('))
+
+        proof_body = self.body('\tvar n = \u00b2proofkit3d.RunTypa(t, profileCases, stepOne)')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('calls proofkit3d.RunTypa, which no harness package declares', output)
+
     def test_a_quoted_step_definition_is_still_not_a_definition(self):
         """Accepting leading whitespace must not turn a `func` in a comment or a string into one.
 
@@ -1319,6 +1464,19 @@ class CheckCompileTest(unittest.TestCase):
         self.assertIn('The header and the closing `}` each', contract)
         self.assertIn('start at column 1', contract)
         self.assertIn('The step function is not part of', contract)
+
+    def test_the_drafting_contract_states_the_separation_and_names_go_reads(self):
+        """The gate reads a proof under Go's rules, so the contract says which those are.
+
+        A file carrying whitespace or a name Go's scanner refuses builds nothing, and what the
+        gate says about it names the missing step or the unread run rather than the character.
+        The contract is where the drafter finds out what that means.
+        """
+        contract = (Path(__file__).parents[3] / '.claude' / 'skills' / 'compile-gear'
+                    / 'SKILL.md').read_text(encoding='utf-8')
+
+        self.assertIn('Between two tokens Go skips', contract)
+        self.assertIn('a name is a Unicode letter or `_`', contract)
 
     def test_each_pattern_answers_the_column_question_as_its_site_says(self):
         """The four decisions, pinned on the patterns themselves.
@@ -1409,12 +1567,12 @@ PROOF_PROBE_HARNESS = ('package proofkit\n\n'
                        '}\n')
 
 
-def go_proof_verdict(body):
+def go_proof_verdict(body, test='TestOne'):
     """What the Go toolchain does with one proof file body.
 
-    Returns `(compiled, ran)`: whether `go test` builds the package at all, and whether it ran a
-    test named `TestOne`. The two are separate questions — a file can compile while its Test never
-    runs, which is what a header Go does not recognise as a test looks like.
+    Returns `(compiled, ran)`: whether `go test` builds the package at all, and whether it ran the
+    named test. The two are separate questions — a file can compile while its Test never runs,
+    which is what a header Go does not recognise as a test looks like.
 
     The package is shaped like a real proof: an external `gear_test` package importing a `proofkit`
     stub, so `body` is the same text the gate is given.
@@ -1430,9 +1588,9 @@ def go_proof_verdict(body):
             'package gear_test\n\n'
             'import (\n\t"testing"\n\n\t"proofprobe/proofkit"\n)\n\n'
             'var profileCases = []int{1}\n\n' + body)
-        run = subprocess.run(['go', 'test', '-v', '-run', 'TestOne', './gear'],
+        run = subprocess.run(['go', 'test', '-v', '-run', test, './gear'],
                              cwd=root, capture_output=True, text=True)
-        return run.returncode == 0, '--- PASS: TestOne' in run.stdout
+        return run.returncode == 0, '--- PASS: %s' % test in run.stdout
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
@@ -1505,6 +1663,352 @@ class ProofDeclarationColumnTest(unittest.TestCase):
         for name, body, compiled, ran in self.CASES:
             with self.subTest(case=name):
                 self.assertEqual(go_proof_verdict(body), (compiled, ran))
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
+    def test_go_refuses_a_vertical_tab_at_every_position_in_a_registration(self):
+        """The Go half of `REGISTRATION_WHITESPACE_CASES`, which the gate half rests on.
+
+        Between two tokens Go skips space, tab, carriage return and newline and nothing else, so
+        each of these files is illegal where the vertical tab sits and neither compiles nor runs.
+        """
+        for position, body in REGISTRATION_WHITESPACE_CASES:
+            with self.subTest(position=position):
+                self.assertEqual(go_proof_verdict(body), (False, False))
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
+    def test_go_compiles_and_runs_a_name_carrying_a_unicode_letter(self):
+        """The accept direction, read from Go rather than assumed.
+
+        Go's identifiers are a Unicode letter or `_` and then letters, decimal digits or `_`, so
+        this proof is an ordinary one that builds and runs. A gate narrowed to ASCII would report
+        a step the proof does declare as one it does not.
+        """
+        self.assertEqual(go_proof_verdict(GO_LETTER_PROOF, 'Test' + GO_LETTER_STEP), (True, True))
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
+    def test_go_refuses_a_name_carrying_a_character_outside_its_identifier_rule(self):
+        """U+00B2 is a word character to Python and not a letter or a digit to Go.
+
+        Written into a step name it makes the proof illegal, which is what the step list agreeing
+        with the proof about that name was hiding.
+        """
+        self.assertEqual(go_proof_verdict(NON_GO_PROOF, 'Test' + NON_GO_STEP), (False, False))
+
+
+# Every `re` entry point whose first argument is a pattern. `re.escape` is not one of them: it
+# takes text and hands back a pattern in which nothing is a class any more.
+RE_PATTERN_CALLS = frozenset(
+    ('compile', 'match', 'fullmatch', 'search', 'findall', 'finditer', 'sub', 'subn', 'split'))
+
+PYTHON_CHARACTER_CLASS = re.compile(r'\\[bBdDsSwW]')
+
+
+def pattern_literals(source):
+    """Every (line, text) string literal that reaches the pattern argument of an `re.*` call.
+
+    A pattern is rarely one literal written at its call site. It is built by `%` from constants
+    defined elsewhere, so a name is followed to what it was assigned, wherever in the module that
+    happened, and a name assigned in two places is followed to both. The looseness is the point:
+    a check meant to fail closed must not leave a hiding place one indirection away.
+
+    Only the pattern argument is read. The subject and the replacement are ordinary text, and a
+    character class written in either is a run of characters rather than a rule.
+
+    Adjacent literals are one constant by the time the parser is done, so a pattern written over
+    two lines arrives here as a single string reported at the line it starts on.
+    """
+    tree = ast.parse(source)
+    bindings = collections.defaultdict(list)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bindings[target.id].append(node.value)
+
+    found = set()
+
+    def visit(node, seen):
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                found.add((sub.lineno, sub.value))
+            elif isinstance(sub, ast.Name) and sub.id not in seen:
+                for value in bindings.get(sub.id, ()):
+                    visit(value, seen | {sub.id})
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if not (isinstance(function, ast.Attribute) and function.attr in RE_PATTERN_CALLS
+                and isinstance(function.value, ast.Name) and function.value.id == 're'):
+            continue
+        pattern = node.args[0] if node.args else next(
+            (keyword.value for keyword in node.keywords if keyword.arg == 'pattern'), None)
+        if pattern is not None:
+            visit(pattern, frozenset())
+    return found
+
+
+# Invented modules, not code from this repository. An illustration of a defect that is a live
+# string in the tree becomes a false target for whoever greps for it next, so these are written
+# to be wrong on purpose and exist nowhere else.
+LOOSE_PATTERN_MODULE = (
+    'import re\n'
+    '\n'
+    'HEADER = re.compile(r"^\\s*func\\s+(\\w+)")\n')
+
+HIDDEN_LOOSE_PATTERN_MODULE = (
+    'import re\n'
+    '\n'
+    'GAP = r"\\s*"\n'
+    'HEADER = re.compile(r"^%sfunc" % GAP)\n')
+
+STRICT_PATTERN_MODULE = (
+    'import re\n'
+    '\n'
+    'GAP = "[ \\t\\r]*"\n'
+    'HEADER = re.compile(r"^%sfunc%s[A-Z]" % (GAP, GAP))\n')
+
+CLASS_IN_THE_SUBJECT_MODULE = (
+    'import re\n'
+    '\n'
+    'NOTE = r"the \\s class is discussed here"\n'
+    'FOUND = re.findall(r"[ \\t]+", NOTE)\n')
+
+
+class GoPatternClassTest(unittest.TestCase):
+    """No pattern that reads Go source may spell a Python character class.
+
+    Go's scanner skips space, tab, carriage return and newline between tokens and nothing else,
+    and its identifiers are a Unicode letter or `_` then letters, decimal digits or `_`. Python's
+    `\\s` and `\\w` are both wider, so every pattern written with them read a file Go refuses as a
+    sound one and credited what it found. Fixing the patterns is the smaller half of that; this is
+    the half that keeps them fixed.
+
+    It fails closed. A literal reaching an `re.*` pattern argument is held to Go's rules unless it
+    is named below, so a new pattern carrying a class fails here until someone classifies it, and
+    classifying it means writing down why the text it matches is not Go.
+    """
+
+    # Patterns whose subject is Markdown. Go never reads a step list, a spec or a provenance
+    # table, so Python's classes are the right ones there and the wide reading is the intended
+    # one: prose is what these match.
+    MARKDOWN_PATTERNS = {
+        r'[\w./-]+\.(?:md|go|py|json|sh)':
+            'PATH_REF, a file path as a step list writes it',
+        r'(?<![\w./-])[\w./-]+\.md\b':
+            'DOCUMENT_REF, a Markdown document a spec names in prose',
+        r'`(%s):(\d+)(?:\s*[-\u2013]\s*(\d+))?`':
+            'INLINE_CITATION, the older `path:line` citation form in a From block',
+        r'\bL(\d+)(?:\s*[-\u2013]\s*(\d+))?\b':
+            'LINE_RANGE, an `L12-L20` range in a From block',
+        r'^##\s+(\S+)\s+`\[(GO|PROSE)\]`\s+(.*)$':
+            'steps_of, a step heading in the step list',
+        r'^\*\*From:\*\*(.*?)(?=\n\s*\n|\Z)':
+            'from_block, the From block under a step heading',
+        r'<!--\s*check-compile:\s*ignore\s+([^>]*?)-->':
+            'named_calls and named_call_shapes, an HTML comment waiving a named call',
+        r'(?<![\w./-])(?:proof|\.tmp)/[\w./-]+':
+            'proof_paths, a proof path named in the step-list summary',
+        r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|':
+            'stamped, a row of the provenance table',
+    }
+
+    # The two classes that say what a Go identifier rune is. They are written as `\w` with what
+    # Go refuses taken out, so the Python classes in them are the subtraction itself rather than a
+    # rule about Go being approximated. `GoIdentifierClassTest` holds both against Go's own tables.
+    GO_CLASS_DEFINITIONS = {
+        r'[^\W\d%s]': 'GO_IDENTIFIER_START, a word character that is neither a digit nor a '
+                      'numeral Go refuses',
+        r'[^\W%s]': 'GO_IDENTIFIER_PART, a word character that is not a numeral Go refuses',
+    }
+
+    def allowed(self):
+        allowed = dict(self.MARKDOWN_PATTERNS)
+        allowed.update(self.GO_CLASS_DEFINITIONS)
+        return allowed
+
+    def findings(self, source):
+        """Every pattern literal in `source` that carries a Python class and is not allowlisted."""
+        allowed = self.allowed()
+        return sorted(
+            (line, ''.join(sorted(set(PYTHON_CHARACTER_CLASS.findall(text)))), text)
+            for line, text in pattern_literals(source)
+            if PYTHON_CHARACTER_CLASS.search(text) and text not in allowed)
+
+    def checker_source(self):
+        return COMPILE_CHECKER_PATH.read_text()
+
+    def test_no_pattern_that_reads_go_source_spells_a_python_class(self):
+        """The gate itself, under its own rule."""
+        self.assertEqual(self.findings(self.checker_source()), [])
+
+    def test_every_allowlisted_pattern_is_still_written_in_the_checker(self):
+        """An allowlist entry for a pattern nobody kept is a waiver over nothing.
+
+        Left standing it would silently cover a future pattern that happened to be spelled the
+        same way, so an entry that no longer matches anything is a failure here.
+        """
+        carrying = {text for _, text in pattern_literals(self.checker_source())
+                    if PYTHON_CHARACTER_CLASS.search(text)}
+        for pattern, reason in sorted(self.allowed().items()):
+            with self.subTest(reason=reason):
+                self.assertIn(pattern, carrying)
+
+    def test_a_python_class_in_a_new_pattern_is_a_finding(self):
+        """The property the whole check exists for, on an invented pattern.
+
+        Nothing was added to the allowlist for it, and that is what makes it fail: the default
+        classification is Go-strict.
+        """
+        findings = self.findings(LOOSE_PATTERN_MODULE)
+
+        self.assertEqual(len(findings), 1, findings)
+        self.assertEqual(findings[0][1], r'\s\w')
+
+    def test_a_python_class_reached_through_a_constant_is_a_finding(self):
+        """A pattern is usually assembled from constants, so the check follows them.
+
+        Reading only the literal at the call site would leave every class one `%` away from
+        invisible, which is exactly how these patterns are written.
+        """
+        findings = self.findings(HIDDEN_LOOSE_PATTERN_MODULE)
+
+        self.assertEqual(len(findings), 1, findings)
+        self.assertEqual(findings[0][1], r'\s')
+
+    def test_a_go_strict_pattern_is_not_a_finding(self):
+        """The control. A check that failed on everything would prove nothing about the eleven."""
+        self.assertEqual(self.findings(STRICT_PATTERN_MODULE), [])
+
+    def test_a_class_written_in_the_subject_is_not_a_finding(self):
+        """Only the pattern argument is a rule. A class in the searched text is characters."""
+        self.assertEqual(self.findings(CLASS_IN_THE_SUBJECT_MODULE), [])
+
+
+GO_UNICODE_TABLE_PROBE = (
+    'package main\n'
+    '\n'
+    'import (\n'
+    '\t"fmt"\n'
+    '\t"unicode"\n'
+    ')\n'
+    '\n'
+    '// The two tables Go builds its identifier rule from, as ranges, under the Unicode\n'
+    '// release the toolchain was built against.\n'
+    'func main() {\n'
+    '\tfmt.Printf("version %s\\n", unicode.Version)\n'
+    '\temit("letter", unicode.IsLetter)\n'
+    '\temit("digit", unicode.IsDigit)\n'
+    '}\n'
+    '\n'
+    'func emit(label string, member func(rune) bool) {\n'
+    '\tstart := rune(-1)\n'
+    '\tfor r := rune(0); r <= 0x110000; r++ {\n'
+    '\t\tif r < 0x110000 && member(r) {\n'
+    '\t\t\tif start < 0 {\n'
+    '\t\t\t\tstart = r\n'
+    '\t\t\t}\n'
+    '\t\t\tcontinue\n'
+    '\t\t}\n'
+    '\t\tif start >= 0 {\n'
+    '\t\t\tfmt.Printf("%s %d %d\\n", label, start, r-1)\n'
+    '\t\t\tstart = -1\n'
+    '\t\t}\n'
+    '\t}\n'
+    '}\n')
+
+
+def go_unicode_tables():
+    """Go's Unicode release, and `unicode.IsLetter` and `unicode.IsDigit` as code point sets."""
+    root = Path(tempfile.mkdtemp(prefix='go-unicode-'))
+    try:
+        (root / 'go.mod').write_text('module unicodeprobe\n\ngo 1.21\n')
+        (root / 'main.go').write_text(GO_UNICODE_TABLE_PROBE)
+        run = subprocess.run(['go', 'run', '.'], cwd=root, capture_output=True, text=True)
+        if run.returncode != 0:
+            raise AssertionError(run.stderr)
+        tables = {'letter': set(), 'digit': set()}
+        version = None
+        for line in run.stdout.split('\n'):
+            if not line:
+                continue
+            fields = line.split()
+            if fields[0] == 'version':
+                version = fields[1]
+                continue
+            label, first, last = fields
+            tables[label].update(range(int(first), int(last) + 1))
+        return version, tables['letter'], tables['digit']
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+class GoIdentifierClassTest(unittest.TestCase):
+    """`GO_IDENTIFIER_START` and `GO_IDENTIFIER_PART` are Go's rule and not an approximation of it.
+
+    The classes are derived from Python's Unicode tables rather than typed out, so what has to be
+    checked is the derivation: that Python's letters and decimal digits are the same sets Go
+    builds its identifier rule from, and that the two classes read exactly those. A Python or a Go
+    release that moved either boundary fails here rather than in a proof nobody can explain.
+    """
+
+    def characters_matching(self, pattern):
+        """Every code point one class matches, in a single pass over the whole range."""
+        return {ord(character) for character in re.findall(pattern, ALL_CODE_POINTS)}
+
+    def test_the_classes_read_every_rune_gos_rule_allows_and_no_other(self):
+        letters = {code for code in range(sys.maxunicode + 1) if chr(code).isalpha()}
+        digits = {code for code in range(sys.maxunicode + 1) if chr(code).isdecimal()}
+
+        self.assertEqual(self.characters_matching(COMPILE_CHECKER.GO_IDENTIFIER_START),
+                         letters | {ord('_')})
+        self.assertEqual(self.characters_matching(COMPILE_CHECKER.GO_IDENTIFIER_PART),
+                         letters | digits | {ord('_')})
+
+    def test_the_characters_the_defect_turned_on_are_named_one_by_one(self):
+        """The set equality above is the rule; these are the runes the eleven sites read.
+
+        U+00B2, U+2160 and U+00BD are word characters to Python and neither letters nor decimal
+        digits to Go, which reports `invalid character U+00B2 in identifier`. The letters beside
+        them are the accept direction: Go identifiers are Unicode, and narrowing to ASCII would
+        refuse a proof that builds.
+        """
+        start = re.compile(COMPILE_CHECKER.GO_IDENTIFIER_START)
+        part = re.compile(COMPILE_CHECKER.GO_IDENTIFIER_PART)
+        for character in ('a', 'Z', '_', 'ü', 'Ω', '漢'):
+            with self.subTest(character=character):
+                self.assertTrue(start.fullmatch(character))
+                self.assertTrue(part.fullmatch(character))
+        for character in ('\u00b2', '\u2160', '\u00bd'):
+            with self.subTest(character=repr(character)):
+                self.assertIsNone(start.fullmatch(character))
+                self.assertIsNone(part.fullmatch(character))
+        for character in ('7', '\u0663'):
+            with self.subTest(character=repr(character)):
+                self.assertIsNone(start.fullmatch(character))
+                self.assertTrue(part.fullmatch(character))
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these tables')
+    def test_go_agrees_about_which_runes_are_letters_and_digits(self):
+        """The derivation rests on Python's tables being Go's, so Go is asked rather than trusted.
+
+        Go's spec writes an identifier as a Unicode letter or `_` then letters, Unicode decimal
+        digits or `_`, and the compiler reads those two tables through `unicode.IsLetter` and
+        `unicode.IsDigit`.
+
+        The two sides are separate Unicode releases that happen to agree, so the failure message
+        names both: a Python and a Go built against different releases genuinely disagree about a
+        handful of runes, and which of the two moved is the first thing to know.
+        """
+        go_version, go_letters, go_digits = go_unicode_tables()
+        releases = ('Go reads Unicode %s and this Python reads Unicode %s'
+                    % (go_version, unicodedata.unidata_version))
+
+        self.assertEqual({code for code in range(sys.maxunicode + 1) if chr(code).isalpha()},
+                         go_letters, releases)
+        self.assertEqual({code for code in range(sys.maxunicode + 1) if chr(code).isdecimal()},
+                         go_digits, releases)
 
 
 class GoFilenameRuleTest(unittest.TestCase):
@@ -1852,6 +2356,30 @@ class HarnessSourceRuleTest(unittest.TestCase):
                 except RuntimeError:
                     continue
                 self.assertNotIn('proofkit.RunExtra', table)
+
+    def test_a_run_declaration_behind_whitespace_go_refuses_is_not_derived(self):
+        """The gap between `func` and the name is Go's separation set, like the indent before it.
+
+        One vertical tab there made `go vet` report `invalid character U+000B` while the gate
+        still derived `RunExtra`, and every registration built on the method was then credited
+        against a harness Go cannot compile.
+        """
+        for character, name in (('\x0b', 'U+000B'), ('\x0c', 'U+000C'), ('\u00a0', 'U+00A0')):
+            with self.subTest(character=name):
+                source = (b'package proofkit\n\nfunc%sRunExtra(a, b, c int) {}\n'
+                          % character.encode())
+
+                self.assertNotIn('proofkit.RunExtra', self.derive('rungap.go', source))
+
+    @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
+    def test_go_refuses_a_harness_declaration_behind_whitespace_it_does_not_have(self):
+        """The Go half of the case above: the file is unreadable and the method uncallable."""
+        for character, name in (('\x0b', 'U+000B'), ('\x0c', 'U+000C'), ('\u00a0', 'U+00A0')):
+            with self.subTest(character=name):
+                source = (b'package proofkit\n\nfunc%sRunExtra(a, b, c int) {}\n'
+                          % character.encode())
+
+                self.assertEqual(go_harness_verdict('rungap.go', source), ('unreadable', False))
 
     @unittest.skipUnless(shutil.which('go'), 'the Go toolchain establishes these verdicts')
     def test_go_agrees_with_the_recorded_harness_verdicts(self):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -166,6 +166,64 @@ class CheckCompileTest(unittest.TestCase):
         self.assertIn(
             'S1 names proof function stepOne, which TestOne does not build with', output)
 
+    # Each run takes the arguments its own signature declares, and no others.
+
+    def test_wrong_argument_count_on_a_real_method_is_refused(self):
+        """A tail of any length credited calls Go cannot compile, on every one of the four runs.
+
+        `proofkit.Run` takes three arguments, `proofkit3d.Run` and `RunSolid` four, and
+        `RunWithGate` five. A shape that accepted three or more read a step as registered by a run
+        that never builds, which is the direction a compile gate must never fail in.
+        """
+        cases = (
+            ('proofkit.Run', ', assertOne', 4, 3),
+            ('proofkit.Run', ', proofkit3d.RequireSolid, assertOne', 5, 3),
+            ('proofkit3d.Run', '', 3, 4),
+            ('proofkit3d.Run', ', proofkit3d.RequireSolid, assertOne', 5, 4),
+            ('proofkit3d.RunSolid', '', 3, 4),
+            ('proofkit3d.RunWithGate', ', assertOne', 4, 5),
+            ('proofkit3d.RunWithGate', '', 3, 5),
+        )
+        for call, extra, passed, declared in cases:
+            with self.subTest(call=call, passed=passed):
+                proof_body = self.registration('TestOne', call, 'stepOne', extra=extra)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 1, output)
+                self.assertIn(
+                    'proof/gear/proof_test.go:2 passes %d arguments to %s, which takes %d, so Go '
+                    'cannot compile this registration' % (passed, call, declared), output)
+                self.assertIn(
+                    'S1 names proof function stepOne, which TestOne does not build with', output)
+
+    def test_declared_argument_count_on_each_method_is_accepted(self):
+        """The counts are the signatures in `proof/proofkit` and `proof/proofkit3d`."""
+        for call, extra in (('proofkit.Run', ''),
+                            ('proofkit3d.Run', ', assertOne'),
+                            ('proofkit3d.RunSolid', ', assertOne'),
+                            ('proofkit3d.RunWithGate', ', proofkit3d.RequireSolid, assertOne')):
+            with self.subTest(call=call):
+                proof_body = self.registration('TestOne', call, 'stepOne', extra=extra)
+
+                result, output = self.run_checker(proof_body=proof_body)
+
+                self.assertEqual(result, 0, output)
+                self.assertIn('compile check: OK', output)
+
+    def test_wrong_argument_count_is_named_once_at_its_own_line(self):
+        """A refused run is named exactly once, so the count complaint is the whole story.
+
+        The wider mention pattern still sees the line, so widening it further is safe; it is
+        skipped here only because the count complaint already names the same line.
+        """
+        proof_body = self.registration('TestOne', 'proofkit.Run', 'stepOne', extra=', assertOne')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output.count('proof/gear/proof_test.go:2'), 1, output)
+
     # The build argument must be the step of the Test's own title.
 
     def test_misnamed_build_argument_is_blocking(self):
@@ -381,6 +439,33 @@ class CheckCompileTest(unittest.TestCase):
             'var sample = `\n'
             '//go:build ignore\n'
             '`\n\n'
+            'func TestOne(t *testing.T) {\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
+            '}\n\n'
+            'func stepOne() {}\n')
+
+        result, output = self.run_checker(proof_body=proof_body)
+
+        self.assertEqual(result, 0, output)
+        self.assertIn('compile check: OK', output)
+
+    def test_build_constraint_text_inside_a_header_block_comment_is_accepted(self):
+        """Go takes a constraint only from a `//` line comment, so block-comment prose is text.
+
+        A file whose leading `/* */` note quotes a constraint builds, vets and formats clean, and
+        `go list` reports it unconstrained. Reading every raw header line refused it.
+        """
+        proof_body = (
+            '/*\n'
+            'Package gear_test proves the gear steps.\n'
+            '\n'
+            'A file that is not built would say\n'
+            '\n'
+            '\t//go:build ignore\n'
+            '\n'
+            'above its package clause. This proof is built, so it says no such thing.\n'
+            '*/\n'
+            'package gear_test\n\n'
             'func TestOne(t *testing.T) {\n'
             '\tproofkit.Run(t, profileCases, stepOne)\n'
             '}\n\n'

--- a/.claude/skills/generate-gear/test_check_step_calls.py
+++ b/.claude/skills/generate-gear/test_check_step_calls.py
@@ -492,9 +492,7 @@ class CheckCompileTest(unittest.TestCase):
             if proof_body is None:
                 proof_body = (
                     'func TestOne(t *testing.T) {\n'
-                    '    proofkit.Run(t, cases(\n'
-                    '        gear{name: "one"},\n'
-                    '    ), stepOne)\n'
+                    '\tproofkit.Run(t, profileCases, stepOne)\n'
                     '}\n\n'
                     'func stepOne() {}\n')
             (root / 'proof' / 'gear' / proof_filename).write_text(proof_body)
@@ -627,25 +625,20 @@ class CheckCompileTest(unittest.TestCase):
         self.assertIn('compile check: OK', output)
 
     def test_registration_in_non_test_go_file_is_rejected(self):
-        proof_body = (
-            'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
-            '}\n\n'
-            'func stepOne() {}\n')
-
-        result, output = self.run_checker(proof_body=proof_body, proof_filename='proof.go')
+        result, output = self.run_checker(proof_filename='proof.go')
 
         self.assertEqual(result, 1)
-        self.assertIn('stepOne, but no Go Test registers it', output)
+        self.assertIn('registers stepOne, but `go test` only runs tests in a _test.go file',
+                      output)
 
     def test_claimed_but_unregistered_proof_function_fails(self):
+        """A step whose Test does not exist fails, and a quoted registration does not save it."""
         proof_body = (
             'func TestOne(t *testing.T) {\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
-            '    _ = "proofkit.Run(t, cases, stepUnused)"\n'
-            '    // proofkit.Run(t, cases, stepUnused)\n'
-            '    _ = stepUnused\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
             '}\n\n'
+            'var sample = "proofkit.Run(t, profileCases, stepUnused)"\n\n'
+            '// proofkit.Run(t, profileCases, stepUnused)\n\n'
             'func stepOne() {}\n'
             'func stepUnused() {}\n')
         step_body = (
@@ -659,34 +652,41 @@ class CheckCompileTest(unittest.TestCase):
         result, output = self.run_checker(proof_body=proof_body, step_body=step_body)
 
         self.assertEqual(result, 1)
-        self.assertIn('S2 names proof function stepUnused, but no Go Test registers it', output)
+        self.assertIn('S2 names proof function stepUnused, which TestUnused does not build with',
+                      output)
 
     def test_early_returned_proof_registration_is_rejected(self):
         proof_body = (
             'func TestOne(t *testing.T) {\n'
-            '    if t != nil { return }\n'
-            '    proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
+            '\tif t != nil {\n'
+            '\t\treturn\n'
+            '\t}\n'
+            '\tproofkit.Run(t, profileCases, stepOne)\n'
             '}\n\n'
             'func stepOne() {}\n')
 
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
-        self.assertIn('stepOne, but no Go Test registers it', output)
+        self.assertIn('proof/gear/proof_test.go:5 runs a proof outside the shape this gate reads',
+                      output)
+        self.assertIn('S1 names proof function stepOne, which TestOne does not build with', output)
 
     def test_false_branch_proof_registration_is_rejected(self):
         proof_body = (
             'func TestOne(t *testing.T) {\n'
-            '    if false {\n'
-            '        proofkit.Run(t, cases(gear{name: "one"}), stepOne)\n'
-            '    }\n'
+            '\tif false {\n'
+            '\t\tproofkit.Run(t, profileCases, stepOne)\n'
+            '\t}\n'
             '}\n\n'
             'func stepOne() {}\n')
 
         result, output = self.run_checker(proof_body=proof_body)
 
         self.assertEqual(result, 1)
-        self.assertIn('stepOne, but no Go Test registers it', output)
+        self.assertIn('proof/gear/proof_test.go:3 runs a proof outside the shape this gate reads',
+                      output)
+        self.assertIn('S1 names proof function stepOne, which TestOne does not build with', output)
 
     def test_short_dotted_calls_are_compile_candidates(self):
         steps = 'Call `sketch.add()`, `sketch.set()`, and `safeCall()`.'


### PR DESCRIPTION
- Reading Go to find each run's build argument kept failing on shapes no proof contains.
- Fixing registration to one declared shape makes it readable by line, and refusable by line.
- Supersedes #36, which closed the same false passes by growing the Go reader.
