### PR TITLE
add stage.py to replace ad-hoc artifact moves

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -64,9 +64,13 @@ proof is where the next reader is looking for the missing check.
    prompt varies run to run and hides gaps by spoon-feeding what the prose should have said, so a
    green run would no longer say anything about the spec.
 
-4. **Run the proof.** Copy every drafted proof file into `proof/<gear>/` and run
+4. **Run the proof.** Run `python3 .claude/skills/generate-gear/stage.py <gear> proof --run` from
+   the repo root. It copies every drafted proof file from `.tmp/<gear>-proof/` into
+   `proof/<gear>/`, deletes any `.go` file there the draft no longer produces, indexes the result
+   so step 5's tracked-or-committed check can see a first-time proof, and then runs
    `bash proof/run.sh`. The wrapper enters the `proof/` module and configures the local engine
-   replacements; the proof must pass with nothing waived.
+   replacements; the proof must pass with nothing waived. Exit 2 means the placement was refused
+   and nothing moved; exit 1 means the proof itself is red.
 
 5. **Check.** Run `python3 .claude/skills/generate-gear/check_compile.py <gear>` from the repo
    root. It gates citations, step-to-proof agreement, the reality of every named API call, and the
@@ -86,8 +90,11 @@ proof is where the next reader is looking for the missing check.
 6. **Diagnose and loop.** Classify any failure with the table below. A draft fault goes back to
    step 3 with the failure text appended, up to about three rounds. A prose fault stops the run.
 
-7. **Place.** On success, move the drafted step list and every drafted proof file into the working
-   tree. This writes files only; it does not commit, push, or touch Fusion's add-in directory.
+7. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> steps` and
+   `python3 .claude/skills/generate-gear/stage.py <gear> proof` from the repo root. They put the
+   drafted step list and every drafted proof file into the working tree and report what moved; the
+   proof call repeats step 4's placement, so it should report every file unchanged. This writes
+   files and the git index only; it does not commit, push, or touch Fusion's add-in directory.
 
 8. **Report.** State what was produced, the coverage list, and every prose fault found.
 

--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -31,8 +31,9 @@ the pipeline exists to make trustworthy.
 5. **Diagnose and loop.** Classify any failure with the table below. An emit fault goes back to
    step 3 with the failure text appended, up to about three rounds. A compile fault stops the run.
 
-6. **Place.** On success, move the draft to `lib/geargen/<gear>.py`. This writes a file only; it
-   does not commit, push, or touch Fusion's add-in directory.
+6. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> module` from
+   the repo root. It puts `.tmp/<gear>.generated.py` at `lib/geargen/<gear>.py` and reports what
+   moved. This writes a file only; it does not commit, push, or touch Fusion's add-in directory.
 
 7. **Report.** State the gate results and every step that was thin or wrong.
 

--- a/.claude/skills/generate-gear/stage.py
+++ b/.claude/skills/generate-gear/stage.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Stage drafted gear artifacts into the working tree.
+
+`compile-gear` and `emit-gear` used to move drafted files by hand with shell
+commands. That left three hazards: a partial copy on a shell-loop failure, a
+stale `.go` file from an earlier draft round still compiled into
+`proof/<gear>/` and silently credited to the current draft, and an untracked
+first-time proof that fails `check_compile`'s tracked-or-committed gate for
+reasons that have nothing to do with the draft. This script replaces the
+shell moves with one mechanical, atomic, idempotent placement per target.
+
+Three subcommands, one per artifact this pipeline stages:
+
+  stage.py <gear> proof  [--run] [--no-index] [--force] [--dry-run]
+      Copies every `*.go` file from `.tmp/<gear>-proof/` into `proof/<gear>/`,
+      deleting any `.go` file already there that the draft no longer
+      produces. Indexes the result (`git add -A -- proof/<gear>`) unless
+      `--no-index` is given, so a first-time proof passes the
+      tracked-or-committed check. `--run` then runs `bash proof/run.sh`.
+
+  stage.py <gear> steps  [--force] [--dry-run]
+      Copies `.tmp/<gear>.steps.md` to `spec/<gear>/steps.md`.
+
+  stage.py <gear> module [--force] [--dry-run]
+      Copies `.tmp/<gear>.generated.py` to `lib/geargen/<gear>.py`.
+
+`--root DIR` (default `.`) is the repo root; every path above is relative to
+it. `--force` overwrites a destination file that is neither this script's
+own prior output nor clean against HEAD. `--dry-run` validates and reports
+what would happen, writing nothing.
+
+The source is always copied, never deleted, so every subcommand is
+idempotent: running it again over the same draft reports every file
+unchanged.
+
+Usage:
+    python3 stage.py [--root DIR] <gear> {proof,steps,module} [options]
+
+Run from the repo root.
+
+Exit 0 = everything asked for was done (and `--run`, if given, passed).
+Exit 1 = placement succeeded, but `bash proof/run.sh` failed (only
+         `proof --run` can return this).
+Exit 2 = refused; nothing was written, or everything written was rolled
+         back.
+"""
+import argparse
+import collections
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+GEAR_NAME = re.compile(r'[a-z][a-z0-9_]*\Z')
+
+
+class Refusal(Exception):
+    """Raised to refuse a placement. The message is printed to stderr; always exit 2."""
+
+
+Plan = collections.namedtuple(
+    'Plan', 'target gear source destination sources_are_dir')
+Actions = collections.namedtuple('Actions', 'write unchanged prune extra')
+
+
+def _joined(root, *parts):
+    return os.path.normpath(os.path.join(root, *parts))
+
+
+def gear_paths(root, gear, target):
+    """Build the source and destination paths for one target.
+
+    Pure path arithmetic: validates the gear name and raises `Refusal`
+    otherwise, but performs no I/O.
+    """
+    if not GEAR_NAME.match(gear):
+        raise Refusal(
+            "%r is not a valid gear name (expected lowercase letters, digits or "
+            "underscore, starting with a letter)" % gear)
+    if target == 'proof':
+        source = _joined(root, '.tmp', '%s-proof' % gear)
+        destination = _joined(root, 'proof', gear)
+        sources_are_dir = True
+    elif target == 'steps':
+        source = _joined(root, '.tmp', '%s.steps.md' % gear)
+        destination = _joined(root, 'spec', gear, 'steps.md')
+        sources_are_dir = False
+    elif target == 'module':
+        source = _joined(root, '.tmp', '%s.generated.py' % gear)
+        destination = _joined(root, 'lib', 'geargen', '%s.py' % gear)
+        sources_are_dir = False
+    else:
+        raise Refusal("unknown target %r" % target)
+    return Plan(target, gear, source, destination, sources_are_dir)
+
+
+def read_sources(plan):
+    """Phase 1 read of the draft. Returns an ordered dict of name to bytes.
+
+    Applies the source refusals (missing source, empty source, a zero-byte
+    `.go` file) and the draft-directory refusal (a non-`.go` regular file or
+    a subdirectory in the draft directory).
+    """
+    sources = collections.OrderedDict()
+    if plan.sources_are_dir:
+        if not os.path.isdir(plan.source):
+            raise Refusal(
+                "%s does not exist, so there is nothing to place" % plan.source)
+        entries = sorted(os.listdir(plan.source))
+        directories = [e for e in entries
+                       if os.path.isdir(os.path.join(plan.source, e))]
+        if directories:
+            full = os.path.join(plan.source, directories[0])
+            raise Refusal(
+                "%s is a subdirectory of the draft, and only .go files belong there"
+                % full)
+        go_files = [e for e in entries if e.endswith('.go')]
+        others = [e for e in entries if not e.endswith('.go')]
+        if others:
+            full = os.path.join(plan.source, others[0])
+            raise Refusal(
+                "%s is not a .go file, and only .go files belong in the draft "
+                "directory" % full)
+        if not go_files:
+            raise Refusal(
+                "%s contains no .go file, so there is nothing to place" % plan.source)
+        for name in go_files:
+            full = os.path.join(plan.source, name)
+            with open(full, 'rb') as fh:
+                data = fh.read()
+            if not data:
+                raise Refusal("%s is zero bytes" % full)
+            sources[name] = data
+    else:
+        if not os.path.isfile(plan.source):
+            raise Refusal(
+                "%s does not exist, so there is nothing to place" % plan.source)
+        with open(plan.source, 'rb') as fh:
+            data = fh.read()
+        if not data:
+            raise Refusal("%s is zero bytes" % plan.source)
+        sources[os.path.basename(plan.destination)] = data
+    return sources
+
+
+def existing_destination(plan):
+    """Read what is in the destination now, restricted to `*.go` for `proof`.
+
+    Returns name to bytes. Raises `Refusal` if a destination path is a
+    directory or a symlink where a file is expected, or if the destination's
+    parent directory does not exist (a missing `proof/<gear>/` is the one
+    exception: it is created when absent, so it is not checked here).
+    """
+    existing = collections.OrderedDict()
+    if plan.sources_are_dir:
+        if os.path.islink(plan.destination):
+            raise Refusal("%s exists but is a symlink" % plan.destination)
+        if os.path.exists(plan.destination) and not os.path.isdir(plan.destination):
+            raise Refusal("%s exists but is not a directory" % plan.destination)
+        if os.path.isdir(plan.destination):
+            for name in sorted(os.listdir(plan.destination)):
+                if not name.endswith('.go'):
+                    continue
+                full = os.path.join(plan.destination, name)
+                if os.path.islink(full):
+                    raise Refusal("%s exists but is a symlink" % full)
+                if os.path.isdir(full):
+                    raise Refusal("%s exists but is a directory" % full)
+                with open(full, 'rb') as fh:
+                    existing[name] = fh.read()
+        return existing
+
+    parent = os.path.dirname(plan.destination)
+    if not os.path.isdir(parent):
+        raise Refusal(
+            "%s does not exist, which likely means %r is the wrong gear name"
+            % (parent, plan.gear))
+    if os.path.exists(plan.destination):
+        if os.path.islink(plan.destination):
+            raise Refusal("%s exists but is a symlink" % plan.destination)
+        if os.path.isdir(plan.destination):
+            raise Refusal("%s exists but is a directory" % plan.destination)
+        with open(plan.destination, 'rb') as fh:
+            existing[os.path.basename(plan.destination)] = fh.read()
+    return existing
+
+
+def destination_extras(plan):
+    """Non-`.go` regular files already sitting in a `proof` destination.
+
+    Reported in the summary, never touched: the destination directory may be
+    legitimately extended by a human (testdata, a README), so only the
+    extension the pipeline actually generates is ever pruned.
+    """
+    if not plan.sources_are_dir or not os.path.isdir(plan.destination):
+        return []
+    extras = []
+    for name in sorted(os.listdir(plan.destination)):
+        if name.endswith('.go'):
+            continue
+        full = os.path.join(plan.destination, name)
+        if os.path.isfile(full):
+            extras.append(name)
+    return extras
+
+
+def receipt_path(root, gear, target):
+    return _joined(root, '.tmp', 'stage', '%s.%s.json' % (gear, target))
+
+
+def load_receipt(root, gear, target):
+    """The map of relative name to SHA-256 this script wrote last time it succeeded.
+
+    A missing or unreadable receipt is `{}`, never an error.
+    """
+    path = receipt_path(root, gear, target)
+    try:
+        with open(path, encoding='utf-8') as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return {}
+
+
+def save_receipt(root, gear, target, sources):
+    """Rewrite the receipt to record the bytes this run placed."""
+    path = receipt_path(root, gear, target)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    receipt = {name: hashlib.sha256(data).hexdigest() for name, data in sources.items()}
+    with open(path, 'w', encoding='utf-8') as fh:
+        json.dump(receipt, fh, sort_keys=True, indent=2)
+        fh.write('\n')
+
+
+def git_is_clean(root, relpath):
+    """Whether `<relpath>` is clean against HEAD, or `None` if that cannot be known.
+
+    `None` means the root is not a git work tree (or git is unavailable), so
+    the dirty-destination check degrades to "safe" rather than to a refusal.
+    """
+    try:
+        result = subprocess.run(
+            ['git', 'status', '--porcelain', '--', relpath],
+            cwd=root, capture_output=True, text=True)
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() == ''
+
+
+def classify_destination(plan, existing, receipt, force, root):
+    """Raise `Refusal` on the first existing file that is neither ours nor clean.
+
+    A file is safe to replace when its SHA-256 matches the receipt from this
+    script's last successful run, or when it is clean against HEAD. `root` is
+    needed here (beyond what `plan` carries) to run `git status` from the
+    right working tree; see the deviations noted in the PR description.
+    """
+    if force:
+        return
+    warned = False
+    for name in sorted(existing):
+        data = existing[name]
+        digest = hashlib.sha256(data).hexdigest()
+        if receipt.get(name) == digest:
+            continue
+        full = (os.path.join(plan.destination, name)
+                if plan.sources_are_dir else plan.destination)
+        relpath = os.path.relpath(full, root)
+        clean = git_is_clean(root, relpath)
+        if clean is None:
+            if not warned:
+                print("stage: %s is not a git work tree; skipping the clean-tree check"
+                      % root, file=sys.stderr)
+                warned = True
+            continue
+        if clean:
+            continue
+        raise Refusal(
+            "%s is neither this script's own output nor clean against HEAD; "
+            "commit it, revert it, or pass --force" % full)
+
+
+def plan_actions(sources, existing):
+    """Diff sources against what already exists. Pure, no I/O.
+
+    `prune` only ever contains names present in `existing` but absent from
+    `sources`; the caller only builds a nonempty `existing` for `proof`, so
+    this is naturally scoped to that target.
+    """
+    write = []
+    unchanged = []
+    for name, data in sources.items():
+        if existing.get(name) == data:
+            unchanged.append(name)
+        else:
+            write.append(name)
+    prune = [name for name in existing if name not in sources]
+    return Actions(sorted(write), sorted(unchanged), sorted(prune), [])
+
+
+def _temp_path(path):
+    directory = os.path.dirname(path) or '.'
+    base = os.path.basename(path)
+    n = 0
+    while True:
+        candidate = os.path.join(directory, '.%s.stage-tmp.%d.%d' % (base, os.getpid(), n))
+        if not os.path.exists(candidate):
+            return candidate
+        n += 1
+
+
+def _atomic_write(path, data):
+    tmp = _temp_path(path)
+    with open(tmp, 'wb') as fh:
+        fh.write(data)
+    try:
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _restore(full, previous):
+    """Best-effort restore of one file to its pre-run state during rollback."""
+    if previous is None:
+        try:
+            os.unlink(full)
+        except OSError:
+            pass
+    else:
+        try:
+            _atomic_write(full, previous)
+        except OSError:
+            pass
+
+
+def apply_actions(plan, actions, sources, existing):
+    """Phase 2: write, then prune, restoring everything touched on any failure.
+
+    Each write goes to a temp name in the destination directory and is moved
+    into place with `os.replace`, so no half-written file is ever visible.
+    If any write or unlink raises, every file this call already touched is
+    restored from the in-memory `existing` snapshot before the exception is
+    re-raised.
+    """
+    if plan.sources_are_dir:
+        os.makedirs(plan.destination, exist_ok=True)
+
+    touched = []
+    try:
+        for name in actions.write:
+            full = (os.path.join(plan.destination, name)
+                    if plan.sources_are_dir else plan.destination)
+            previous = existing.get(name)
+            _atomic_write(full, sources[name])
+            touched.append((full, previous))
+        for name in actions.prune:
+            full = (os.path.join(plan.destination, name)
+                    if plan.sources_are_dir else plan.destination)
+            previous = existing.get(name)
+            os.unlink(full)
+            touched.append((full, previous))
+    except Exception:
+        for full, previous in reversed(touched):
+            _restore(full, previous)
+        raise
+
+
+def index_paths(root, plan):
+    """`git add -A -- proof/<gear>`. Returns False (with a printed note) if git fails."""
+    relpath = os.path.relpath(plan.destination, root)
+    try:
+        result = subprocess.run(
+            ['git', 'add', '-A', '--', relpath], cwd=root,
+            capture_output=True, text=True)
+    except FileNotFoundError:
+        print("stage: git is not available; %s was not indexed" % relpath, file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print("stage: git add failed for %s; not indexed (%s)"
+              % (relpath, result.stderr.strip()), file=sys.stderr)
+        return False
+    print("stage: indexed %s" % relpath)
+    return True
+
+
+def run_proof(root):
+    """Run `bash proof/run.sh`, passing its output through, and return its exit code."""
+    print("stage: running bash proof/run.sh")
+    result = subprocess.run(
+        ['bash', 'proof/run.sh'], cwd=root, capture_output=True, text=True)
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+def report(plan, actions, dry_run, sources):
+    """Print the action lines and the summary line, in sorted path order."""
+    prefix = 'would ' if dry_run else ''
+    write_verb = 'write' if dry_run else 'wrote'
+    prune_verb = 'prune' if dry_run else 'pruned'
+
+    def full_path(name):
+        return (os.path.join(plan.destination, name)
+                if plan.sources_are_dir else plan.destination)
+
+    for name in actions.write:
+        print("stage: %s%s %s (%d bytes)"
+              % (prefix, write_verb, full_path(name), len(sources[name])))
+    for name in actions.unchanged:
+        print("stage: unchanged %s" % full_path(name))
+    for name in actions.prune:
+        print("stage: %s%s %s (the draft no longer produces it)"
+              % (prefix, prune_verb, full_path(name)))
+    for name in actions.extra:
+        print("stage: %s left alone (not produced by the draft)" % full_path(name))
+
+    if plan.target == 'proof':
+        print("stage: proof OK (%d written, %d unchanged, %d pruned)"
+              % (len(actions.write), len(actions.unchanged), len(actions.prune)))
+    elif actions.write:
+        print("stage: %s OK (%d written)" % (plan.target, len(actions.write)))
+    else:
+        print("stage: %s OK (%d unchanged)" % (plan.target, len(actions.unchanged)))
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog='stage.py',
+        description='Stage a drafted gear artifact (proof, steps or module) into the '
+                     'working tree.')
+    parser.add_argument('--root', default='.', help='repo root (default .)')
+    parser.add_argument('gear', help='gear name, e.g. spurgear')
+    sub = parser.add_subparsers(dest='target', required=True)
+
+    proof = sub.add_parser('proof', help='place proof/<gear>/ from .tmp/<gear>-proof/')
+    proof.add_argument('--run', action='store_true',
+                        help='run bash proof/run.sh after a successful placement')
+    proof.add_argument('--no-index', action='store_true',
+                        help='skip `git add -A -- proof/<gear>`')
+    proof.add_argument('--force', action='store_true',
+                        help='overwrite a destination file that is not clean or ours')
+    proof.add_argument('--dry-run', action='store_true',
+                        help='validate and report; write nothing')
+
+    steps = sub.add_parser('steps', help='place spec/<gear>/steps.md from .tmp/<gear>.steps.md')
+    steps.add_argument('--force', action='store_true',
+                        help='overwrite a destination file that is not clean or ours')
+    steps.add_argument('--dry-run', action='store_true',
+                        help='validate and report; write nothing')
+
+    module = sub.add_parser('module',
+                             help='place lib/geargen/<gear>.py from .tmp/<gear>.generated.py')
+    module.add_argument('--force', action='store_true',
+                         help='overwrite a destination file that is not clean or ours')
+    module.add_argument('--dry-run', action='store_true',
+                         help='validate and report; write nothing')
+
+    return parser
+
+
+def main(argv):
+    parser = build_parser()
+    args = parser.parse_args(argv[1:])
+    root = args.root
+
+    try:
+        plan = gear_paths(root, args.gear, args.target)
+        sources = read_sources(plan)
+        existing = existing_destination(plan)
+        extras = destination_extras(plan)
+        receipt = load_receipt(root, args.gear, plan.target)
+        classify_destination(plan, existing, receipt, args.force, root)
+        actions = plan_actions(sources, existing)._replace(extra=extras)
+    except Refusal as exc:
+        print("stage: %s" % exc, file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        report(plan, actions, True, sources)
+        return 0
+
+    try:
+        apply_actions(plan, actions, sources, existing)
+    except Exception as exc:
+        print("stage: %s: placement failed and was rolled back (%s)" % (plan.target, exc),
+              file=sys.stderr)
+        return 2
+
+    save_receipt(root, args.gear, plan.target, sources)
+
+    if plan.target == 'proof' and not getattr(args, 'no_index', False):
+        index_paths(root, plan)
+
+    report(plan, actions, False, sources)
+
+    if getattr(args, 'run', False):
+        code = run_proof(root)
+        if code != 0:
+            print("stage: proof run FAILED (exit %d)" % code, file=sys.stderr)
+            return 1
+        print("stage: proof run OK")
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/.claude/skills/generate-gear/test_stage.py
+++ b/.claude/skills/generate-gear/test_stage.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Regression tests for stage.py, the drafted-artifact placement script."""
+import contextlib
+import importlib.util
+import io
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+MODULE_PATH = Path(__file__).with_name('stage.py')
+SPEC = importlib.util.spec_from_file_location('stage', MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def make_root(tmp, gear='spurgear', draft=None, placed=None, steps=None, module=None):
+    """Build a fake repo root: .tmp/, proof/<gear>/, spec/<gear>/, lib/geargen/, proof/run.sh."""
+    root = Path(tmp)
+    (root / '.tmp').mkdir(parents=True, exist_ok=True)
+    (root / 'proof' / gear).mkdir(parents=True, exist_ok=True)
+    (root / 'spec' / gear).mkdir(parents=True, exist_ok=True)
+    (root / 'lib' / 'geargen').mkdir(parents=True, exist_ok=True)
+    proof_dir = root / 'proof'
+    proof_dir.mkdir(parents=True, exist_ok=True)
+    run_sh = proof_dir / 'run.sh'
+    run_sh.write_text('#!/usr/bin/env bash\necho "run.sh not configured"\nexit 0\n')
+    run_sh.chmod(run_sh.stat().st_mode | stat.S_IEXEC)
+
+    if draft is not None:
+        draft_dir = root / '.tmp' / ('%s-proof' % gear)
+        draft_dir.mkdir(parents=True, exist_ok=True)
+        for name, content in draft.items():
+            path = draft_dir / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, bytes):
+                path.write_bytes(content)
+            else:
+                path.write_text(content)
+
+    if placed is not None:
+        placed_dir = root / 'proof' / gear
+        for name, content in placed.items():
+            path = placed_dir / name
+            if isinstance(content, bytes):
+                path.write_bytes(content)
+            else:
+                path.write_text(content)
+
+    if steps is not None:
+        (root / '.tmp' / ('%s.steps.md' % gear)).write_text(steps)
+
+    if module is not None:
+        (root / '.tmp' / ('%s.generated.py' % gear)).write_text(module)
+
+    return root
+
+
+def run_stage(root, *argv):
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = MODULE.main(['stage.py', '--root', str(root), *argv])
+    return code, out.getvalue(), err.getvalue()
+
+
+def git_init(root):
+    subprocess.run(['git', 'init', '--quiet'], cwd=str(root), check=True)
+    subprocess.run(['git', 'config', 'user.email', 'fixture@example.invalid'],
+                    cwd=str(root), check=True)
+    subprocess.run(['git', 'config', 'user.name', 'fixture'], cwd=str(root), check=True)
+
+
+def git_commit_all(root, message='fixture'):
+    subprocess.run(['git', 'add', '-A'], cwd=str(root), check=True)
+    subprocess.run(['git', 'commit', '--quiet', '-m', message], cwd=str(root), check=True)
+
+
+class PlacementTests(unittest.TestCase):
+    def test_proof_copies_every_drafted_go_file_into_empty_destination(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'package spurgear_test\n',
+                                          'b_test.go': 'package spurgear_test\n'})
+            code, out, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertIn('wrote', out)
+            dest = root / 'proof' / 'spurgear'
+            self.assertEqual((dest / 'a_test.go').read_text(), 'package spurgear_test\n')
+            self.assertEqual((dest / 'b_test.go').read_text(), 'package spurgear_test\n')
+
+    def test_proof_reports_unchanged_and_does_not_rewrite_identical_bytes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            content = 'package spurgear_test\n'
+            root = make_root(tmp, draft={'a_test.go': content}, placed={'a_test.go': content})
+            dest = root / 'proof' / 'spurgear' / 'a_test.go'
+            before_mtime = dest.stat().st_mtime_ns
+            code, out, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertIn('unchanged', out)
+            self.assertEqual(dest.stat().st_mtime_ns, before_mtime)
+
+    def test_proof_overwrites_a_destination_file_that_differs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'}, placed={'a_test.go': 'old\n'})
+            code, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(), 'new\n')
+
+    def test_steps_places_draft_at_spec_steps_md(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, steps='# steps\n')
+            code, out, _ = run_stage(root, 'spurgear', 'steps')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'spec' / 'spurgear' / 'steps.md').read_text(), '# steps\n')
+            self.assertIn('wrote', out)
+
+    def test_module_places_draft_at_lib_geargen(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, module='# generated\n')
+            code, _, _ = run_stage(root, 'spurgear', 'module')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'lib' / 'geargen' / 'spurgear.py').read_text(),
+                             '# generated\n')
+
+    def test_source_survives_and_rerun_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            code1, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code1, 0)
+            self.assertTrue((root / '.tmp' / 'spurgear-proof' / 'a_test.go').exists())
+            code2, out2, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code2, 0)
+            self.assertNotIn('wrote', out2)
+            self.assertIn('unchanged', out2)
+
+
+class StaleFileTests(unittest.TestCase):
+    def test_prunes_a_go_file_the_draft_no_longer_produces(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'},
+                              placed={'helpers_test.go': 'stale\n'})
+            code, out, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertIn('pruned', out)
+            self.assertIn('helpers_test.go', out)
+            self.assertFalse((root / 'proof' / 'spurgear' / 'helpers_test.go').exists())
+
+    def test_non_go_file_in_destination_survives_and_is_mentioned(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'},
+                              placed={'testdata.json': '{}'})
+            code, out, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertTrue((root / 'proof' / 'spurgear' / 'testdata.json').exists())
+            self.assertEqual(out.count('testdata.json'), 1)
+
+    def test_go_file_in_subdirectory_of_destination_is_not_pruned(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            sub = root / 'proof' / 'spurgear' / 'sub'
+            sub.mkdir()
+            (sub / 'nested_test.go').write_text('nested\n')
+            code, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertTrue((sub / 'nested_test.go').exists())
+
+
+class RefusalTests(unittest.TestCase):
+    def _assert_refused_untouched(self, root, gear, *argv, before=None):
+        code, _, err = run_stage(root, gear, *argv)
+        self.assertEqual(code, 2)
+        self.assertTrue(err.strip())
+        if before is not None:
+            for path, content in before.items():
+                self.assertEqual(Path(path).read_bytes(), content)
+
+    def test_missing_source_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp)
+            self._assert_refused_untouched(root, 'spurgear', 'proof')
+
+    def test_draft_directory_with_no_go_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'notes.txt': 'hi\n'})
+            (root / '.tmp' / 'spurgear-proof' / 'notes.txt').unlink()
+            self._assert_refused_untouched(root, 'spurgear', 'proof')
+
+    def test_draft_directory_with_zero_byte_go_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': ''})
+            self._assert_refused_untouched(root, 'spurgear', 'proof')
+
+    def test_draft_directory_with_non_go_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n', 'notes.md': 'hi\n'})
+            self._assert_refused_untouched(root, 'spurgear', 'proof')
+
+    def test_draft_directory_with_subdirectory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            (root / '.tmp' / 'spurgear-proof' / 'sub').mkdir()
+            self._assert_refused_untouched(root, 'spurgear', 'proof')
+
+    def test_missing_steps_source_and_zero_byte_steps_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp)
+            self._assert_refused_untouched(root, 'spurgear', 'steps')
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, steps='')
+            self._assert_refused_untouched(root, 'spurgear', 'steps')
+
+    def test_missing_module_source_and_zero_byte_module_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp)
+            self._assert_refused_untouched(root, 'spurgear', 'module')
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, module='')
+            self._assert_refused_untouched(root, 'spurgear', 'module')
+
+    def test_bad_gear_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp)
+            for bad in ('../evil', 'Spur', ''):
+                self._assert_refused_untouched(root, bad, 'steps')
+
+    def test_steps_and_module_refuse_when_parent_directory_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, steps='# steps\n')
+            import shutil
+            shutil.rmtree(root / 'spec' / 'spurgear')
+            self._assert_refused_untouched(root, 'spurgear', 'steps')
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, module='# gen\n')
+            import shutil
+            shutil.rmtree(root / 'lib' / 'geargen')
+            self._assert_refused_untouched(root, 'spurgear', 'module')
+
+    def test_proof_creates_destination_directory_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            import shutil
+            shutil.rmtree(root / 'proof' / 'spurgear')
+            code, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertTrue((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+
+
+class DirtyDestinationTests(unittest.TestCase):
+    def test_hand_edited_destination_refuses_without_force(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-2\n'},
+                              placed={'a_test.go': 'draft-1\n'})
+            git_init(root)
+            git_commit_all(root)
+            (root / 'proof' / 'spurgear' / 'a_test.go').write_text('hand-edited\n')
+
+            code, _, err = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 2)
+            self.assertIn('a_test.go', err)
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(),
+                             'hand-edited\n')
+
+    def test_force_overwrites_hand_edited_destination(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-2\n'},
+                              placed={'a_test.go': 'draft-1\n'})
+            git_init(root)
+            git_commit_all(root)
+            (root / 'proof' / 'spurgear' / 'a_test.go').write_text('hand-edited\n')
+
+            code, _, _ = run_stage(root, 'spurgear', 'proof', '--force')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(),
+                             'draft-2\n')
+
+    def test_receipt_matching_hand_edited_content_succeeds_without_force(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-1\n'})
+            code0, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code0, 0)
+            git_init(root)
+            git_commit_all(root)
+
+            (root / '.tmp' / 'spurgear-proof' / 'a_test.go').write_text('draft-2\n')
+            code, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(),
+                             'draft-2\n')
+
+    def test_clean_committed_destination_with_no_receipt_is_overwritten(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-2\n'},
+                              placed={'a_test.go': 'draft-1\n'})
+            git_init(root)
+            git_commit_all(root)
+
+            code, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(),
+                             'draft-2\n')
+
+    def test_non_git_root_stages_successfully_and_notes_skipped_check(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-2\n'},
+                              placed={'a_test.go': 'draft-1\n'})
+            code, _, err = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            self.assertIn('not a git work tree', err)
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(),
+                             'draft-2\n')
+
+
+class AtomicityTests(unittest.TestCase):
+    def test_replace_failure_rolls_back_every_touched_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp,
+                              draft={'a_test.go': 'new-a\n', 'b_test.go': 'new-b\n'},
+                              placed={'a_test.go': 'old-a\n', 'b_test.go': 'old-b\n'})
+            real_replace = os.replace
+            calls = {'n': 0}
+
+            def flaky_replace(src, dst):
+                calls['n'] += 1
+                if calls['n'] == 2:
+                    raise OSError('synthetic replace failure')
+                return real_replace(src, dst)
+
+            with mock.patch.object(MODULE.os, 'replace', side_effect=flaky_replace):
+                code, _, err = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 2)
+            self.assertTrue(err.strip())
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(), 'old-a\n')
+            self.assertEqual((root / 'proof' / 'spurgear' / 'b_test.go').read_text(), 'old-b\n')
+
+    def test_unlink_failure_during_prune_rolls_back_writes_too(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp,
+                              draft={'a_test.go': 'new-a\n'},
+                              placed={'a_test.go': 'old-a\n', 'stale_test.go': 'stale\n'})
+
+            def flaky_unlink(path):
+                raise OSError('synthetic unlink failure')
+
+            with mock.patch.object(MODULE.os, 'unlink', side_effect=flaky_unlink):
+                code, _, err = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 2)
+            self.assertTrue(err.strip())
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(), 'old-a\n')
+            self.assertTrue((root / 'proof' / 'spurgear' / 'stale_test.go').exists())
+
+
+class RunIndexDryRunTests(unittest.TestCase):
+    def test_run_with_passing_stub_reports_ok_and_passes_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            run_sh = root / 'proof' / 'run.sh'
+            run_sh.write_text('#!/usr/bin/env bash\necho hello-from-stub\nexit 0\n')
+            run_sh.chmod(run_sh.stat().st_mode | stat.S_IEXEC)
+
+            code, out, _ = run_stage(root, 'spurgear', 'proof', '--run')
+            self.assertEqual(code, 0)
+            self.assertIn('proof run OK', out)
+            self.assertIn('hello-from-stub', out)
+
+    def test_run_with_failing_stub_returns_1_and_keeps_placement(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            run_sh = root / 'proof' / 'run.sh'
+            run_sh.write_text('#!/usr/bin/env bash\necho boom-from-stub\nexit 1\n')
+            run_sh.chmod(run_sh.stat().st_mode | stat.S_IEXEC)
+
+            code, out, err = run_stage(root, 'spurgear', 'proof', '--run')
+            self.assertEqual(code, 1)
+            self.assertIn('FAILED', err)
+            self.assertIn('boom-from-stub', out)
+            self.assertTrue((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+
+    def test_run_flag_rejected_for_steps_and_module(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, steps='# steps\n', module='# gen\n')
+            with self.assertRaises(SystemExit) as cm:
+                MODULE.main(['stage.py', '--root', str(root), 'spurgear', 'steps', '--run'])
+            self.assertEqual(cm.exception.code, 2)
+            with self.assertRaises(SystemExit) as cm:
+                MODULE.main(['stage.py', '--root', str(root), 'spurgear', 'module', '--run'])
+            self.assertEqual(cm.exception.code, 2)
+
+    def test_proof_indexes_writes_and_prunes_unless_no_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'},
+                              placed={'stale_test.go': 'stale\n'})
+            git_init(root)
+            git_commit_all(root)
+
+            code, _, _ = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code, 0)
+            staged = subprocess.run(
+                ['git', 'diff', '--cached', '--name-only'], cwd=str(root),
+                capture_output=True, text=True, check=True).stdout
+            self.assertIn('proof/spurgear/a_test.go', staged)
+            self.assertIn('proof/spurgear/stale_test.go', staged)
+
+    def test_no_index_leaves_git_index_untouched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'})
+            git_init(root)
+            git_commit_all(root)
+
+            code, _, _ = run_stage(root, 'spurgear', 'proof', '--no-index')
+            self.assertEqual(code, 0)
+            staged = subprocess.run(
+                ['git', 'diff', '--cached', '--name-only'], cwd=str(root),
+                capture_output=True, text=True, check=True).stdout
+            self.assertEqual(staged.strip(), '')
+
+    def test_dry_run_prints_would_lines_and_touches_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'},
+                              placed={'stale_test.go': 'stale\n'})
+            code, out, _ = run_stage(root, 'spurgear', 'proof', '--dry-run')
+            self.assertEqual(code, 0)
+            self.assertIn('would write', out)
+            self.assertIn('would prune', out)
+            self.assertFalse((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+            self.assertTrue((root / 'proof' / 'spurgear' / 'stale_test.go').exists())
+            self.assertFalse((root / '.tmp' / 'stage').exists())
+
+    def test_dry_run_against_missing_source_still_exits_2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp)
+            code_dry, _, err_dry = run_stage(root, 'spurgear', 'proof', '--dry-run')
+            code_real, _, err_real = run_stage(root, 'spurgear', 'proof')
+            self.assertEqual(code_dry, 2)
+            self.assertEqual(code_real, 2)
+            self.assertEqual(err_dry.strip(), err_real.strip())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Stops a stale proof `.go` file from being silently compiled and credited to the current draft.
- Indexes a first-time proof so the tracked-or-committed gate stops failing for unrelated reasons.
- Validates and writes atomically, so a mid-copy failure can't leave a half-placed proof.
