### PR TITLE
add watch_progress.py to replace manual poll loop

### DIFF
--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -73,13 +73,26 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
      no longer proves the *spec* states it well enough. Identical prompt every run ⇒ a pass/fail is
      attributable to the spec, which is the whole point. When a regen reveals a gap, fix the
      **spec/playbook** and re-run the **same** standard prompt — never patch the prompt.
-   - **Launch in the background and watch the heartbeat.** Run the subagent as a background task
-     and poll `.tmp/<gear>.progress.log` every ~2–3 minutes (the standard prompt makes the subagent
-     append one milestone line per phase). Stall rules: **no `start` line within ~5 minutes** ⇒ the
-     launch never began (e.g. an unanswered approval gate) — stop and surface it; **no new line for
-     >10 minutes** ⇒ the agent stalled — stop the run, relaunch once, and only then involve the
-     user. A healthy round is ~10–15 minutes end-to-end; never let a silent run sit for an hour.
-     Delete any stale `.tmp/<gear>.progress.log` before launching so the heartbeat is unambiguous.
+   - **Launch in the background and let the watcher do the waiting.** Clear the previous run's
+     telemetry first — `rm -f .tmp/<gear>.progress.log .tmp/<gear>.progress.log.watch` — then run
+     the subagent as a background task (the standard prompt makes it append one milestone line per
+     phase). Do **not** poll the log by hand. Wait with one foreground call, Bash timeout 600000:
+
+     ```
+     python3 .claude/skills/generate-gear/watch_progress.py .tmp/<gear>.progress.log
+     ```
+
+     It blocks until the run reaches a verdict or its 9-minute call budget expires, then prints the
+     status, the elapsed time, the milestone counts and the tail of the log. Report from that
+     output; do not re-read the log. Act on the exit code: **0** the subagent is done — go to step
+     5; **4** still healthy — run the identical command again (a healthy 10–15 minute round takes
+     one or two of these); **1** no heartbeat within the launch window, so the launch never began
+     (e.g. an unanswered approval gate) — stop and surface it; **2** silent past the stall window —
+     stop the run, relaunch once, and only then involve the user; **3** past the 45-minute ceiling
+     with the run still alive — stop it and surface the elapsed time; **5** the progress log is not
+     in the state the watch assumed — inspect before relaunching. The script carries SKILL.md's
+     windows as its defaults (`--launch-window 300`, `--stall-window 600`, `--max-runtime 2700`);
+     override one only with a stated reason.
 
 5. **Validate (reference-free).** The output is checked against the **spec**, not against any
    implementation:

--- a/.claude/skills/generate-gear/test_watch_progress.py
+++ b/.claude/skills/generate-gear/test_watch_progress.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Tests for watch_progress.py's parsing, stall-decision, and loop behaviour.
+
+No test sleeps for real: the loop tests inject FakeClock, and RealClock.sleep
+is additionally patched out and asserted never called, so a regression that
+reintroduces a direct time.sleep fails the suite instead of slowing it down.
+"""
+import importlib.util, os, tempfile, time, unittest
+from pathlib import Path
+from unittest import mock
+import io
+
+MODULE_PATH = Path(__file__).with_name('watch_progress.py')
+SPEC = importlib.util.spec_from_file_location('watch_progress', MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeClock(object):
+    """Virtual clock. sleep() advances time instead of spending it."""
+    def __init__(self, start=None):
+        self.t = float(start if start is not None else time.time())
+        self.slept = []
+    def now(self):
+        return self.t
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.t += seconds
+
+
+def windows(**kw):
+    base = dict(launch=MODULE.DEFAULT_LAUNCH_WINDOW, stall=MODULE.DEFAULT_STALL_WINDOW,
+                max_runtime=MODULE.DEFAULT_MAX_RUNTIME, budget=MODULE.DEFAULT_BUDGET,
+                poll=MODULE.DEFAULT_POLL_INTERVAL, tail=MODULE.DEFAULT_TAIL, allow_stale=False)
+    base.update(kw)
+    return MODULE.Windows(**base)
+
+
+class ParseLineTests(unittest.TestCase):
+    def test_basic_start(self):
+        hb = MODULE.parse_line('1755993212 start')
+        self.assertEqual(hb.epoch, 1755993212)
+        self.assertEqual(hb.milestone, 'start')
+        self.assertEqual(hb.kind, 'start')
+        self.assertTrue(hb.parsed)
+
+    def test_read_milestone_kept_whole(self):
+        hb = MODULE.parse_line('1755993212 read:spec/spurgear/instructions.md')
+        self.assertEqual(hb.milestone, 'read:spec/spurgear/instructions.md')
+        self.assertEqual(hb.kind, 'read')
+
+    def test_check_fail(self):
+        hb = MODULE.parse_line('1755993212 check:2:fail')
+        self.assertEqual(hb.kind, 'check:fail')
+
+    def test_tab_and_space_runs(self):
+        hb1 = MODULE.parse_line('1755993212\tdraft:written')
+        hb2 = MODULE.parse_line('1755993212   done')
+        self.assertEqual(hb1.kind, 'draft:written')
+        self.assertEqual(hb2.kind, 'done')
+
+    def test_whitespace_and_crlf_stripped(self):
+        hb = MODULE.parse_line('  1755993212 start  \r\n')
+        self.assertEqual(hb.epoch, 1755993212)
+        self.assertEqual(hb.kind, 'start')
+
+    def test_blank_lines_return_none(self):
+        self.assertIsNone(MODULE.parse_line(''))
+        self.assertIsNone(MODULE.parse_line('   '))
+
+    def test_millisecond_epoch(self):
+        hb = MODULE.parse_line('1755993212000 done')
+        self.assertEqual(hb.epoch, 1755993212)
+
+    def test_quoted_line(self):
+        hb = MODULE.parse_line('"1755993212 draft:written"')
+        self.assertEqual(hb.kind, 'draft:written')
+        self.assertTrue(hb.parsed)
+
+    def test_bad_timestamp_keeps_milestone(self):
+        hb = MODULE.parse_line('2026-08-24T10:00:00 start')
+        self.assertIsNone(hb.epoch)
+        self.assertEqual(hb.kind, 'start')
+        self.assertTrue(hb.parsed)
+
+    def test_bare_done(self):
+        hb = MODULE.parse_line('done')
+        self.assertIsNone(hb.epoch)
+        self.assertEqual(hb.kind, 'done')
+        self.assertTrue(hb.parsed)
+
+    def test_unrecognized_line(self):
+        hb = MODULE.parse_line('hello world')
+        self.assertEqual(hb.kind, 'other')
+        self.assertFalse(hb.parsed)
+
+    def test_bracketed_timestamp(self):
+        hb = MODULE.parse_line('[1755993212] start')
+        self.assertEqual(hb.epoch, 1755993212)
+
+
+class SummarizeTests(unittest.TestCase):
+    def test_full_log_counts(self):
+        base = 1755990000
+        lines = ['%d start' % base]
+        lines += ['%d read:foo%d' % (base + i + 1, i) for i in range(6)]
+        lines += ['%d draft:written' % (base + 7)]
+        lines += ['%d check:1:pass' % (base + 8), '%d check:2:pass' % (base + 9)]
+        lines += ['%d check:3:fail' % (base + 10)]
+        lines += ['%d done' % (base + 11)]
+        summary = MODULE.summarize(lines)
+        self.assertEqual(summary.counts['start'], 1)
+        self.assertEqual(summary.counts['read'], 6)
+        self.assertEqual(summary.counts['draft:written'], 1)
+        self.assertEqual(summary.counts['check:pass'], 2)
+        self.assertEqual(summary.counts['check:fail'], 1)
+        self.assertEqual(summary.counts['done'], 1)
+        self.assertTrue(summary.saw_done)
+        self.assertEqual(summary.first_epoch, base)
+
+    def test_done_in_middle_still_seen(self):
+        base = 1755990000
+        summary = MODULE.summarize(
+            ['%d start' % base, '%d done' % (base + 1), '%d check:1:pass' % (base + 2)])
+        self.assertTrue(summary.saw_done)
+
+    def test_two_start_lines(self):
+        base = 1755990000
+        summary = MODULE.summarize(
+            ['%d start' % base, '%d read:x' % (base + 5), '%d start' % (base + 15)])
+        self.assertEqual(summary.start_count, 2)
+        self.assertEqual(summary.first_epoch, base)
+
+    def test_unparsed_excluded_from_heartbeats(self):
+        summary = MODULE.summarize(['1 start', 'garbage line here', 'also not valid !!', '2 done'])
+        self.assertEqual(summary.unparsed, 2)
+        self.assertEqual(summary.heartbeats, 2)
+
+    def test_no_start_three_reads(self):
+        summary = MODULE.summarize(['1 read:a', '2 read:b', '3 read:c'])
+        self.assertEqual(summary.counts['start'], 0)
+        self.assertEqual(summary.heartbeats, 3)
+
+
+class EvaluateTests(unittest.TestCase):
+    def _state(self, exists=True, lines=None):
+        lines = lines or []
+        return MODULE.LogState(exists=exists, size=len(''.join(lines)), mtime=0.0, lines=lines)
+
+    def test_evaluate_precedence_table(self):
+        # (case #, now, reference, last_activity, lines, ever_existed, windows_kw, expected)
+        cases = [
+            (18, 60, 0, 0, [], True, {'launch': 300}, MODULE.EXIT_RUNNING),
+            (19, 301, 0, 0, [], True, {'launch': 300}, MODULE.EXIT_NO_START),
+            (20, 300, 0, 0, [], True, {'launch': 300}, MODULE.EXIT_RUNNING),
+            (21, 400, 0, 390, ['0 read:x'], True, {'launch': 300, 'stall': 600}, MODULE.EXIT_RUNNING),
+            (22, 601, 0, 0, ['0 start'], True, {'stall': 600}, MODULE.EXIT_STALLED),
+            (23, 600, 0, 0, ['0 start'], True, {'stall': 600}, MODULE.EXIT_RUNNING),
+            (24, 10000, 0, 5000, ['0 start', '1 done'], True,
+             {'stall': 600, 'max_runtime': 2700}, MODULE.EXIT_DONE),
+            (25, 2701, 0, 2696, ['0 start'], True, {'max_runtime': 2700, 'stall': 600}, MODULE.EXIT_MAX_RUNTIME),
+            (26, 3000, 0, 0, [], True, {'launch': 300, 'max_runtime': 2700}, MODULE.EXIT_NO_START),
+            (27, 60, 0, 0, [], True, {}, MODULE.EXIT_ANOMALY),
+            (28, 60, 0, 0, [], False, {'launch': 300}, MODULE.EXIT_RUNNING),
+            (29, 10, 0, 5, ['0 start', '5 check:1:fail'], True, {}, MODULE.EXIT_RUNNING),
+        ]
+        for case_num, now, reference, last_activity, lines, ever_existed, kw, expected in cases:
+            with self.subTest(case=case_num):
+                exists = not (case_num in (27, 28))
+                st = self._state(exists=exists, lines=lines)
+                summary = MODULE.summarize(lines)
+                ws = windows(**kw)
+                code, _ = MODULE.evaluate(now, reference, last_activity, st, summary, ws, ever_existed)
+                self.assertEqual(code, expected)
+
+
+class StaleLogTests(unittest.TestCase):
+    # anchor/reference epoch used by these cases
+    ANCHOR = 1755990000
+
+    def test_30_stale_by_epoch(self):
+        lines = ['%d start' % (self.ANCHOR - 3600)]
+        state = MODULE.LogState(exists=True, size=10, mtime=self.ANCHOR - 3600.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        self.assertTrue(MODULE.is_stale_log(state, summary, self.ANCHOR))
+
+    def test_32_stale_by_mtime_when_unparsable(self):
+        lines = ['not-a-timestamp start']
+        state = MODULE.LogState(exists=True, size=10, mtime=self.ANCHOR - 3600.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        self.assertTrue(MODULE.is_stale_log(state, summary, self.ANCHOR))
+
+    def test_33_not_stale_within_slack(self):
+        lines = ['%d start' % (self.ANCHOR - 5)]
+        state = MODULE.LogState(exists=True, size=10, mtime=self.ANCHOR - 5.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        self.assertFalse(MODULE.is_stale_log(state, summary, self.ANCHOR))
+
+
+class WatchLoopTests(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.dir = self._tmpdir.name
+        self.log_path = os.path.join(self.dir, 'sample.progress.log')
+        patcher = mock.patch.object(MODULE.time, 'sleep')
+        self.real_sleep = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _write(self, clock, lines):
+        with open(self.log_path, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        os.utime(self.log_path, (clock.t, clock.t))
+
+    def _write_with_mtime(self, lines, mtime):
+        with open(self.log_path, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        os.utime(self.log_path, (mtime, mtime))
+
+    def test_30_pre_existing_stale_log_is_anomaly(self):
+        anchor_epoch = 1755990000
+        clock = FakeClock(start=anchor_epoch)
+        stale_epoch = anchor_epoch - 3600
+        self._write_with_mtime(['%d start' % stale_epoch, '%d done' % stale_epoch], stale_epoch)
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(), clock, out)
+        self.assertEqual(code, MODULE.EXIT_ANOMALY)
+        self.assertIn('next: the progress log is not in the state this watch assumed', out.getvalue())
+        self.assertFalse(self.real_sleep.called)
+
+    def test_31_allow_stale_skips_anomaly(self):
+        anchor_epoch = 1755990000
+        clock = FakeClock(start=anchor_epoch)
+        stale_epoch = anchor_epoch - 3600
+        self._write_with_mtime(['%d start' % stale_epoch, '%d done' % stale_epoch], stale_epoch)
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(allow_stale=True), clock, out)
+        self.assertEqual(code, MODULE.EXIT_DONE)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_34_done_before_third_poll(self):
+        clock = FakeClock(start=1000)
+        state = {'polls': 0}
+        real_sleep_orig = MODULE.time.sleep
+
+        def side_effecting_sleep(seconds):
+            state['polls'] += 1
+            clock.t += seconds
+            if state['polls'] >= 2:
+                self._write(clock, ['%d start' % clock.t, '%d done' % clock.t])
+        clock.sleep = side_effecting_sleep
+        self._write(clock, ['%d start' % clock.t])
+
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(poll=1, budget=60), clock, out)
+        self.assertEqual(code, MODULE.EXIT_DONE)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_35_log_never_appears(self):
+        clock = FakeClock(start=1000)
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(launch=10, poll=1, budget=60), clock, out)
+        self.assertEqual(code, MODULE.EXIT_NO_START)
+        self.assertGreaterEqual(clock.t, 1000 + 11)
+        self.assertLess(clock.t, 1000 + 15)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_36_one_start_then_nothing(self):
+        clock = FakeClock(start=1000)
+        self._write(clock, ['%d start' % clock.t])
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(stall=20, poll=1, budget=120), clock, out)
+        self.assertEqual(code, MODULE.EXIT_STALLED)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_37_growth_resets_stall(self):
+        clock = FakeClock(start=1000)
+        self._write(clock, ['%d start' % clock.t])
+        counter = {'n': 0}
+
+        def growing_sleep(seconds):
+            clock.t += seconds
+            counter['n'] += 1
+            self._write(clock, ['%d start' % 1000, '%d read:%d' % (clock.t, counter['n'])])
+        clock.sleep = growing_sleep
+
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(budget=30, poll=5, stall=20), clock, out)
+        self.assertEqual(code, MODULE.EXIT_RUNNING)
+        self.assertGreaterEqual(clock.t, 1030)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_38_max_runtime_while_alive(self):
+        clock = FakeClock(start=1000)
+        self._write(clock, ['%d start' % clock.t])
+        counter = {'n': 0}
+
+        def growing_sleep(seconds):
+            clock.t += seconds
+            counter['n'] += 1
+            self._write(clock, ['%d start' % 1000, '%d read:%d' % (clock.t, counter['n'])])
+        clock.sleep = growing_sleep
+
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(max_runtime=40, budget=300, poll=5, stall=600),
+                             clock, out)
+        self.assertEqual(code, MODULE.EXIT_MAX_RUNTIME)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_39_anchor_reused_across_calls(self):
+        clock = FakeClock(start=1000)
+        out1 = io.StringIO()
+        code1 = MODULE.watch(self.log_path, windows(budget=0), clock, out1)
+        self.assertEqual(code1, MODULE.EXIT_RUNNING)
+
+        clock.t += 400
+        out2 = io.StringIO()
+        code2 = MODULE.watch(self.log_path, windows(launch=300, budget=0), clock, out2)
+        self.assertEqual(code2, MODULE.EXIT_NO_START)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_40_reset_restarts_reference(self):
+        clock = FakeClock(start=1000)
+        MODULE.watch(self.log_path, windows(budget=0), clock, io.StringIO())
+        clock.t += 400
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(launch=300, budget=0), clock, out, reset=True)
+        self.assertEqual(code, MODULE.EXIT_RUNNING)
+        self.assertFalse(self.real_sleep.called)
+
+    def test_41_poll_clamped_to_budget(self):
+        clock = FakeClock(start=1000)
+        # never write the file, so we hit budget expiry (RUNNING) rather than NO_START
+        out = io.StringIO()
+        code = MODULE.watch(self.log_path, windows(launch=100, poll=100, budget=7), clock, out)
+        self.assertEqual(code, MODULE.EXIT_RUNNING)
+        self.assertEqual(len(clock.slept), 1)
+        self.assertLessEqual(clock.slept[0], 7)
+        self.assertFalse(self.real_sleep.called)
+
+
+class RenderAndMainTests(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.dir = self._tmpdir.name
+        self.log_path = os.path.join(self.dir, 'sample.progress.log')
+
+    def _write(self, lines, mtime=None):
+        with open(self.log_path, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        if mtime is not None:
+            os.utime(self.log_path, (mtime, mtime))
+
+    def test_42_render_done(self):
+        lines = ['1000 start', '1010 done']
+        state = MODULE.LogState(exists=True, size=20, mtime=1010.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        out = io.StringIO()
+        MODULE.render(out, MODULE.EXIT_DONE, 'done', self.log_path, 1000, 1010, 1000,
+                       state, summary, windows())
+        text = out.getvalue()
+        self.assertTrue(text.startswith('watch_progress: DONE (exit 0)\n'))
+        self.assertIn('elapsed:', text)
+        self.assertIn('milestones:', text)
+        self.assertIn('1010 done', text)
+
+    def test_43_tail_limit(self):
+        base = 1755990000
+        lines = ['%d read:%d' % (base + i, i) for i in range(20)]
+        state = MODULE.LogState(exists=True, size=100, mtime=base + 19.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        out = io.StringIO()
+        MODULE.render(out, MODULE.EXIT_RUNNING, 'healthy', self.log_path, base, base + 19, base + 19,
+                       state, summary, windows(tail=3))
+        text = out.getvalue()
+        self.assertIn('last 3 of 20 lines', text)
+        header = '--- tail (last 3 of 20 lines) ---\n'
+        tail_section = text.split(header)[1]
+        tail_lines = tail_section.rstrip('\n').split('\n')
+        self.assertEqual(len(tail_lines), 3)
+        self.assertEqual(tail_lines, lines[-3:])
+
+    def test_44_no_start_render(self):
+        state = MODULE.LogState(exists=False, size=0, mtime=None, lines=[])
+        summary = MODULE.summarize([])
+        out = io.StringIO()
+        MODULE.render(out, MODULE.EXIT_NO_START, 'no heartbeat', self.log_path, 0, 400, 0,
+                       state, summary, windows())
+        self.assertIn('next: the launch never began', out.getvalue())
+
+    def test_45_running_render(self):
+        state = MODULE.LogState(exists=False, size=0, mtime=None, lines=[])
+        summary = MODULE.summarize([])
+        out = io.StringIO()
+        MODULE.render(out, MODULE.EXIT_RUNNING, 'healthy', self.log_path, 0, 60, 0,
+                       state, summary, windows())
+        self.assertIn('next: still healthy — run this same command again.', out.getvalue())
+
+    def test_46_missing_start_note(self):
+        lines = ['1000 read:x']
+        state = MODULE.LogState(exists=True, size=10, mtime=1000.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        out = io.StringIO()
+        MODULE.render(out, MODULE.EXIT_RUNNING, 'healthy', self.log_path, 990, 1005, 1000,
+                       state, summary, windows())
+        self.assertIn("note: no explicit 'start' line", out.getvalue())
+
+    def test_47_skew_note_does_not_change_exit_code(self):
+        base = 1755990000
+        lines = ['%d start' % base]
+        state = MODULE.LogState(exists=True, size=10, mtime=base + 3600.0, lines=lines)
+        summary = MODULE.summarize(lines)
+        out = io.StringIO()
+        MODULE.render(out, MODULE.EXIT_RUNNING, 'healthy', self.log_path, base, base + 5, base,
+                       state, summary, windows())
+        self.assertIn('note:', out.getvalue())
+        self.assertIn('timestamps in this log may be unreliable', out.getvalue())
+
+    def test_48_main_no_log_argument(self):
+        out = io.StringIO()
+        err = io.StringIO()
+        with mock.patch.object(MODULE.sys, 'stderr', err):
+            code = MODULE.main([], clock=FakeClock(), out=out)
+        self.assertEqual(code, MODULE.EXIT_USAGE)
+        self.assertTrue(err.getvalue())
+
+    def test_49_main_negative_window(self):
+        err = io.StringIO()
+        with mock.patch.object(MODULE.sys, 'stderr', err):
+            code = MODULE.main(['--stall-window', '-5', self.log_path], clock=FakeClock(),
+                                out=io.StringIO())
+        self.assertEqual(code, MODULE.EXIT_USAGE)
+
+    def test_50_once_on_healthy_growing_log(self):
+        self._write(['1000 start', '1005 read:x'], mtime=1005.0)
+        clock = FakeClock(start=1010)
+        out = io.StringIO()
+        with mock.patch.object(MODULE.time, 'sleep') as real_sleep:
+            code = MODULE.main([self.log_path, '--once'], clock=clock, out=out)
+        self.assertEqual(code, MODULE.EXIT_RUNNING)
+        self.assertFalse(real_sleep.called)
+
+    def test_51_once_on_done_log(self):
+        self._write(['1000 start', '1005 done'], mtime=1005.0)
+        clock = FakeClock(start=1010)
+        out = io.StringIO()
+        code = MODULE.main([self.log_path, '--once'], clock=clock, out=out)
+        self.assertEqual(code, MODULE.EXIT_DONE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.claude/skills/generate-gear/watch_progress.py
+++ b/.claude/skills/generate-gear/watch_progress.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Watch a progress-heartbeat log and block until it reaches a verdict.
+
+`/generate-gear` step 4 runs its drafting subagent as a background task. The
+subagent is expected to append heartbeat lines of the form
+`<unix-epoch-seconds> <milestone>` to a log file, where milestone is one of
+`start`, `read:<path>`, `draft:written`, `check:<n>:pass`, `check:<n>:fail`,
+or `done`. This script watches that log so the orchestrator does not have to
+poll it by hand: call it once after launching the subagent, and if it exits
+with status RUNNING, call the identical command again — one foreground call
+per wait, repeated until the exit code is not RUNNING.
+
+Exit codes:
+  0  DONE         a `done` heartbeat is present; the subagent finished.
+  1  NO_START     no heartbeat at all, and the launch window has passed.
+  2  STALLED      the run started, then the log stopped growing too long.
+  3  MAX_RUNTIME  still alive and heartbeating, but past the absolute ceiling.
+  4  RUNNING      healthy, still working; this invocation's budget elapsed.
+                  Call the watcher again, unchanged.
+  5  ANOMALY      the log vanished/became unreadable mid-watch, or a stale
+                  pre-existing log was detected at first read.
+  64 USAGE        bad arguments.
+"""
+import argparse
+import collections
+import os
+import re
+import sys
+import time
+
+
+EXIT_DONE = 0
+EXIT_NO_START = 1
+EXIT_STALLED = 2
+EXIT_MAX_RUNTIME = 3
+EXIT_RUNNING = 4
+EXIT_ANOMALY = 5
+EXIT_USAGE = 64
+
+STATUS_NAMES = {EXIT_DONE: 'DONE', EXIT_NO_START: 'NO_START', EXIT_STALLED: 'STALLED',
+                EXIT_MAX_RUNTIME: 'MAX_RUNTIME', EXIT_RUNNING: 'RUNNING',
+                EXIT_ANOMALY: 'ANOMALY'}
+
+DEFAULT_LAUNCH_WINDOW = 300      # SKILL.md "~5 minutes"
+DEFAULT_STALL_WINDOW = 600       # SKILL.md ">10 minutes"
+DEFAULT_MAX_RUNTIME = 2700       # 45 min ceiling; healthy round is 10-15 min
+DEFAULT_BUDGET = 540             # 9 min, inside the Bash tool's 10-min cap
+DEFAULT_POLL_INTERVAL = 5
+DEFAULT_TAIL = 15
+STALE_SLACK = 60
+SKEW_SLACK = 120
+
+Heartbeat = collections.namedtuple('Heartbeat', 'epoch milestone kind raw parsed')
+LogState = collections.namedtuple('LogState', 'exists size mtime lines')
+Summary = collections.namedtuple(
+    'Summary', 'heartbeats unparsed counts first_epoch last_epoch last_raw saw_done start_count')
+Windows = collections.namedtuple(
+    'Windows', 'launch stall max_runtime budget poll tail allow_stale')
+
+_CHECK_RE = re.compile(r'^check:\d+:(pass|fail)$', re.IGNORECASE)
+_READ_RE = re.compile(r'^read:', re.IGNORECASE)
+
+
+class RealClock(object):
+    """Wall clock. Every time read and every wait in this module goes through a clock
+    object so the stall logic can be tested without real sleeping."""
+    def now(self):
+        return time.time()
+
+    def sleep(self, seconds):
+        time.sleep(seconds)
+
+
+def parse_epoch(token):
+    """Strip quotes/brackets; 9-11 digits -> seconds; 12-14 digits -> ms/1000; else None."""
+    token = token.strip()
+    if token.startswith('[') and token.endswith(']'):
+        token = token[1:-1]
+    token = token.strip('[]')
+    if not token.isdigit():
+        return None
+    length = len(token)
+    if 9 <= length <= 11:
+        return int(token)
+    if 12 <= length <= 14:
+        return int(token) // 1000
+    return None
+
+
+def classify(milestone):
+    """Classify a milestone field into one of: start, read, draft:written,
+    check:pass, check:fail, done, other. Case-insensitive, by prefix."""
+    lower = milestone.lower()
+    if lower == 'start':
+        return 'start'
+    if lower.startswith('read:'):
+        return 'read'
+    if lower.startswith('draft:'):
+        return 'draft:written'
+    m = _CHECK_RE.match(lower)
+    if m:
+        return 'check:pass' if m.group(1) == 'pass' else 'check:fail'
+    if lower == 'done':
+        return 'done'
+    return 'other'
+
+
+def _looks_like_milestone(token):
+    """True if a bare (timestamp-less) token is a recognised milestone."""
+    lower = token.lower()
+    if lower in ('start', 'done', 'draft:written'):
+        return True
+    if lower.startswith('read:'):
+        return True
+    if _CHECK_RE.match(lower):
+        return True
+    return False
+
+
+def parse_line(raw):
+    """Parse one raw log line into a Heartbeat, or None if it is blank."""
+    line = raw.rstrip('\r\n')
+    line = line.strip()
+    if not line:
+        return None
+    if len(line) >= 2 and line[0] == line[-1] and line[0] in ('"', "'"):
+        line = line[1:-1].strip()
+
+    parts = line.split(None, 1)
+    if len(parts) == 2:
+        ts_token, milestone = parts
+        epoch = parse_epoch(ts_token)
+        kind = classify(milestone)
+        parsed = epoch is not None or kind != 'other'
+        return Heartbeat(epoch=epoch, milestone=milestone, kind=kind, raw=raw, parsed=parsed)
+
+    # single field
+    token = parts[0] if parts else ''
+    if _looks_like_milestone(token):
+        kind = classify(token)
+        return Heartbeat(epoch=None, milestone=token, kind=kind, raw=raw, parsed=True)
+
+    return Heartbeat(epoch=None, milestone=token, kind='other', raw=raw, parsed=False)
+
+
+def summarize(lines):
+    """Fold parse_line over the lines into a Summary. Pure."""
+    heartbeats = 0
+    unparsed = 0
+    counts = collections.Counter()
+    first_epoch = None
+    last_epoch = None
+    last_raw = None
+    saw_done = False
+    start_count = 0
+
+    for raw in lines:
+        hb = parse_line(raw)
+        if hb is None:
+            continue
+        last_raw = raw.rstrip('\r\n').strip()
+        if not hb.parsed:
+            unparsed += 1
+            continue
+        heartbeats += 1
+        counts[hb.kind] += 1
+        if hb.kind == 'start':
+            start_count += 1
+        if hb.kind == 'done':
+            saw_done = True
+        if hb.epoch is not None:
+            if first_epoch is None:
+                first_epoch = hb.epoch
+            last_epoch = hb.epoch
+
+    return Summary(heartbeats=heartbeats, unparsed=unparsed, counts=counts,
+                    first_epoch=first_epoch, last_epoch=last_epoch, last_raw=last_raw,
+                    saw_done=saw_done, start_count=start_count)
+
+
+def read_log(path):
+    """Stat + read the log. Never raises; missing/unreadable yields exists=False."""
+    try:
+        st = os.stat(path)
+    except OSError:
+        return LogState(exists=False, size=0, mtime=None, lines=[])
+    try:
+        with open(path, 'r', errors='replace') as f:
+            text = f.read()
+    except OSError:
+        return LogState(exists=False, size=0, mtime=None, lines=[])
+    lines = text.splitlines()
+    return LogState(exists=True, size=st.st_size, mtime=st.st_mtime, lines=lines)
+
+
+def anchor_path(log_path):
+    return log_path + '.watch'
+
+
+def load_anchor(log_path, clock):
+    """Read the sidecar's single integer; on missing/garbage write now() and
+    return created=True."""
+    path = anchor_path(log_path)
+    try:
+        with open(path, 'r') as f:
+            content = f.read().strip()
+        epoch = int(content)
+        return epoch, False
+    except (OSError, ValueError):
+        epoch = int(clock.now())
+        with open(path, 'w') as f:
+            f.write('%d\n' % epoch)
+        return epoch, True
+
+
+def reset_anchor(log_path):
+    try:
+        os.remove(anchor_path(log_path))
+    except OSError:
+        pass
+
+
+def is_stale_log(state, summary, reference):
+    """A leftover log from a previous run predates this watch. Pure."""
+    if not state.exists or not state.lines:
+        return False
+    if summary.first_epoch is not None:
+        return (reference - summary.first_epoch) > STALE_SLACK
+    if state.mtime is not None:
+        return (reference - state.mtime) > STALE_SLACK
+    return False
+
+
+def evaluate(now, reference, last_activity, state, summary, windows, ever_existed):
+    """Decide the status. Pure, no I/O, no clock. Precedence per design §4.4."""
+    if ever_existed and not state.exists:
+        return EXIT_ANOMALY, 'the progress log existed and is now missing or unreadable'
+
+    if summary.saw_done:
+        return EXIT_DONE, "a 'done' heartbeat is present"
+
+    launch_evidence = summary.start_count > 0 or summary.heartbeats > 0
+    if not launch_evidence and (now - reference) > windows.launch:
+        return EXIT_NO_START, 'no heartbeat within the launch window'
+
+    if launch_evidence and (now - last_activity) > windows.stall:
+        return EXIT_STALLED, 'no log growth within the stall window'
+
+    if (now - reference) > windows.max_runtime:
+        return EXIT_MAX_RUNTIME, 'past the max-runtime ceiling'
+
+    return EXIT_RUNNING, 'healthy'
+
+
+def notes_for(state, summary):
+    """Advisory note: lines. Pure."""
+    notes = []
+    launch_evidence = summary.start_count > 0 or summary.heartbeats > 0
+    if launch_evidence and summary.start_count == 0:
+        notes.append("note: no explicit 'start' line; treating the first heartbeat as the launch.")
+    if summary.start_count > 1:
+        notes.append("note: %d 'start' lines — the log may hold more than one run." % summary.start_count)
+    if summary.last_epoch is not None and state.mtime is not None:
+        skew = abs(summary.last_epoch - state.mtime)
+        if skew > SKEW_SLACK:
+            notes.append(
+                "note: last line's timestamp is %ds from the file's mtime — "
+                "timestamps in this log may be unreliable." % int(skew))
+    if summary.unparsed > 0:
+        notes.append('note: %d unparsed line(s) present.' % summary.unparsed)
+    return notes
+
+
+_NEXT_LINES = {
+    EXIT_NO_START: 'next: the launch never began (e.g. an unanswered approval gate) — '
+                   'stop and surface it to the user.',
+    EXIT_STALLED: 'next: the agent stalled — stop the run, relaunch once, and only then '
+                  'involve the user.',
+    EXIT_MAX_RUNTIME: 'next: past the ceiling with the run still alive — stop it and surface '
+                       'the elapsed time to the user.',
+    EXIT_ANOMALY: 'next: the progress log is not in the state this watch assumed — stop and '
+                  'inspect before relaunching.',
+    EXIT_RUNNING: 'next: still healthy — run this same command again.',
+}
+
+
+def _format_hms(seconds):
+    seconds = max(0, int(seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return '%02d:%02d:%02d' % (h, m, s)
+
+
+def render(out, code, reason, log_path, reference, now, last_activity, state, summary, windows):
+    """Produce the report block. Pure apart from writing to out."""
+    status = STATUS_NAMES.get(code, '?')
+    out.write('watch_progress: %s (exit %d)\n' % (status, code))
+    out.write('log:        %s\n' % log_path)
+    out.write('elapsed:    %s  (reference %d, now %d)\n' % (
+        _format_hms(now - reference), int(reference), int(now)))
+
+    if summary.last_raw is not None:
+        if summary.last_epoch is not None:
+            ago = max(0, now - summary.last_epoch)
+        elif state.mtime is not None:
+            ago = max(0, now - state.mtime)
+        else:
+            ago = max(0, now - last_activity)
+        out.write('last line:  %s  (%ds ago)\n' % (summary.last_raw, int(ago)))
+    else:
+        out.write('last line:  (none)\n')
+
+    out.write('lines:      %d heartbeats, %d unparsed\n' % (summary.heartbeats, summary.unparsed))
+
+    if summary.counts:
+        parts = ['%s=%d' % (kind, count) for kind, count in sorted(summary.counts.items())]
+        out.write('milestones: %s\n' % ' '.join(parts))
+    else:
+        out.write('milestones: (none)\n')
+
+    for note in notes_for(state, summary):
+        out.write(note + '\n')
+
+    if code != EXIT_DONE and code in _NEXT_LINES:
+        out.write(_NEXT_LINES[code] + '\n')
+
+    tail = state.lines[-windows.tail:] if state.lines else []
+    out.write('--- tail (last %d of %d lines) ---\n' % (len(tail), len(state.lines)))
+    for line in tail:
+        out.write(line + '\n')
+
+
+def watch(log_path, windows, clock, out, since=None, reset=False):
+    """The wait loop. Blocks (via clock.sleep) until a terminal status or the
+    budget elapses."""
+    if reset:
+        reset_anchor(log_path)
+    if since is not None:
+        reference, created = since, False
+    else:
+        reference, created = load_anchor(log_path, clock)
+
+    deadline = clock.now() + windows.budget
+    ever_existed = False
+    last_activity = None
+    prev_signature = None
+    first_read = True
+
+    while True:
+        state = read_log(log_path)
+        if state.exists:
+            ever_existed = True
+            signature = (state.size, state.mtime)
+            if last_activity is None:
+                last_activity = max(reference, state.mtime)
+            elif signature != prev_signature:
+                last_activity = clock.now()
+            prev_signature = signature
+        else:
+            if last_activity is None:
+                last_activity = reference
+
+        summary = summarize(state.lines)
+
+        if (first_read and created and not windows.allow_stale
+                and is_stale_log(state, summary, reference)):
+            now = clock.now()
+            render(out, EXIT_ANOMALY, 'stale log predates this watch', log_path, reference, now,
+                   last_activity, state, summary, windows)
+            return EXIT_ANOMALY
+        first_read = False
+
+        now = clock.now()
+        code, reason = evaluate(now, reference, last_activity, state, summary, windows, ever_existed)
+        if code != EXIT_RUNNING:
+            render(out, code, reason, log_path, reference, now, last_activity, state, summary, windows)
+            return code
+
+        if now >= deadline:
+            render(out, EXIT_RUNNING, reason, log_path, reference, now, last_activity, state,
+                   summary, windows)
+            return EXIT_RUNNING
+
+        clock.sleep(min(windows.poll, max(0, deadline - now)))
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    """Bad CLI usage exits EXIT_USAGE (sysexits.h EX_USAGE), not argparse's default 2,
+    so it can never be mistaken for one of this script's own status codes."""
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        sys.stderr.write('%s: error: %s\n' % (self.prog, message))
+        raise SystemExit(EXIT_USAGE)
+
+
+def build_parser():
+    parser = _ArgumentParser(
+        prog='watch_progress.py',
+        description='Watch a progress-heartbeat log and block until it reaches a verdict.')
+    parser.add_argument('log', metavar='LOG', help='Path to the progress log to watch.')
+    parser.add_argument('--launch-window', type=int, default=DEFAULT_LAUNCH_WINDOW)
+    parser.add_argument('--stall-window', type=int, default=DEFAULT_STALL_WINDOW)
+    parser.add_argument('--max-runtime', type=int, default=DEFAULT_MAX_RUNTIME)
+    parser.add_argument('--budget', type=int, default=DEFAULT_BUDGET)
+    parser.add_argument('--poll-interval', type=int, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument('--tail', type=int, default=DEFAULT_TAIL)
+    parser.add_argument('--once', action='store_true')
+    parser.add_argument('--since', type=int, default=None)
+    parser.add_argument('--reset', action='store_true')
+    parser.add_argument('--allow-stale', action='store_true')
+    return parser
+
+
+def main(argv, clock=None, out=None):
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as e:
+        return e.code if e.code is not None else EXIT_USAGE
+
+    if clock is None:
+        clock = RealClock()
+    if out is None:
+        out = sys.stdout
+
+    for name, value in (('--launch-window', args.launch_window), ('--stall-window', args.stall_window),
+                         ('--max-runtime', args.max_runtime), ('--budget', args.budget),
+                         ('--poll-interval', args.poll_interval), ('--tail', args.tail)):
+        if value < 0:
+            sys.stderr.write('watch_progress: %s must not be negative\n' % name)
+            return EXIT_USAGE
+
+    budget = 0 if args.once else args.budget
+
+    windows = Windows(launch=args.launch_window, stall=args.stall_window,
+                       max_runtime=args.max_runtime, budget=budget,
+                       poll=args.poll_interval, tail=args.tail, allow_stale=args.allow_stale)
+
+    return watch(args.log, windows, clock, out, since=args.since, reset=args.reset)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
- Replaces the hand-run heartbeat poll in `/generate-gear` step 4 with one blocking watcher call.
- Makes the stall/ceiling rules mechanical and testable instead of LLM-tracked by hand.
