### PR TITLE
render drafting prompts from templates

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -58,8 +58,10 @@ proof is where the next reader is looking for the missing check.
    row in the step list's provenance table. Step 5 checks them. The playbook belongs there because
    steps cite its rules by anchor, so a playbook fix leaves every step list stale until it is recompiled.
 
-3. **Draft.** Spawn a subagent with the verbatim prompt in the appendix, substituting only
-   `<gear>`. It writes `.tmp/<gear>.steps.md` and the proof files under `.tmp/<gear>-proof/`. Do
+3. **Draft.** Spawn a subagent with the standard drafting prompt: run
+   `python3 .claude/skills/generate-gear/render_prompt.py compile-gear <gear>` and pass its
+   printed output to the subagent unchanged. It writes `.tmp/<gear>.steps.md` and the proof
+   files under `.tmp/<gear>-proof/`. Do
    **not** add per-gear hints, gotcha reminders or "high-risk" lists to that prompt. A hand-tuned
    prompt varies run to run and hides gaps by spoon-feeding what the prose should have said, so a
    green run would no longer say anything about the spec.
@@ -122,189 +124,13 @@ this skill: a compiler that rewrites its own source removes the thing being chec
   step list means the prose or this procedure is wrong.
 - Never add gear-specific guidance to the drafting prompt.
 
-## Standard drafting prompt (use verbatim — substitute only `<gear>`)
+## Standard drafting prompt
 
-> Compile the specification for `<gear>` into a step list and a runnable proof. Work in the repo
-> worktree. Write the step list to `.tmp/<gear>.steps.md`, and the proof, as one or more Go files,
-> to `.tmp/<gear>-proof/`.
->
-> **Read, in full, only these:** `spec/<gear>/instructions.md`, `spec/<gear>/fusion.md` if it
-> exists, every document those reference by name, `.claude/skills/generate-gear/PLAYBOOK.md`,
-> `proof/proofkit/` for the sketch harness API, `proof/proofkit3d/` for the solid harness API, and
-> `proof/involute/` for the involute tooth math the spur family shares, so you import it rather
-> than deriving it again.
->
-> **Do not read** `lib/geargen/<gear>.py`, any other gear's implementation, or a previous
-> `steps.md` or proof for this gear. If the spec is unclear, record it as a spec gap in your report
-> and make your best attempt. Never resolve it by looking at existing output.
->
-> **A step is one entry in the Fusion timeline.** Drawing a whole sketch is one step, however much
-> geometry goes into it. So is each extrude, chamfer, pattern, combine, fillet. Write the step list
-> at that size, and keep the detail inside the step it belongs to.
->
-> **The step list opens with one sentence naming the proof files**, above the provenance heading and
-> before any other section, written as the committed paths `proof/<gear>/<file>.go` even though you
-> are writing the files themselves to `.tmp/<gear>-proof/`, since the step list ships next to the
-> placed proof, not next to your scratch copy. A gate reads only the text above the provenance
-> heading for those paths and requires each one to exist and be committed, so a sentence written
-> below that heading, or one naming bare file names, leaves the gate with nothing to check.
->
-> **Under the `## Provenance` heading comes the provenance table** of each file in the provenance
-> input set owned by `.claude/skills/generate-gear/check_compile.py`, with its `git hash-object`
-> value, in a two-column markdown table with both cells in backticks. The set covers the gear's
-> `instructions.md`, its `fusion.md` if present, the playbook, and existing auxiliary Markdown
-> documents referenced by the two spec files.
->
-> **Each step carries** a heading of the form `## <id> `[GO]` <title>` or with `[PROSE]`, the
-> instructions themselves, a `**From:**` line naming the spec files and line ranges you compiled it
-> from, and every Fusion API call it requires written inside a code span. A `[GO]` step also names
-> the proof function that realises it.
->
-> **A call span in a step is a call the module must make.** A later gate reads every call written
-> in a code span and requires the generated module to make it. A name a step mentions without
-> requiring it therefore has to be marked: a method the module defines for the framework to call, a
-> call named only to forbid it, and one of several alternatives the spec lets the implementation
-> choose between are all mentions, not requirements. Mark each with the exemption directive on its
-> own line in the step that mentions it, `<!-- check-step-calls: ignore nameOne nameTwo -->`, and
-> say in the step's prose why the mention is not a requirement.
->
-> **Before naming any `adsk.*` call**, ask the `fusion:query-api` skill about it. Two questions
-> carry most of the work: `members <Class>` lists everything a class offers, inherited members
-> included, each with the class that declares it, which is how you find out whether the class you
-> are calling on really has the member; and `show <Class>.<member>` gives one member's signature
-> and documentation. Write the call with the arguments that signature asks for. If the spec names
-> a call the API does not have, or passes an argument of the wrong type, say so in your report and
-> do not quietly correct it.
->
-> **The proof is a Go test** in package `<gear>_test`, spread over as many files as the split
-> needs, with one function per step. Every step function, 2D or 3D alike, is declared as a
-> function, `func step<Title>(...)`, matching what the step list names — a step bound to a
-> variable is not read — and is registered by the Go `Test` of the same title, in a shape that is
-> fixed and has no variants:
->
-> ```go
-> func TestGearProfileSketch(t *testing.T) {
->         proofkit.Run(t, profileCases, stepGearProfileSketch)
-> }
-> ```
->
-> Three lines, headed exactly as above, with the testing package named in full: `go test` also
-> runs `Test_Foo`, `Test1x` and a header written against an aliased import of `testing`, and the
-> gate refuses all three by name rather than reading them. The header and the closing `}` each
-> start at column 1, which is where `gofmt` writes them. Go compiles an indented one, and the gate
-> refuses it anyway, because these three lines are the shape rather than ordinary code; the refusal
-> names the header or quotes the shape, so it is never silent. The step function is not part of
-> that shape and is read wherever it starts on its line. The `Test` function holds nothing else.
-> Use `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
-> `proofkit.Run` for a solid step, and put the assertion after the build where the run takes one. The build argument is always the
-> third, each argument is written out as a plain name, and the case table is a named variable
-> rather than a call built in place. Each run takes a table of parameter cases, one subtest each.
-> Pass exactly the arguments the run's own signature declares — `proofkit3d.RunWithGate` takes the
-> gate as well as the assertion, and `proofkit.Run` takes neither — since a count the method does
-> not declare is a call Go cannot compile. The gate reads the run methods and their argument
-> counts out of `proof/proofkit/` and `proof/proofkit3d/`, so those sources are what a run is
-> checked against.
->
-> The gate reads this shape by line rather than by parsing Go, so anything else is refused, not
-> interpreted. A build under another name, a `Test` header outside the shape shown above, a `Test`
-> whose title does not match the step it builds, a run reached through a loop, a condition or a
-> closure, a run whose arguments come from one forwarded call as in `proofkit3d.Run(runArgs(t))`,
-> a run passing a different number of arguments than its method declares, and a proof file whose
-> header carries a build constraint all fail the check by name and line. A call to a `Run…` method
-> no harness package declares fails the same way, and that one is not confined to a registration:
-> a misspelled run in a helper is `undefined` to Go wherever it sits, so it is named wherever it
-> is written. Go reads a constraint from `//go:build` when nothing sits
-> between the slashes and the directive, whitespace or the end of the line follows the directive,
-> and the line is above the package clause. A leading byte order mark hides nothing: Go strips one
-> and honours what is under it, and the gate reads it the same way. The same text further down,
-> inside a string, inside a `/* */` comment in the header, written `// go:build …` with a space, or
-> run straight on as `//go:build!ignore`, is content rather than a constraint, and all of it
-> passes. The legacy `+build` form is refused in every spelling, including the near-misses Go
-> builds, because a proof file needs no build constraint at all. The refusal says what to write;
-> write that.
->
-> **Name proof files so Go compiles them.** Go decides which files are in a package from their
-> names alone: a name starting with `_` or `.` is invisible to it, and a name whose trailing
-> `_`-separated words are a GOOS, a GOARCH, or a GOOS and a GOARCH — `steps_windows_test.go`,
-> `steps_arm64_test.go`, `steps_windows_amd64_test.go` — is compiled only on that platform. A
-> proof in such a file registers nothing, `go test` reports no test files rather than failing, and
-> the gate names the file and asks for a rename. Ordinary trailing words are unaffected, so
-> `geometry_test.go`, `sketches_test.go` and `solids_test.go` are all fine.
->
-> **Write proof files as UTF-8 Go can read.** Go refuses to compile a source file whose bytes it
-> cannot read, and a refused file registers nothing, so the gate refuses it too, naming the file,
-> the line and the column. Four byte patterns do it: a UTF-16 byte order mark, which is what a
-> file saved as UTF-16 opens with; any other bytes that are not UTF-8; a NUL byte anywhere; and a
-> byte order mark anywhere other than the very first character. One leading `EF BB BF` is the
-> exception Go strips, so a file that opens with a single mark is read normally and every line
-> below it keeps its number. Write the file as UTF-8, with none of those bytes in it.
->
-> **Separate tokens and spell names the way Go's scanner reads them.** Between two tokens Go skips
-> space, tab, carriage return and newline and nothing else, and a name is a Unicode letter or `_`
-> followed by letters, decimal digits or `_`. A vertical tab between `func` and a name, a
-> non-breaking space in the indentation, a superscript digit inside a step title: each makes the
-> file illegal where it sits, `go test` reports it as an illegal character and the package builds
-> nothing, so the gate reads no declaration on that line and names the step or the run that went
-> missing instead. The name a step claims in the step list is held to the same rule and is read
-> whole: with such a character written against it the claim is not a Go name at all, so it credits
-> nothing and the step is reported as naming no proof function. Unicode letters themselves are
-> ordinary — `stepPrüfung` is a name Go compiles and the gate reads.
->
-> **The case table reaches every branch, from every direction the spec offers.** A branch a step
-> takes needs a case on each side of it, and a branch the spec says is reachable in more than one
-> way needs a case for each way, because the ways differ in what they get wrong. Cover the ends of
-> every range the spec states for a parameter, negative values included wherever the spec says the
-> value is signed — a sign the scheme drops is still solvable at the positive value, so a table of
-> positive cases proves nothing about the sign. Where the spec names the regime the design must
-> hold across, that regime is the table.
->
-> **Assert what the spec pins.** Where the spec fixes a fact a later step selects or matches on — a
-> curve count a profile search takes as its key, an edge or face count, an extent, a volume — the
-> proof asserts that fact on the geometry it actually built, in the step that produces it. Restating
-> the number in a comment is not proving it. Assert it against the real construction rather than
-> against a simplified stand-in drawn for the purpose, since the stand-in is the thing whose
-> agreement is in question.
->
-> **A boundary a harness refuses is not permission to drop the step.** Substitute geometry the
-> harness does accept — chord a curve it will not trim, draw a split the engine will not perform —
-> and assert what the substitute still pins, saying in the proof what was substituted and what the
-> substitution costs. Only where no substitute survives the gate is the step `[PROSE]`, and then say
-> so **in the proof file**, next to the nearest thing the proof does build, with the reason it
-> cannot be reached. A limit recorded only in the step list is a limit the next reader of the proof
-> will not find.
->
-> **A sketch step** builds through `proofkit.Run`, whose build function is
-> `func(t testing.TB, s *sketch.Sketch, p map[string]float64)`. Model what Fusion does: use
-> `CreateReferencePoint` for anything projected in rather than fixing coordinates, mark solid and
-> construction geometry as Fusion would, and let profile detection split curves at crossings rather
-> than drawing boundary arcs by hand. Call `proofkit.Step` as you move between parts of a step, and
-> `proofkit.Unmodelled` for a case the proof cannot represent, never a silent return.
->
-> **A solid step** builds through `proofkit3d`, whose build function is
-> `func(t *testing.T, doc *decad.Document, params map[string]float64) []*decad.Body` and returns
-> the bodies the step leaves behind. Every `proofkit3d` run also takes an assertion,
-> `func(t *testing.T, doc *decad.Document, bodies []*decad.Body, params map[string]float64)`, which
-> runs after the gate and checks the measurements the step is supposed to produce; it is required,
-> and a nil one fails the run. `proofkit3d.Unmodelled` is the 3D counterpart of
-> `proofkit.Unmodelled`, for a case `decad` cannot represent.
->
-> **The proof must pass with nothing waived.** `proofkit` gates a sketch on
-> `sketch.VerificationReport.Check`, which asks for more than DOF 0: no conflicting or redundant
-> constraint, no stale or broken reference geometry, valid profiles, a system that is not
-> near-singular, and no discrete ambiguity. A scheme that reaches DOF 0 but still allows a mirrored
-> or 180-degree-rotated answer fails there, and the fix is a constraint that carries a direction,
-> not a comment.
->
-> `proofkit3d.Run` gates a solid on `decad`'s own verification verdict: the document report has to
-> come back trustworthy, and the build has to return bodies rather than nothing or a nil.
-> `proofkit3d.RunSolid` reads the same report but tolerates exactly one kind of diagnostic, an area
-> or centroid reading a faceted boolean left outside the default tolerance, and adds the topology a
-> solid has to have: every body reports as solid, watertight, manifold and free of
-> self-intersection, with a single lump and no voids. `proofkit3d.RunWithGate` takes the gate as an
-> argument; do not pass a weaker one to get a build through.
->
-> **The two artifacts must describe the same build.** Every `[GO]` step names its proof function,
-> and every proof function is named by a step.
->
-> **Report:** what you produced, and every place the spec was unclear, incomplete, contradictory,
-> or wrong about the Fusion API. Those are the defects to fix. Do not smooth them over.
+The prompt text lives in `.claude/skills/compile-gear/prompt.md`; `{{gear}}` is its only
+placeholder. Render it — never retype or paraphrase it — with:
+
+    python3 .claude/skills/generate-gear/render_prompt.py compile-gear <gear>
+
+Hand the printed output to the drafting subagent unchanged. The renderer refuses to print
+anything for an unknown skill name, a missing template, or a template carrying a placeholder it
+was not given, so a garbled render can never reach the subagent.

--- a/.claude/skills/compile-gear/prompt.md
+++ b/.claude/skills/compile-gear/prompt.md
@@ -1,0 +1,184 @@
+Compile the specification for `{{gear}}` into a step list and a runnable proof. Work in the repo
+worktree. Write the step list to `.tmp/{{gear}}.steps.md`, and the proof, as one or more Go files,
+to `.tmp/{{gear}}-proof/`.
+
+**Read, in full, only these:** `spec/{{gear}}/instructions.md`, `spec/{{gear}}/fusion.md` if it
+exists, every document those reference by name, `.claude/skills/generate-gear/PLAYBOOK.md`,
+`proof/proofkit/` for the sketch harness API, `proof/proofkit3d/` for the solid harness API, and
+`proof/involute/` for the involute tooth math the spur family shares, so you import it rather
+than deriving it again.
+
+**Do not read** `lib/geargen/{{gear}}.py`, any other gear's implementation, or a previous
+`steps.md` or proof for this gear. If the spec is unclear, record it as a spec gap in your report
+and make your best attempt. Never resolve it by looking at existing output.
+
+**A step is one entry in the Fusion timeline.** Drawing a whole sketch is one step, however much
+geometry goes into it. So is each extrude, chamfer, pattern, combine, fillet. Write the step list
+at that size, and keep the detail inside the step it belongs to.
+
+**The step list opens with one sentence naming the proof files**, above the provenance heading and
+before any other section, written as the committed paths `proof/{{gear}}/<file>.go` even though you
+are writing the files themselves to `.tmp/{{gear}}-proof/`, since the step list ships next to the
+placed proof, not next to your scratch copy. A gate reads only the text above the provenance
+heading for those paths and requires each one to exist and be committed, so a sentence written
+below that heading, or one naming bare file names, leaves the gate with nothing to check.
+
+**Under the `## Provenance` heading comes the provenance table** of each file in the provenance
+input set owned by `.claude/skills/generate-gear/check_compile.py`, with its `git hash-object`
+value, in a two-column markdown table with both cells in backticks. The set covers the gear's
+`instructions.md`, its `fusion.md` if present, the playbook, and existing auxiliary Markdown
+documents referenced by the two spec files.
+
+**Each step carries** a heading of the form `## <id> `[GO]` <title>` or with `[PROSE]`, the
+instructions themselves, a `**From:**` line naming the spec files and line ranges you compiled it
+from, and every Fusion API call it requires written inside a code span. A `[GO]` step also names
+the proof function that realises it.
+
+**A call span in a step is a call the module must make.** A later gate reads every call written
+in a code span and requires the generated module to make it. A name a step mentions without
+requiring it therefore has to be marked: a method the module defines for the framework to call, a
+call named only to forbid it, and one of several alternatives the spec lets the implementation
+choose between are all mentions, not requirements. Mark each with the exemption directive on its
+own line in the step that mentions it, `<!-- check-step-calls: ignore nameOne nameTwo -->`, and
+say in the step's prose why the mention is not a requirement.
+
+**Before naming any `adsk.*` call**, ask the `fusion:query-api` skill about it. Two questions
+carry most of the work: `members <Class>` lists everything a class offers, inherited members
+included, each with the class that declares it, which is how you find out whether the class you
+are calling on really has the member; and `show <Class>.<member>` gives one member's signature
+and documentation. Write the call with the arguments that signature asks for. If the spec names
+a call the API does not have, or passes an argument of the wrong type, say so in your report and
+do not quietly correct it.
+
+**The proof is a Go test** in package `{{gear}}_test`, spread over as many files as the split
+needs, with one function per step. Every step function, 2D or 3D alike, is declared as a
+function, `func step<Title>(...)`, matching what the step list names — a step bound to a
+variable is not read — and is registered by the Go `Test` of the same title, in a shape that is
+fixed and has no variants:
+
+```go
+func TestGearProfileSketch(t *testing.T) {
+        proofkit.Run(t, profileCases, stepGearProfileSketch)
+}
+```
+
+Three lines, headed exactly as above, with the testing package named in full: `go test` also
+runs `Test_Foo`, `Test1x` and a header written against an aliased import of `testing`, and the
+gate refuses all three by name rather than reading them. The header and the closing `}` each
+start at column 1, which is where `gofmt` writes them. Go compiles an indented one, and the gate
+refuses it anyway, because these three lines are the shape rather than ordinary code; the refusal
+names the header or quotes the shape, so it is never silent. The step function is not part of
+that shape and is read wherever it starts on its line. The `Test` function holds nothing else.
+Use `proofkit3d.Run`, `proofkit3d.RunSolid` or `proofkit3d.RunWithGate` in place of
+`proofkit.Run` for a solid step, and put the assertion after the build where the run takes one. The build argument is always the
+third, each argument is written out as a plain name, and the case table is a named variable
+rather than a call built in place. Each run takes a table of parameter cases, one subtest each.
+Pass exactly the arguments the run's own signature declares — `proofkit3d.RunWithGate` takes the
+gate as well as the assertion, and `proofkit.Run` takes neither — since a count the method does
+not declare is a call Go cannot compile. The gate reads the run methods and their argument
+counts out of `proof/proofkit/` and `proof/proofkit3d/`, so those sources are what a run is
+checked against.
+
+The gate reads this shape by line rather than by parsing Go, so anything else is refused, not
+interpreted. A build under another name, a `Test` header outside the shape shown above, a `Test`
+whose title does not match the step it builds, a run reached through a loop, a condition or a
+closure, a run whose arguments come from one forwarded call as in `proofkit3d.Run(runArgs(t))`,
+a run passing a different number of arguments than its method declares, and a proof file whose
+header carries a build constraint all fail the check by name and line. A call to a `Run…` method
+no harness package declares fails the same way, and that one is not confined to a registration:
+a misspelled run in a helper is `undefined` to Go wherever it sits, so it is named wherever it
+is written. Go reads a constraint from `//go:build` when nothing sits
+between the slashes and the directive, whitespace or the end of the line follows the directive,
+and the line is above the package clause. A leading byte order mark hides nothing: Go strips one
+and honours what is under it, and the gate reads it the same way. The same text further down,
+inside a string, inside a `/* */` comment in the header, written `// go:build …` with a space, or
+run straight on as `//go:build!ignore`, is content rather than a constraint, and all of it
+passes. The legacy `+build` form is refused in every spelling, including the near-misses Go
+builds, because a proof file needs no build constraint at all. The refusal says what to write;
+write that.
+
+**Name proof files so Go compiles them.** Go decides which files are in a package from their
+names alone: a name starting with `_` or `.` is invisible to it, and a name whose trailing
+`_`-separated words are a GOOS, a GOARCH, or a GOOS and a GOARCH — `steps_windows_test.go`,
+`steps_arm64_test.go`, `steps_windows_amd64_test.go` — is compiled only on that platform. A
+proof in such a file registers nothing, `go test` reports no test files rather than failing, and
+the gate names the file and asks for a rename. Ordinary trailing words are unaffected, so
+`geometry_test.go`, `sketches_test.go` and `solids_test.go` are all fine.
+
+**Write proof files as UTF-8 Go can read.** Go refuses to compile a source file whose bytes it
+cannot read, and a refused file registers nothing, so the gate refuses it too, naming the file,
+the line and the column. Four byte patterns do it: a UTF-16 byte order mark, which is what a
+file saved as UTF-16 opens with; any other bytes that are not UTF-8; a NUL byte anywhere; and a
+byte order mark anywhere other than the very first character. One leading `EF BB BF` is the
+exception Go strips, so a file that opens with a single mark is read normally and every line
+below it keeps its number. Write the file as UTF-8, with none of those bytes in it.
+
+**Separate tokens and spell names the way Go's scanner reads them.** Between two tokens Go skips
+space, tab, carriage return and newline and nothing else, and a name is a Unicode letter or `_`
+followed by letters, decimal digits or `_`. A vertical tab between `func` and a name, a
+non-breaking space in the indentation, a superscript digit inside a step title: each makes the
+file illegal where it sits, `go test` reports it as an illegal character and the package builds
+nothing, so the gate reads no declaration on that line and names the step or the run that went
+missing instead. The name a step claims in the step list is held to the same rule and is read
+whole: with such a character written against it the claim is not a Go name at all, so it credits
+nothing and the step is reported as naming no proof function. Unicode letters themselves are
+ordinary — `stepPrüfung` is a name Go compiles and the gate reads.
+
+**The case table reaches every branch, from every direction the spec offers.** A branch a step
+takes needs a case on each side of it, and a branch the spec says is reachable in more than one
+way needs a case for each way, because the ways differ in what they get wrong. Cover the ends of
+every range the spec states for a parameter, negative values included wherever the spec says the
+value is signed — a sign the scheme drops is still solvable at the positive value, so a table of
+positive cases proves nothing about the sign. Where the spec names the regime the design must
+hold across, that regime is the table.
+
+**Assert what the spec pins.** Where the spec fixes a fact a later step selects or matches on — a
+curve count a profile search takes as its key, an edge or face count, an extent, a volume — the
+proof asserts that fact on the geometry it actually built, in the step that produces it. Restating
+the number in a comment is not proving it. Assert it against the real construction rather than
+against a simplified stand-in drawn for the purpose, since the stand-in is the thing whose
+agreement is in question.
+
+**A boundary a harness refuses is not permission to drop the step.** Substitute geometry the
+harness does accept — chord a curve it will not trim, draw a split the engine will not perform —
+and assert what the substitute still pins, saying in the proof what was substituted and what the
+substitution costs. Only where no substitute survives the gate is the step `[PROSE]`, and then say
+so **in the proof file**, next to the nearest thing the proof does build, with the reason it
+cannot be reached. A limit recorded only in the step list is a limit the next reader of the proof
+will not find.
+
+**A sketch step** builds through `proofkit.Run`, whose build function is
+`func(t testing.TB, s *sketch.Sketch, p map[string]float64)`. Model what Fusion does: use
+`CreateReferencePoint` for anything projected in rather than fixing coordinates, mark solid and
+construction geometry as Fusion would, and let profile detection split curves at crossings rather
+than drawing boundary arcs by hand. Call `proofkit.Step` as you move between parts of a step, and
+`proofkit.Unmodelled` for a case the proof cannot represent, never a silent return.
+
+**A solid step** builds through `proofkit3d`, whose build function is
+`func(t *testing.T, doc *decad.Document, params map[string]float64) []*decad.Body` and returns
+the bodies the step leaves behind. Every `proofkit3d` run also takes an assertion,
+`func(t *testing.T, doc *decad.Document, bodies []*decad.Body, params map[string]float64)`, which
+runs after the gate and checks the measurements the step is supposed to produce; it is required,
+and a nil one fails the run. `proofkit3d.Unmodelled` is the 3D counterpart of
+`proofkit.Unmodelled`, for a case `decad` cannot represent.
+
+**The proof must pass with nothing waived.** `proofkit` gates a sketch on
+`sketch.VerificationReport.Check`, which asks for more than DOF 0: no conflicting or redundant
+constraint, no stale or broken reference geometry, valid profiles, a system that is not
+near-singular, and no discrete ambiguity. A scheme that reaches DOF 0 but still allows a mirrored
+or 180-degree-rotated answer fails there, and the fix is a constraint that carries a direction,
+not a comment.
+
+`proofkit3d.Run` gates a solid on `decad`'s own verification verdict: the document report has to
+come back trustworthy, and the build has to return bodies rather than nothing or a nil.
+`proofkit3d.RunSolid` reads the same report but tolerates exactly one kind of diagnostic, an area
+or centroid reading a faceted boolean left outside the default tolerance, and adds the topology a
+solid has to have: every body reports as solid, watertight, manifold and free of
+self-intersection, with a single lump and no voids. `proofkit3d.RunWithGate` takes the gate as an
+argument; do not pass a weaker one to get a build through.
+
+**The two artifacts must describe the same build.** Every `[GO]` step names its proof function,
+and every proof function is named by a step.
+
+**Report:** what you produced, and every place the spec was unclear, incomplete, contradictory,
+or wrong about the Fusion API. Those are the defects to fix. Do not smooth them over.

--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -22,9 +22,10 @@ the pipeline exists to make trustworthy.
    `python3 .claude/skills/generate-gear/check_compile.py <gear>`. Emitting from a stale step list
    wastes the round. If it fails, run `/compile-gear <gear>` first.
 
-3. **Draft.** Spawn a subagent with the verbatim prompt in the appendix, substituting only
-   `<gear>`. It writes `.tmp/<gear>.generated.py`. Add no per-gear hints; anything the drafter
-   needs belongs in the step list.
+3. **Draft.** Spawn a subagent with the standard drafting prompt: run
+   `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear>` and pass its printed
+   output to the subagent unchanged. It writes `.tmp/<gear>.generated.py`. Add no per-gear
+   hints; anything the drafter needs belongs in the step list.
 
 4. **Gate.** Run all seven checks below. Every one must exit 0.
 
@@ -86,38 +87,13 @@ step list by hand, and never work around it in the Python.
 - Never hand-edit the step list or the proof.
 - Never add gear-specific guidance to the drafting prompt.
 
-## Standard drafting prompt (use verbatim — substitute only `<gear>`)
+## Standard drafting prompt
 
-> Write the Fusion 360 add-in implementation for `<gear>` by following its compiled step list. Work
-> in the repo worktree. Write `.tmp/<gear>.generated.py`. Do not try to run it; the `adsk` modules
-> only exist inside Fusion, so parsing is as far as it goes.
->
-> **Read, in this order:** `spec/<gear>/steps.md`, which is your instruction set and which you work
-> through in order; `proof/<gear>/`, the checked geometry, which steps tagged `[GO]` tell you to
-> transliterate literally rather than re-derive; `.claude/skills/generate-gear/PLAYBOOK.md` for the
-> rules the steps cite by anchor; and the framework you build on and must not reimplement, which is
-> `lib/geargen/base.py`, `misc.py`, `utilities.py`, `spurproxy.py` and `lib/fusion360utils/`.
->
-> **Do not read** `lib/geargen/<gear>.py`, `spec/<gear>/instructions.md`, `spec/<gear>/fusion.md`,
-> or any previous draft. The step list is deliberately the only description of the gear you get. If
-> a step is unclear, record it as a defect in your report and make your best attempt.
->
-> **Before writing any `adsk.*` call**, ask the `fusion:query-api` skill about it. Two questions
-> carry most of the work: `members <Class>` lists everything a class offers, inherited members
-> included, each with the class that declares it, which is how you find out whether the class you
-> are calling on really has the member; and `show <Class>.<member>` gives one member's signature
-> and documentation. Pass what the signature asks for. Where it says `ValueInput`, a bare number
-> raises. Where it says `ObjectCollection`, a Python list raises. Where it says `Point3D`, a
-> `SketchPoint` raises. If the step list names a call the API does not have, report it and do not
-> quietly correct it.
->
-> **Do every step.** A step you cannot finish is a defect to report, never a comment left in the
-> file and never a silent omission.
->
-> **Self-check before finishing**, fixing until all seven gates pass: parse, `pyright_check.py` with
-> 0 BLOCKING, `check_input_read.py`, `check_contract.py`, `check_anchors.py`, `check_step_calls.py`
-> and `check_api_calls.py`. Never silence a finding by deleting a comment, renaming a variable, or
-> removing the call it objects to.
->
-> **Report:** the gate results, the final line count, and every step that was unclear, incomplete,
-> or that you could not carry out as written, named by its step ID.
+The prompt text lives in `.claude/skills/emit-gear/prompt.md`; `{{gear}}` is its only
+placeholder. Render it — never retype or paraphrase it — with:
+
+    python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear>
+
+Hand the printed output to the drafting subagent unchanged. The renderer refuses to print
+anything for an unknown skill name, a missing template, or a template carrying a placeholder it
+was not given, so a garbled render can never reach the subagent.

--- a/.claude/skills/emit-gear/prompt.md
+++ b/.claude/skills/emit-gear/prompt.md
@@ -1,0 +1,33 @@
+Write the Fusion 360 add-in implementation for `{{gear}}` by following its compiled step list. Work
+in the repo worktree. Write `.tmp/{{gear}}.generated.py`. Do not try to run it; the `adsk` modules
+only exist inside Fusion, so parsing is as far as it goes.
+
+**Read, in this order:** `spec/{{gear}}/steps.md`, which is your instruction set and which you work
+through in order; `proof/{{gear}}/`, the checked geometry, which steps tagged `[GO]` tell you to
+transliterate literally rather than re-derive; `.claude/skills/generate-gear/PLAYBOOK.md` for the
+rules the steps cite by anchor; and the framework you build on and must not reimplement, which is
+`lib/geargen/base.py`, `misc.py`, `utilities.py`, `spurproxy.py` and `lib/fusion360utils/`.
+
+**Do not read** `lib/geargen/{{gear}}.py`, `spec/{{gear}}/instructions.md`, `spec/{{gear}}/fusion.md`,
+or any previous draft. The step list is deliberately the only description of the gear you get. If
+a step is unclear, record it as a defect in your report and make your best attempt.
+
+**Before writing any `adsk.*` call**, ask the `fusion:query-api` skill about it. Two questions
+carry most of the work: `members <Class>` lists everything a class offers, inherited members
+included, each with the class that declares it, which is how you find out whether the class you
+are calling on really has the member; and `show <Class>.<member>` gives one member's signature
+and documentation. Pass what the signature asks for. Where it says `ValueInput`, a bare number
+raises. Where it says `ObjectCollection`, a Python list raises. Where it says `Point3D`, a
+`SketchPoint` raises. If the step list names a call the API does not have, report it and do not
+quietly correct it.
+
+**Do every step.** A step you cannot finish is a defect to report, never a comment left in the
+file and never a silent omission.
+
+**Self-check before finishing**, fixing until all seven gates pass: parse, `pyright_check.py` with
+0 BLOCKING, `check_input_read.py`, `check_contract.py`, `check_anchors.py`, `check_step_calls.py`
+and `check_api_calls.py`. Never silence a finding by deleting a comment, renaming a variable, or
+removing the call it objects to.
+
+**Report:** the gate results, the final line count, and every step that was unclear, incomplete,
+or that you could not carry out as written, named by its step ID.

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -64,9 +64,11 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 4. **Generate.** Spawn a subagent that writes `.tmp/<gear>.generated.py` from **the spec +
    playbook + the framework files + any declared dependency files only**. It MUST NOT read an
    existing `lib/geargen/<gear>.py` if one is present.
-   - **Use the verbatim "Standard generation prompt" in the appendix below — do NOT improvise it,
-     and do NOT add per-gear hints, "high-risk" checklists, reminders of specific gotchas, or any
-     gear-specific guidance to the prompt.** Substitute only `<gear>`. All gear-specific knowledge
+   - **Use the standard generation prompt: run
+     `python3 .claude/skills/generate-gear/render_prompt.py generate-gear <gear>` and pass its
+     printed output to the subagent unchanged — do NOT improvise the prompt, and do NOT add
+     per-gear hints, "high-risk" checklists, reminders of specific gotchas, or any gear-specific
+     guidance to it.** All gear-specific knowledge
      (geometry, failure modes, the exact ⚠️ rules) MUST live in the **spec/playbook**, never in the
      generation prompt. Reason: a hand-tuned prompt (a) adds orchestrator variance round-to-round on
      top of the model's, and (b) **masks spec gaps** — if the prompt spoon-feeds a rule, a green run
@@ -217,65 +219,19 @@ geometry in the report so it is visible, not silently assumed.
   in its Dependencies section so generation reads the dependency and the contract self-check
   covers the borrowed surface.
 
-## Standard generation prompt (use verbatim — substitute only `<gear>`)
+## Standard generation prompt
 
-This is the fixed prompt for the Generate-step (step 4) generation subagent. Use it **exactly**, changing only the
-`<gear>` token. Do **not** add gear-specific hints, gotcha reminders, or "high-risk" lists — those
-belong in the spec/playbook. Identical prompt every run is what makes the regen an honest test of
-the spec.
+The prompt text lives in `.claude/skills/generate-gear/prompt.md`; `{{gear}}` is its only
+placeholder. This is the fixed prompt for the Generate-step (step 4) subagent. Render it —
+never retype or paraphrase it — with:
 
-> Generate a Fusion 360 gear-generator implementation **purely from its spec** — reference-free.
-> Work in the repo's worktree. Write the result to `.tmp/<gear>.generated.py` (parse-only; the
-> `adsk` modules are not importable here — do not try to run it).
->
-> **HARD RULE — reference-free:** Do NOT open, read, grep, or otherwise consult an existing
-> `lib/geargen/<gear>.py`. If anything is unclear, record it as a spec-gap note in your report —
-> never resolve it by peeking at an existing implementation.
->
-> **Progress heartbeat (liveness telemetry only — it does not alter what you generate):** append
-> one line `<unix-epoch-seconds> <milestone>` to `.tmp/<gear>.progress.log` at each milestone
-> (e.g. `date +%s` for the timestamp): `start` as your first action; `read:<path>` after finishing
-> each required input file; `draft:written` immediately after writing `.tmp/<gear>.generated.py`;
-> `check:<n>:pass` / `check:<n>:fail` after each self-check round; `done` as your last action
-> before reporting. Never go more than a few minutes without a heartbeat line.
->
-> **Read, in full, ONLY these:**
-> - `spec/<gear>/instructions.md` — THE SPEC, the sole source of truth. Read it end-to-end. **Every
->   rule, formula, and ⚠️ note in it is binding** — the spec already encodes the known failure
->   modes; obey them precisely. Do not rely on any guidance outside the spec/playbook.
-> - `.claude/skills/generate-gear/PLAYBOOK.md` — shared framework conventions and Fusion-API rules.
-> - Every document the spec references by name (e.g. a geometry-derivation `.md`).
-> - The framework files the output builds on: `lib/geargen/base.py`, `lib/geargen/misc.py`,
->   `lib/geargen/utilities.py`, `lib/geargen/solids.py`, `lib/geargen/spurproxy.py`, and
->   `lib/fusion360utils/`.
-> - Every gear/module the spec's **Dependencies** section declares (read the exact surface bevel/…
->   borrows: class names, constructor/`draw` signatures, and any attribute it reads or writes).
->
-> **Contract = the spec's own declarations.** The spec's Architecture, Method-contract / call-graph,
-> Generation-Context, Generation-Order, Exact-input-ids, Dependencies, and Sketch-Discipline
-> sections ARE the hard requirement. Extract them yourself and satisfy them exactly: reproduce every
-> class name, method/hook name and signature, constant, dialog input id/label/unit/default, and
-> declared helper. Follow the Instructions sections' geometry and feature order verbatim, including
-> every edge case and ⚠️ the spec calls out. Local variable names, comments, and private-helper
-> decomposition beyond the pinned boundaries may vary.
->
-> **Self-check before finishing** (fix and repeat until all pass):
-> 1. `python3 -c "import ast; ast.parse(open('.tmp/<gear>.generated.py').read())"` succeeds.
-> 2. `python3 .claude/skills/generate-gear/pyright_check.py .tmp/<gear>.generated.py` reports
->    **0 BLOCKING** (undefined names / typos and wrong-adsk-submodule refs). REVIEW findings are
->    advisory stub noise — do not act on them or change the code to silence them.
-> 3. `python3 .claude/skills/generate-gear/check_input_read.py .tmp/<gear>.generated.py` exits 0:
->    every dialog input is read with the helper matching its declared type (`get_value` for
->    value/string inputs, `get_boolean` for `addBoolValueInput`, `get_selection` for selections —
->    `[PB-INPUT-READ]`). A mismatch is a real runtime crash pyright can't see.
-> 4. Every class / method / constant / input id / declared helper the spec's contract sections name
->    is present, spelled exactly.
-> 5. Every name imported from another module exists in that module.
->
-> **Report:** whether the self-checks pass (with line numbers for the contract items); the final
-> line count; and — most important — a precise list of any place the spec was **ambiguous or
-> insufficient** and you had to infer, since those are the spec gaps to fix. Do not smooth over
-> inferences; name them.
+    python3 .claude/skills/generate-gear/render_prompt.py generate-gear <gear>
+
+Hand the printed output to the subagent unchanged. Do **not** add gear-specific hints, gotcha
+reminders, or "high-risk" lists — those belong in the spec/playbook. An identical prompt every
+run is what makes the regen an honest test of the spec, and the renderer refuses to print
+anything for an unknown skill name, a missing template, or a template carrying a placeholder it
+was not given.
 
 When a run fails validation or (later) misbehaves in Fusion, the fix is always to the **spec or
 playbook**, after which you re-run **this same prompt** — you never edit the prompt to compensate.

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -427,7 +427,7 @@ def strip_go_comments_and_literals(src):
 # What this buys is that the gate never has to decide what a brace means. What it costs is that a
 # run written any other way is refused rather than read. That is the safe direction: a refusal
 # names the file and line and says what to write, while a misreading silently credits a step no
-# test builds. `.claude/skills/compile-gear/SKILL.md` states the same shape to the drafter, so the
+# test builds. `.claude/skills/compile-gear/prompt.md` states the same shape to the drafter, so the
 # refusal is a contract violation rather than a surprise.
 #
 # Comments and literals are blanked before matching, so a registration quoted inside a doc comment
@@ -717,7 +717,7 @@ GO_TOKEN_SEPARATION = re.compile('%(sp1)s' % GO_TOKENS)
 
 # A step is read only from a function declaration. Go would also accept `var stepFoo = func(...)`,
 # and that form is deliberately not recognised: the drafting contract in
-# `.claude/skills/compile-gear/SKILL.md` is one function per step, and a gate that reads both forms
+# `.claude/skills/compile-gear/prompt.md` is one function per step, and a gate that reads both forms
 # has two shapes to keep right instead of one. What the refusal must not do is call a
 # variable-bound step undefined, so the complaint says the step has to be declared as a function.
 #
@@ -731,7 +731,7 @@ STEP_DEFINITION = re.compile(
     r'^%(sp)sfunc%(sp1)s(step[A-Z]%(part)s*)%(sp)s[\[(]' % GO_TOKENS)
 
 # The header is anchored at column 1, and that is a decision rather than an oversight. It is the
-# first of the three lines of the registration shape `.claude/skills/compile-gear/SKILL.md` states
+# first of the three lines of the registration shape `.claude/skills/compile-gear/prompt.md` states
 # to the drafter, and that shape is a contract: the example there writes the header at column 1,
 # `gofmt` writes it there, and holding the contract is what this pattern is for. Go does run an indented
 # `Test`, so the refusal is this gate holding its own shape rather than following Go, and it is

--- a/.claude/skills/generate-gear/prompt.md
+++ b/.claude/skills/generate-gear/prompt.md
@@ -1,0 +1,52 @@
+Generate a Fusion 360 gear-generator implementation **purely from its spec** — reference-free.
+Work in the repo's worktree. Write the result to `.tmp/{{gear}}.generated.py` (parse-only; the
+`adsk` modules are not importable here — do not try to run it).
+
+**HARD RULE — reference-free:** Do NOT open, read, grep, or otherwise consult an existing
+`lib/geargen/{{gear}}.py`. If anything is unclear, record it as a spec-gap note in your report —
+never resolve it by peeking at an existing implementation.
+
+**Progress heartbeat (liveness telemetry only — it does not alter what you generate):** append
+one line `<unix-epoch-seconds> <milestone>` to `.tmp/{{gear}}.progress.log` at each milestone
+(e.g. `date +%s` for the timestamp): `start` as your first action; `read:<path>` after finishing
+each required input file; `draft:written` immediately after writing `.tmp/{{gear}}.generated.py`;
+`check:<n>:pass` / `check:<n>:fail` after each self-check round; `done` as your last action
+before reporting. Never go more than a few minutes without a heartbeat line.
+
+**Read, in full, ONLY these:**
+- `spec/{{gear}}/instructions.md` — THE SPEC, the sole source of truth. Read it end-to-end. **Every
+  rule, formula, and ⚠️ note in it is binding** — the spec already encodes the known failure
+  modes; obey them precisely. Do not rely on any guidance outside the spec/playbook.
+- `.claude/skills/generate-gear/PLAYBOOK.md` — shared framework conventions and Fusion-API rules.
+- Every document the spec references by name (e.g. a geometry-derivation `.md`).
+- The framework files the output builds on: `lib/geargen/base.py`, `lib/geargen/misc.py`,
+  `lib/geargen/utilities.py`, `lib/geargen/solids.py`, `lib/geargen/spurproxy.py`, and
+  `lib/fusion360utils/`.
+- Every gear/module the spec's **Dependencies** section declares (read the exact surface bevel/…
+  borrows: class names, constructor/`draw` signatures, and any attribute it reads or writes).
+
+**Contract = the spec's own declarations.** The spec's Architecture, Method-contract / call-graph,
+Generation-Context, Generation-Order, Exact-input-ids, Dependencies, and Sketch-Discipline
+sections ARE the hard requirement. Extract them yourself and satisfy them exactly: reproduce every
+class name, method/hook name and signature, constant, dialog input id/label/unit/default, and
+declared helper. Follow the Instructions sections' geometry and feature order verbatim, including
+every edge case and ⚠️ the spec calls out. Local variable names, comments, and private-helper
+decomposition beyond the pinned boundaries may vary.
+
+**Self-check before finishing** (fix and repeat until all pass):
+1. `python3 -c "import ast; ast.parse(open('.tmp/{{gear}}.generated.py').read())"` succeeds.
+2. `python3 .claude/skills/generate-gear/pyright_check.py .tmp/{{gear}}.generated.py` reports
+   **0 BLOCKING** (undefined names / typos and wrong-adsk-submodule refs). REVIEW findings are
+   advisory stub noise — do not act on them or change the code to silence them.
+3. `python3 .claude/skills/generate-gear/check_input_read.py .tmp/{{gear}}.generated.py` exits 0:
+   every dialog input is read with the helper matching its declared type (`get_value` for
+   value/string inputs, `get_boolean` for `addBoolValueInput`, `get_selection` for selections —
+   `[PB-INPUT-READ]`). A mismatch is a real runtime crash pyright can't see.
+4. Every class / method / constant / input id / declared helper the spec's contract sections name
+   is present, spelled exactly.
+5. Every name imported from another module exists in that module.
+
+**Report:** whether the self-checks pass (with line numbers for the contract items); the final
+line count; and — most important — a precise list of any place the spec was **ambiguous or
+insufficient** and you had to infer, since those are the spec gaps to fix. Do not smooth over
+inferences; name them.

--- a/.claude/skills/generate-gear/render_prompt.py
+++ b/.claude/skills/generate-gear/render_prompt.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Render a skill's standard drafting prompt with the gear name substituted.
+
+Each of the three drafting skills keeps its fixed subagent prompt in a
+`prompt.md` sibling to its `SKILL.md`, with `{{gear}}` as the only placeholder.
+This script prints that template with `{{gear}}` replaced, so "use the prompt
+verbatim" is the output of a program instead of a promise the orchestrating
+model has to keep by retyping.
+
+Angle-bracket tokens (`<Class>`, `<file>`, `<n>`, …) are literal prompt text and
+are never touched; only `{{…}}` is a placeholder.
+
+Usage:  python3 render_prompt.py <skill> [<gear>]
+Exit 0 = prompt printed to stdout; exit 2 = anything else (broken input).
+"""
+import re
+import sys
+from pathlib import Path
+
+KNOWN_SKILLS = ('compile-gear', 'emit-gear', 'generate-gear')
+DEFAULT_GEAR = 'spurgear'
+
+PLACEHOLDER_RE = re.compile(r'\{\{([A-Za-z0-9_-]+)\}\}')
+GEAR_RE = re.compile(r'^[a-z][a-z0-9_-]*$')
+
+USAGE = 'usage: render_prompt.py <skill> [<gear>]'
+
+
+class RenderError(Exception):
+    """A broken input: the message is written to stderr and nothing is printed."""
+
+
+def template_path(skill, skills_root):
+    """Return the `prompt.md` path for `skill` under `skills_root`."""
+    if skill not in KNOWN_SKILLS:
+        raise RenderError(
+            'unknown skill {!r}; known skills are {}'.format(
+                skill, ', '.join(KNOWN_SKILLS)))
+    return Path(skills_root) / skill / 'prompt.md'
+
+
+def render(template_text, values):
+    """Substitute `{{name}}` placeholders in `template_text` from `values`.
+
+    Every placeholder must be a key of `values`, and every key of `values` must
+    occur at least once — a template someone hard-coded a gear name into must
+    not render silently. Any `{{` or `}}` surviving substitution (a malformed
+    placeholder such as `{{gear}`) is an error too.
+    """
+    found = set(PLACEHOLDER_RE.findall(template_text))
+    unknown = sorted(found - set(values))
+    if unknown:
+        raise RenderError(
+            'template uses unknown placeholder(s): {}'.format(
+                ', '.join('{{{{{}}}}}'.format(name) for name in unknown)))
+    missing = sorted(set(values) - found)
+    if missing:
+        raise RenderError(
+            'template contains no {}'.format(
+                ', '.join('{{{{{}}}}}'.format(name) for name in missing)))
+
+    rendered = PLACEHOLDER_RE.sub(lambda match: values[match.group(1)], template_text)
+    if '{{' in rendered or '}}' in rendered:
+        raise RenderError('template has stray {{ or }} left after substitution')
+    return rendered
+
+
+def main(argv, skills_root=None):
+    if skills_root is None:
+        skills_root = Path(__file__).resolve().parent.parent
+
+    args = list(argv[1:])
+    if not 1 <= len(args) <= 2:
+        sys.stderr.write(USAGE + '\n')
+        return 2
+    skill = args[0]
+    gear = args[1] if len(args) == 2 else DEFAULT_GEAR
+
+    try:
+        if not GEAR_RE.match(gear):
+            raise RenderError(
+                'invalid gear name {!r}; expected {}'.format(gear, GEAR_RE.pattern))
+        path = template_path(skill, skills_root)
+        try:
+            template_text = path.read_text(encoding='utf-8')
+        except OSError as exc:
+            raise RenderError('cannot read template {}: {}'.format(path, exc))
+        sys.stdout.write(render(template_text, {'gear': gear}))
+    except RenderError as exc:
+        sys.stderr.write('render_prompt: {}\n'.format(exc))
+        return 2
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -1253,7 +1253,7 @@ class CheckCompileTest(unittest.TestCase):
         """Go compiles `var stepFoo = func(…)`, so calling the directory undefining it misleads.
 
         The gate keeps requiring the `func` form, matching the one-function-per-step contract in
-        `.claude/skills/compile-gear/SKILL.md`. Only the message changed, to name the shape the
+        `.claude/skills/compile-gear/prompt.md`. Only the message changed, to name the shape the
         step has to be written in.
         """
         proof_body = (
@@ -1275,7 +1275,7 @@ class CheckCompileTest(unittest.TestCase):
     # Go's layout is free and nothing in this repository holds a proof file to `gofmt`, so every
     # line below can arrive indented and Go still compiles it. Two of the four patterns that read
     # such a line are widened to match Go, and two keep a column-1 anchor because their line is
-    # part of the registration shape `.claude/skills/compile-gear/SKILL.md` states to the drafter.
+    # part of the registration shape `.claude/skills/compile-gear/prompt.md` states to the drafter.
     # `ProofDeclarationColumnTest` holds the Go half of each pairing; these hold the gate half, so
     # neither decision can be reversed without a failure here.
 
@@ -1514,7 +1514,7 @@ class CheckCompileTest(unittest.TestCase):
         keep an anchor no document mentions, which is how the same defect arose on the step side.
         """
         contract = (Path(__file__).parents[3] / '.claude' / 'skills' / 'compile-gear'
-                    / 'SKILL.md').read_text(encoding='utf-8')
+                    / 'prompt.md').read_text(encoding='utf-8')
 
         self.assertIn('The header and the closing `}` each', contract)
         self.assertIn('start at column 1', contract)
@@ -1528,7 +1528,7 @@ class CheckCompileTest(unittest.TestCase):
         The contract is where the drafter finds out what that means.
         """
         contract = (Path(__file__).parents[3] / '.claude' / 'skills' / 'compile-gear'
-                    / 'SKILL.md').read_text(encoding='utf-8')
+                    / 'prompt.md').read_text(encoding='utf-8')
 
         self.assertIn('Between two tokens Go skips', contract)
         self.assertIn('a name is a Unicode letter or `_`', contract)

--- a/.claude/skills/generate-gear/test_render_prompt.py
+++ b/.claude/skills/generate-gear/test_render_prompt.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Regressions for the standard-drafting-prompt renderer."""
+import contextlib
+import importlib.util
+import io
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+
+RENDERER_PATH = Path(__file__).with_name('render_prompt.py')
+MODULE_SPEC = importlib.util.spec_from_file_location('render_prompt', RENDERER_PATH)
+RENDERER = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(RENDERER)
+
+SKILLS_ROOT = RENDERER_PATH.resolve().parent.parent
+
+
+class RenderUnitTest(unittest.TestCase):
+    """Drive `main` against a temporary skills tree."""
+
+    def run_main(self, args, templates=None):
+        templates = templates or {}
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for skill, text in templates.items():
+                skill_dir = root / skill
+                skill_dir.mkdir(parents=True, exist_ok=True)
+                (skill_dir / 'prompt.md').write_text(text, encoding='utf-8')
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                code = RENDERER.main(['render_prompt.py'] + list(args), skills_root=root)
+        return code, out.getvalue(), err.getvalue()
+
+    def test_renders_and_substitutes(self):
+        code, out, err = self.run_main(
+            ['compile-gear', 'spurgear'], {'compile-gear': 'a {{gear}} b'})
+        self.assertEqual(code, 0, err)
+        self.assertEqual(out, 'a spurgear b')
+
+    def test_default_gear_is_spurgear(self):
+        code, out, err = self.run_main(
+            ['compile-gear'], {'compile-gear': 'a {{gear}} b'})
+        self.assertEqual(code, 0, err)
+        self.assertIn('spurgear', out)
+
+    def test_unknown_skill_exits_2(self):
+        code, out, err = self.run_main(
+            ['frobnicate-gear'], {'compile-gear': '{{gear}}'})
+        self.assertEqual(code, 2)
+        self.assertEqual(out, '')
+        for skill in RENDERER.KNOWN_SKILLS:
+            self.assertIn(skill, err)
+
+    def test_missing_template_exits_2(self):
+        code, out, err = self.run_main(['emit-gear'], {'compile-gear': '{{gear}}'})
+        self.assertEqual(code, 2)
+        self.assertEqual(out, '')
+        self.assertIn('emit-gear/prompt.md', err.replace('\\', '/'))
+
+    def test_invalid_gear_name_exits_2(self):
+        for gear in ('SpurGear', 'spur gear', '../etc', '<gear>', '{{gear}}', ''):
+            with self.subTest(gear=gear):
+                code, out, err = self.run_main(
+                    ['compile-gear', gear], {'compile-gear': 'a {{gear}} b'})
+                self.assertEqual(code, 2)
+                self.assertEqual(out, '')
+                self.assertIn('render_prompt:', err)
+
+    def test_unknown_placeholder_exits_2(self):
+        code, out, err = self.run_main(
+            ['compile-gear'], {'compile-gear': '{{gear}} has {{teeth}}'})
+        self.assertEqual(code, 2)
+        self.assertEqual(out, '')
+        self.assertIn('teeth', err)
+
+    def test_template_without_gear_placeholder_exits_2(self):
+        code, out, err = self.run_main(
+            ['compile-gear'], {'compile-gear': 'hard-coded spurgear\n'})
+        self.assertEqual(code, 2)
+        self.assertEqual(out, '')
+        self.assertIn('gear', err)
+
+    def test_stray_braces_exit_2(self):
+        code, out, err = self.run_main(
+            ['compile-gear'], {'compile-gear': 'a {{gear}} and {{gear}\n'})
+        self.assertEqual(code, 2)
+        self.assertEqual(out, '')
+
+    def test_angle_bracket_literals_untouched(self):
+        template = 'ask about <Class>.<member>, write <file>, log <unix-epoch-seconds> <n>\n{{gear}}\n'
+        code, out, err = self.run_main(['compile-gear', 'bevel'], {'compile-gear': template})
+        self.assertEqual(code, 0, err)
+        self.assertEqual(out, template.replace('{{gear}}', 'bevel'))
+
+    def test_output_preserves_template_bytes(self):
+        template = '  leading space\n\n\ttab line\ntrailing spaces   \n{{gear}} end'
+        code, out, err = self.run_main(['emit-gear', 'helical'], {'emit-gear': template})
+        self.assertEqual(code, 0, err)
+        self.assertEqual(out, template.replace('{{gear}}', 'helical'))
+
+
+class CommittedTemplatesTest(unittest.TestCase):
+    """Check the templates and SKILL.md files that ship in the repo."""
+
+    def render(self, skill, gear):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = RENDERER.main(['render_prompt.py', skill, gear])
+        return code, out.getvalue(), err.getvalue()
+
+    def test_all_templates_render(self):
+        for skill in RENDERER.KNOWN_SKILLS:
+            with self.subTest(skill=skill):
+                code, out, err = self.render(skill, 'testgear')
+                self.assertEqual(code, 0, err)
+                self.assertIn('testgear', out)
+                self.assertNotIn('{{', out)
+                self.assertNotIn('}}', out)
+
+    def test_templates_declare_only_gear(self):
+        for skill in RENDERER.KNOWN_SKILLS:
+            with self.subTest(skill=skill):
+                text = (SKILLS_ROOT / skill / 'prompt.md').read_text(encoding='utf-8')
+                names = RENDERER.PLACEHOLDER_RE.findall(text)
+                self.assertIn('gear', names)
+                self.assertEqual(set(names), {'gear'})
+
+    def test_emit_prompt_gate_scripts_exist(self):
+        text = (SKILLS_ROOT / 'emit-gear' / 'prompt.md').read_text(encoding='utf-8')
+        names = {
+            name for name in re.findall(r'\w+\.py', text)
+            if name.startswith('check_') or name == 'pyright_check.py'
+        }
+        self.assertTrue(names, 'emit prompt should name the gate scripts')
+        for name in sorted(names):
+            with self.subTest(script=name):
+                self.assertTrue(
+                    (SKILLS_ROOT / 'generate-gear' / name).is_file(),
+                    '{} named by the emit prompt does not exist'.format(name))
+
+    def test_skill_md_references_renderer_not_a_copy(self):
+        for skill in RENDERER.KNOWN_SKILLS:
+            with self.subTest(skill=skill):
+                skill_md = (SKILLS_ROOT / skill / 'SKILL.md').read_text(encoding='utf-8')
+                self.assertIn('render_prompt.py {}'.format(skill), skill_md)
+                template = (SKILLS_ROOT / skill / 'prompt.md').read_text(encoding='utf-8')
+                first_line = template.splitlines()[0].replace('{{gear}}', '<gear>')
+                self.assertNotIn(
+                    first_line, skill_md,
+                    'SKILL.md re-inlines the prompt instead of pointing at prompt.md')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Make "use the prompt verbatim" a program's output, not a retyped blockquote.
- Each skill's prompt moves to a sibling `prompt.md`, rendered by `render_prompt.py`.
- Tests gate a re-inlined copy, an orphaned gate script, or a stray placeholder.
