### PR TITLE
add run_gates.py for the emit-gear gate battery

### DIFF
--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -26,10 +26,14 @@ the pipeline exists to make trustworthy.
    `<gear>`. It writes `.tmp/<gear>.generated.py`. Add no per-gear hints; anything the drafter
    needs belongs in the step list.
 
-4. **Gate.** Run all seven checks below. Every one must exit 0.
+4. **Gate.** Run `python3 .claude/skills/generate-gear/run_gates.py <gear>`. It runs all seven
+   checks below plus the advisory novel-type report, and prints one verdict. Exit 0 = every gate
+   that ran passed; exit 1 = a gate failed; exit 2 = a setup error (missing input, missing stubs,
+   unreachable API database) that no new draft can fix.
 
-5. **Diagnose and loop.** Classify any failure with the table below. An emit fault goes back to
-   step 3 with the failure text appended, up to about three rounds. A compile fault stops the run.
+5. **Diagnose and loop.** The runner prints a first-pass fault classification; confirm the rows it
+   marks NEEDS JUDGMENT against the table below. An emit fault goes back to step 3 with the runner
+   output appended, up to about three rounds. A compile fault, or an exit 2, stops the run.
 
 6. **Place.** On success, move the draft to `lib/geargen/<gear>.py`. This writes a file only; it
    does not commit, push, or touch Fusion's add-in directory.
@@ -37,6 +41,11 @@ the pipeline exists to make trustworthy.
 7. **Report.** State the gate results and every step that was thin or wrong.
 
 ## Gates
+
+`run_gates.py` runs every row below, in a cost-ordered sequence, and continues past a failure so
+one round reports every problem. The one exception is a parse failure, which skips the gates that
+read the candidate as Python and runs only the anchor check. The commands are listed so a single
+gate can be re-run by hand; the runner prints the exact command for each row it reports.
 
 | Gate | Command | What it catches |
 |---|---|---|
@@ -50,19 +59,23 @@ the pipeline exists to make trustworthy.
 
 `pyright_check.py` REVIEW findings are advisory stub noise. Only BLOCKING gates.
 
+A gear with no `spec/<gear>/contract.json` gets the contract gate reported as SKIP, and its
+contract is prose-checked by the reviewing agent instead (`generate-gear/SKILL.md`). Pass
+`--require-contract` where the manifest must exist, as it must for `spurgear`.
+
 ## Triage the type complaints
 
-After the seven gates pass, run
-`python3 .claude/skills/generate-gear/check_novel_types.py .tmp/<gear>.generated.py`. It reports
-every type complaint the candidate draws that no shipped gear in `lib/geargen/` draws, on the
-grounds that a complaint working code never produces is worth a look.
+`run_gates.py` runs `check_novel_types.py` last, as its advisory row. It reports every type
+complaint the candidate draws that no shipped gear in `lib/geargen/` draws, on the grounds that a
+complaint working code never produces is worth a look.
 
 This reports rather than gates, because an API the shipped gears never touch has no baseline and
 correct code using it reads as new. Read each finding and decide. It is the only check that has
 caught a method called on a class that does not define it, or a `BRepBodies` handed to a parameter
 typed `ObjectCollection` — both of which passed all seven gates.
 
-Pass `--gate` to make findings fail the run, once the baseline covers the API surface in question.
+Pass `run_gates.py --gate-novel-types` to make findings fail the run, once the baseline covers the
+API surface in question.
 
 ## Telling an emit fault from a compile fault
 
@@ -114,9 +127,12 @@ step list by hand, and never work around it in the Python.
 > **Do every step.** A step you cannot finish is a defect to report, never a comment left in the
 > file and never a silent omission.
 >
-> **Self-check before finishing**, fixing until all seven gates pass: parse, `pyright_check.py` with
-> 0 BLOCKING, `check_input_read.py`, `check_contract.py`, `check_anchors.py`, `check_step_calls.py`
-> and `check_api_calls.py`. Never silence a finding by deleting a comment, renaming a variable, or
+> **Self-check before finishing**, by running
+> `python3 .claude/skills/generate-gear/run_gates.py <gear> --no-advisory` and fixing until it
+> exits 0. It runs every gate and reports all failures at once, so fix the whole list before
+> re-running. Exit 2 is a setup problem, not a draft problem: report it and stop rather than
+> editing around it. Run it once more without `--no-advisory` before you finish, and report what
+> its advisory row says. Never silence a finding by deleting a comment, renaming a variable, or
 > removing the call it objects to.
 >
 > **Report:** the gate results, the final line count, and every step that was unclear, incomplete,

--- a/.claude/skills/generate-gear/run_gates.py
+++ b/.claude/skills/generate-gear/run_gates.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+"""Run the whole emit-gear gate battery for one gear and print one verdict.
+
+Why this exists: `/emit-gear` step 4 used to ask the orchestrating LLM to run seven gate
+commands one at a time, then classify any failure by hand against the fault table in
+`.claude/skills/emit-gear/SKILL.md`. Every part of that is mechanical — the commands are
+fixed, their arguments are derived from `<gear>`, their exit codes already say pass/fail —
+and leaving it to the model meant gates silently dropped under context pressure, argument
+order improvised (`check_contract.py` takes the manifest first, `check_step_calls.py` takes
+the step list first), and a retry loop that saw one failure at a time instead of all of
+them. This script runs the fixed battery once, in a fixed order, and reports every result
+plus a first-pass fault classification.
+
+Usage:
+    run_gates.py <gear> [candidate] [options]
+
+positional:
+  gear                  gear name, e.g. spurgear. Names spec/<gear>/steps.md and
+                         spec/<gear>/contract.json.
+  candidate              path to the candidate Python file.
+                         Default: .tmp/<gear>.generated.py (relative to --root).
+
+options:
+  --root PATH            repo root. Default: three levels above this script.
+  --only KEY[,KEY...]    run only these gates. Keys: parse, pyright, input_read,
+                         contract, step_calls, anchors, api_calls, novel_types.
+                         Unselected gates are reported with status "skip",
+                         reason "not selected".
+  --fail-fast            stop scheduling gates after the first failure. Off by default.
+  --require-contract     a missing spec/<gear>/contract.json fails the run instead of
+                         skipping the contract gate.
+  --gate-novel-types     pass --gate to check_novel_types.py, making its findings
+                         blocking (this is what CI does).
+  --no-advisory          do not run check_novel_types.py at all.
+  --json-out PATH        also write the full JSON verdict (pretty-printed) to PATH.
+  --format {text,json}   text (default) = human report followed by one JSON line.
+                         json = the JSON line only, nothing else on stdout.
+  --timeout SECONDS      per-gate timeout. Default 900. A gate that exceeds it gets
+                         status "error".
+
+Exit codes:
+    0  every gate that ran passed. Skips are allowed. Advisory findings may exist
+       (unless --gate-novel-types).
+    1  at least one gate failed on content. Classify with the printed table: emit fault
+       -> back to the drafter with the report text appended; compile fault -> stop.
+    2  setup error: bad usage, missing candidate, missing spec/<gear>/steps.md, a gate
+       script missing from the skill directory, a gate exited 2, a gate timed out, or
+       --require-contract with no manifest. Fix the environment or the inputs; never
+       retry the drafter.
+"""
+import argparse
+import ast
+import dataclasses
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+# --- constants ---------------------------------------------------------------------------
+SCHEMA = 1
+DEFAULT_TIMEOUT = 900
+GATE_ORDER = ("parse", "input_read", "contract", "step_calls",
+              "anchors", "api_calls", "pyright", "novel_types")
+CANDIDATE_READING = frozenset({"input_read", "contract", "step_calls",
+                                "api_calls", "pyright", "novel_types"})
+JSON_MARKER = "GATES_JSON: "
+
+GATE_TITLES = {
+    "parse": "Parse",
+    "input_read": "Input reads",
+    "contract": "Contract",
+    "step_calls": "Step calls",
+    "anchors": "Anchors",
+    "api_calls": "API calls",
+    "pyright": "Types",
+    "novel_types": "Novel types",
+}
+
+GATE_SCRIPTS = {
+    "input_read": "check_input_read.py",
+    "contract": "check_contract.py",
+    "step_calls": "check_step_calls.py",
+    "anchors": "check_anchors.py",
+    "api_calls": "check_api_calls.py",
+    "pyright": "pyright_check.py",
+    "novel_types": "check_novel_types.py",
+}
+
+FAULT_LABEL = {
+    "emit": "EMIT FAULT",
+    "compile": "COMPILE FAULT",
+    "judgment": "NEEDS JUDGMENT",
+    "setup": "SETUP ERROR",
+}
+
+NOT_DECIDED_NOTE = (
+    'not decided here (SKILL.md rows the runner leaves to the reviewing agent): '
+    '"A wrong argument type where the step gave the signature", "A step gives an argument '
+    'type the signature rejects", "A step is too thin to act on", and "Two steps '
+    'contradict each other".')
+
+HEADLINE_PATTERN = re.compile(r'^\S.*check.*:')
+API_CALL_NAME_RE = re.compile(r"calls '(\w+)\('")
+NOVEL_COUNT_RE = re.compile(r'novel-type check: (\d+) complaint')
+
+
+# --- small value types (dataclasses) ------------------------------------------------------
+@dataclass
+class GateResult:
+    key: str
+    title: str
+    status: str
+    advisory: bool
+    exit_code: int | None
+    duration_s: float | None
+    command: list[str]
+    stdout: str
+    stderr: str
+    skip_reason: str | None
+    fault: str | None
+
+
+@dataclass
+class Paths:
+    root: str            # absolute
+    candidate: str        # root-relative when under root, else absolute
+    steps: str            # root-relative "spec/<gear>/steps.md"
+    contract: str          # root-relative "spec/<gear>/contract.json"
+
+
+# --- path and argument plumbing ------------------------------------------------------------
+def scripts_dir():
+    """Directory holding the gate scripts. Its own __file__ dir. Patched by tests."""
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def repo_root():
+    """Three levels above scripts_dir(), same rule pyright_check.repo_root() uses."""
+    return os.path.abspath(os.path.join(scripts_dir(), "..", "..", ".."))
+
+
+def _abs(root, path):
+    return path if os.path.isabs(path) else os.path.join(root, path)
+
+
+def _root_relative(abs_path, root):
+    try:
+        rel = os.path.relpath(abs_path, root)
+    except ValueError:
+        return abs_path
+    return abs_path if rel.startswith("..") else rel
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(
+        prog="run_gates.py",
+        description="Run the emit-gear gate battery for one gear and print one verdict.")
+    p.add_argument("gear")
+    p.add_argument("candidate", nargs="?", default=None)
+    p.add_argument("--root", default=None)
+    p.add_argument("--only", default=None,
+                    help="comma-separated gate keys to run; the rest are skipped")
+    p.add_argument("--fail-fast", action="store_true")
+    p.add_argument("--require-contract", action="store_true")
+    p.add_argument("--gate-novel-types", action="store_true")
+    p.add_argument("--no-advisory", action="store_true")
+    p.add_argument("--json-out", default=None)
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    args = p.parse_args(argv)
+    if args.only:
+        args.only = [k.strip() for k in args.only.split(",") if k.strip()]
+    return args
+
+
+def resolve_paths(gear, candidate_arg, root_arg):
+    """Absolutise the root, default the candidate to .tmp/<gear>.generated.py, and express
+    every path root-relative so printed commands are copy-pasteable from the repo root."""
+    root = os.path.abspath(root_arg) if root_arg else repo_root()
+    if candidate_arg:
+        cand_abs = os.path.abspath(candidate_arg)
+    else:
+        cand_abs = os.path.join(root, ".tmp", "%s.generated.py" % gear)
+    candidate = _root_relative(cand_abs, root)
+    steps = os.path.join("spec", gear, "steps.md")
+    contract = os.path.join("spec", gear, "contract.json")
+    return Paths(root=root, candidate=candidate, steps=steps, contract=contract)
+
+
+def _active_keys(args):
+    if args.only:
+        keys = [k for k in GATE_ORDER if k in args.only]
+    else:
+        keys = list(GATE_ORDER)
+    if args.no_advisory and "novel_types" in keys:
+        keys = [k for k in keys if k != "novel_types"]
+    return keys
+
+
+def setup_errors(paths, args):
+    """Pre-flight, returns human messages. Checks: root is a directory; candidate exists;
+    steps.md exists; every gate script the plan needs exists in scripts_dir();
+    --require-contract implies contract.json exists; --only names are known keys."""
+    errors = []
+    if not os.path.isdir(paths.root):
+        errors.append("repo root is not a directory: %s" % paths.root)
+        return errors
+
+    if args.only:
+        unknown = sorted(set(args.only) - set(GATE_ORDER))
+        if unknown:
+            errors.append("unknown --only key(s): %s" % ", ".join(unknown))
+
+    cand_abs = _abs(paths.root, paths.candidate)
+    if not os.path.isfile(cand_abs):
+        errors.append("candidate not found: %s" % paths.candidate)
+
+    steps_abs = _abs(paths.root, paths.steps)
+    if not os.path.isfile(steps_abs):
+        errors.append(
+            "step list not found: %s -- /emit-gear cannot run without it; "
+            "run /compile-gear first" % paths.steps)
+
+    if args.require_contract:
+        contract_abs = _abs(paths.root, paths.contract)
+        if not os.path.isfile(contract_abs):
+            errors.append(
+                "--require-contract given but no manifest at %s" % paths.contract)
+
+    for key in _active_keys(args):
+        script_name = GATE_SCRIPTS.get(key)
+        if script_name and not os.path.isfile(os.path.join(scripts_dir(), script_name)):
+            errors.append("gate script missing: %s (needed for '%s')" % (script_name, key))
+
+    return errors
+
+
+# --- gate plan ------------------------------------------------------------------------------
+def _script_path(name, paths):
+    return _root_relative(os.path.join(scripts_dir(), name), paths.root)
+
+
+def gate_command(key, paths, args):
+    """The one place that knows each gate's argument order. Uses sys.executable, root-relative
+    script and input paths."""
+    py = sys.executable
+    if key == "parse":
+        return [py, "-c", "import ast; ast.parse(open(%r).read())" % paths.candidate]
+    if key == "input_read":
+        return [py, _script_path("check_input_read.py", paths), paths.candidate]
+    if key == "contract":
+        return [py, _script_path("check_contract.py", paths), paths.contract, paths.candidate]
+    if key == "step_calls":
+        return [py, _script_path("check_step_calls.py", paths), paths.steps, paths.candidate]
+    if key == "anchors":
+        return [py, _script_path("check_anchors.py", paths)]
+    if key == "api_calls":
+        return [py, _script_path("check_api_calls.py", paths), paths.candidate]
+    if key == "pyright":
+        return [py, _script_path("pyright_check.py", paths), paths.candidate]
+    if key == "novel_types":
+        cmd = [py, _script_path("check_novel_types.py", paths), paths.candidate]
+        if args.gate_novel_types:
+            cmd.append("--gate")
+        return cmd
+    raise ValueError("unknown gate key: %s" % key)
+
+
+def build_plan(paths, args):
+    """(key, title, command, skip_reason). Command is None exactly when skip_reason is set.
+    Applies --only, --no-advisory, --gate-novel-types, and the missing-contract skip.
+    Order is GATE_ORDER."""
+    active = set(_active_keys(args))
+    plan = []
+    for key in GATE_ORDER:
+        title = GATE_TITLES[key]
+        if key not in active:
+            plan.append((key, title, None, "not selected"))
+            continue
+        if key == "contract" and not os.path.isfile(_abs(paths.root, paths.contract)):
+            reason = (
+                "no manifest at %s -- the prose contract check is the reviewing agent's "
+                "job (generate-gear/SKILL.md); pass --require-contract to make this fatal"
+                % paths.contract)
+            plan.append((key, title, None, reason))
+            continue
+        plan.append((key, title, gate_command(key, paths, args), None))
+    return plan
+
+
+# --- execution --------------------------------------------------------------------------------
+def run_parse_gate(paths, timeout):
+    """In-process ast.parse of the candidate. On SyntaxError, status 'fail', exit_code 1,
+    stdout 'parse: SyntaxError at L<line>:<col>: <msg>'. Its `command` field still records the
+    SKILL.md one-liner so the report shows a command a human can re-run."""
+    command = [sys.executable, "-c", "import ast; ast.parse(open(%r).read())" % paths.candidate]
+    start = time.monotonic()
+    cand_abs = _abs(paths.root, paths.candidate)
+    try:
+        with open(cand_abs, encoding="utf-8") as fh:
+            src = fh.read()
+    except OSError as exc:
+        duration = round(time.monotonic() - start, 2)
+        return GateResult("parse", "Parse", "error", False, 2, duration, command,
+                           "", str(exc), None, "setup")
+    try:
+        ast.parse(src, filename=cand_abs)
+    except SyntaxError as exc:
+        duration = round(time.monotonic() - start, 2)
+        stdout = "parse: SyntaxError at L%s:%s: %s" % (exc.lineno, exc.offset, exc.msg)
+        return GateResult("parse", "Parse", "fail", False, 1, duration, command,
+                           stdout, "", None, None)
+    duration = round(time.monotonic() - start, 2)
+    return GateResult("parse", "Parse", "pass", False, 0, duration, command,
+                       "parse: OK", "", None, None)
+
+
+def run_script_gate(key, title, command, cwd, timeout, advisory):
+    """subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=timeout,
+    env=os.environ). Maps: rc 0 -> pass, rc 1 -> fail, anything else -> error.
+    TimeoutExpired -> status 'error' with a synthetic message."""
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(command, cwd=cwd, capture_output=True, text=True,
+                               timeout=timeout, env=os.environ)
+    except subprocess.TimeoutExpired as exc:
+        duration = round(time.monotonic() - start, 2)
+        stdout = exc.stdout or ""
+        stderr = (exc.stderr or "") + "\ngate timed out after %ss" % timeout
+        return GateResult(key, title, "error", advisory, None, duration, command,
+                           stdout, stderr, None, "setup")
+    duration = round(time.monotonic() - start, 2)
+    if proc.returncode == 0:
+        status = "pass"
+    elif proc.returncode == 1:
+        status = "fail"
+    else:
+        status = "error"
+    fault = "setup" if status == "error" else None
+    return GateResult(key, title, status, advisory, proc.returncode, duration, command,
+                       proc.stdout, proc.stderr, None, fault)
+
+
+def classify_advisory(result, args):
+    """check_novel_types exits 0 both when clean and when it found complaints (without --gate).
+    Detect findings with NOVEL_COUNT_RE and set status 'note' when the count is > 0 and the
+    gate is not blocking. With --gate-novel-types the exit code is authoritative and rc 1 is a
+    plain fail."""
+    if args.gate_novel_types:
+        return result
+    if result.status != "pass":
+        return result
+    match = NOVEL_COUNT_RE.search(result.stdout or "")
+    count = int(match.group(1)) if match else 0
+    if count > 0:
+        return dataclasses.replace(result, status="note")
+    return result
+
+
+def execute(plan, paths, args):
+    """Walk the plan. If the parse gate fails, convert every not-yet-run CANDIDATE_READING gate
+    to status 'skip', reason 'candidate does not parse'. With --fail-fast, convert every
+    remaining gate to 'skip', reason 'not run (--fail-fast after <key> failed)'."""
+    results = []
+    parse_failed = False
+    fail_fast_stop = None
+    for key, title, command, skip_reason in plan:
+        advisory = key == "novel_types"
+        if skip_reason is not None:
+            results.append(GateResult(key, title, "skip", advisory, None, None, [],
+                                       "", "", skip_reason, None))
+            continue
+        if parse_failed and key in CANDIDATE_READING:
+            results.append(GateResult(key, title, "skip", advisory, None, None, command,
+                                       "", "", "candidate does not parse", None))
+            continue
+        if fail_fast_stop is not None:
+            reason = "not run (--fail-fast after %s failed)" % fail_fast_stop
+            results.append(GateResult(key, title, "skip", advisory, None, None, command,
+                                       "", "", reason, None))
+            continue
+
+        if key == "parse":
+            result = run_parse_gate(paths, args.timeout)
+        else:
+            result = run_script_gate(key, title, command, paths.root, args.timeout, advisory)
+            if key == "novel_types":
+                result = classify_advisory(result, args)
+        results.append(result)
+
+        if key == "parse" and result.status == "fail":
+            parse_failed = True
+        if args.fail_fast and result.status in ("fail", "error") and fail_fast_stop is None:
+            fail_fast_stop = key
+    return results
+
+
+# --- classification -----------------------------------------------------------------------
+def steps_named_calls(steps_path):
+    """Load check_step_calls via importlib and return the bare names from named_call_shapes().
+    None when unreadable. Always loads the real sibling script next to this file -- not the
+    (possibly stubbed) scripts_dir() -- because this is a cross-check against the real step
+    list's parser, not a subprocess gate."""
+    try:
+        module_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                    "check_step_calls.py")
+        spec = importlib.util.spec_from_file_location("check_step_calls", module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        with open(steps_path, encoding="utf-8") as fh:
+            steps_src = fh.read()
+        shapes = module.named_call_shapes(steps_src)
+        return {name for name, _has_receiver in shapes}
+    except Exception:
+        return None
+
+
+def unresolved_api_names(stdout):
+    return [m.group(1) for m in API_CALL_NAME_RE.finditer(stdout or "")]
+
+
+def classify(results, paths):
+    """One row per non-passing gate: {gate, fault, certain, why}. Implements the table in
+    section 3.5 of the design. Pure function of the results plus the step list, so it is
+    directly unit-testable."""
+    rows = []
+    calls_cache = None
+    calls_loaded = False
+
+    for r in results:
+        if r.status not in ("fail", "error", "note"):
+            continue
+
+        if r.status == "error":
+            rows.append({
+                "gate": r.key, "fault": "setup", "certain": True,
+                "why": ("the gate exited with a setup error (bad exit code, missing "
+                        "script, or a timeout) -- fix the environment, not the draft"),
+            })
+            continue
+
+        if r.key == "parse":
+            rows.append({
+                "gate": "parse", "fault": "emit", "certain": True,
+                "why": ('a syntax error is drafter behavior (SKILL.md: "Syntax error, '
+                        'undefined name, wrong submodule -> Emit fault")'),
+            })
+        elif r.key == "pyright":
+            rows.append({
+                "gate": "pyright", "fault": "emit", "certain": True,
+                "why": ("a BLOCKING pyright finding is exactly an undefined name or "
+                        "wrong adsk submodule"),
+            })
+        elif r.key == "input_read":
+            rows.append({
+                "gate": "input_read", "fault": "emit", "certain": True,
+                "why": ("the reader helper is chosen by the drafter at the read site; "
+                        "the step list never dictates it"),
+            })
+        elif r.key == "step_calls":
+            rows.append({
+                "gate": "step_calls", "fault": "emit", "certain": True,
+                "why": ("a named call never made, or a stub left behind, is drafter "
+                        "behavior"),
+            })
+        elif r.key == "anchors":
+            rows.append({
+                "gate": "anchors", "fault": "compile", "certain": True,
+                "why": ("the gate reads only spec/**/*.md and the playbook, never the "
+                        "candidate -- no draft can fix it; fix the anchor and recompile"),
+            })
+        elif r.key == "contract":
+            rows.append({
+                "gate": "contract", "fault": "judgment", "certain": False,
+                "why": ("a missing class or ctx field can be a drafter omission (emit) "
+                        "or a manifest that no longer matches the spec (compile); a "
+                        "source_guards hit can point at a hand-written source file the "
+                        "draft does not own"),
+            })
+        elif r.key == "api_calls":
+            names = unresolved_api_names(r.stdout)
+            if not calls_loaded:
+                calls_cache = steps_named_calls(_abs(paths.root, paths.steps))
+                calls_loaded = True
+            if calls_cache is None:
+                rows.append({
+                    "gate": "api_calls", "fault": "emit", "certain": True,
+                    "why": ("could not read the step list to cross-check -- treating "
+                            "as an emit fault by default"),
+                })
+            else:
+                hit = [n for n in names if n in calls_cache]
+                if hit:
+                    rows.append({
+                        "gate": "api_calls", "fault": "judgment", "certain": False,
+                        "why": (
+                            "'%s' is named in spec/<gear>/steps.md, so the step list may "
+                            "be naming a call that does not exist (compile fault); if the "
+                            "step list does not name it, it is an emit fault" % hit[0]),
+                    })
+                else:
+                    rows.append({
+                        "gate": "api_calls", "fault": "emit", "certain": True,
+                        "why": ("a method that exists nowhere, and the step list does "
+                                "not name it, is drafter behavior"),
+                    })
+        elif r.key == "novel_types":
+            rows.append({
+                "gate": "novel_types", "fault": "judgment", "certain": False,
+                "why": "advisory only -- read each finding and decide",
+            })
+
+    return rows
+
+
+# --- rendering ------------------------------------------------------------------------------
+def headline(result):
+    """The gate's headline line: its first stdout line matching ^\\S.*check.*: -- otherwise
+    its first non-empty stdout line."""
+    if result.status == "skip":
+        return result.skip_reason or ""
+    lines = (result.stdout or "").splitlines()
+    for line in lines:
+        if HEADLINE_PATTERN.match(line):
+            return line
+    for line in lines:
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def compute_counts(results):
+    counts = {"pass": 0, "fail": 0, "skip": 0, "error": 0, "advisory_findings": 0}
+    for r in results:
+        if r.status in counts:
+            counts[r.status] += 1
+    for r in results:
+        if r.key == "novel_types" and r.status == "note":
+            match = NOVEL_COUNT_RE.search(r.stdout or "")
+            if match:
+                counts["advisory_findings"] = int(match.group(1))
+    return counts
+
+
+def overall(results, args):
+    """('setup_error', 2) if any status is 'error'; else ('fail', 1) if any status is 'fail';
+    else ('pass', 0)."""
+    if any(r.status == "error" for r in results):
+        return "setup_error", 2
+    if any(r.status == "fail" for r in results):
+        return "fail", 1
+    return "pass", 0
+
+
+def render_text(results, classification, paths, args):
+    lines = ["run_gates: %s  candidate=%s  root=%s" % (args.gear, paths.candidate, paths.root),
+             ""]
+
+    status_tag = {"pass": "PASS", "fail": "FAIL", "error": "ERROR", "note": "NOTE"}
+    for r in results:
+        if r.status == "skip":
+            lines.append("  SKIP  %-11s %s" % (r.key, r.skip_reason))
+        else:
+            tag = status_tag[r.status]
+            dur = "(%.2fs)" % r.duration_s if r.duration_s is not None else ""
+            lines.append(("  %-5s %-11s %s  %s" % (tag, r.key, dur, headline(r))).rstrip())
+        if r.status in ("fail", "error", "note"):
+            for line in (r.stdout or "").splitlines():
+                lines.append(" " * 8 + line)
+            if r.stderr:
+                lines.append(" " * 8 + "stderr:")
+                for line in r.stderr.splitlines():
+                    lines.append(" " * 8 + line)
+
+    counts = compute_counts(results)
+    verdict, _exit_code = overall(results, args)
+    lines.append("")
+    lines.append(
+        "verdict: %s -- %d passed, %d failed, %d skipped, %d errored, %d advisory finding(s)"
+        % (verdict.upper(), counts["pass"], counts["fail"], counts["skip"], counts["error"],
+           counts["advisory_findings"]))
+
+    if classification:
+        lines.append("")
+        lines.append('first-pass fault classification (SKILL.md "Telling an emit fault from '
+                      'a compile fault"):')
+        for row in classification:
+            label = FAULT_LABEL.get(row["fault"], row["fault"])
+            lines.append("  %-11s %-16s %s" % (row["gate"], label, row["why"]))
+        lines.append("  " + NOT_DECIDED_NOTE)
+
+    rerun = [r for r in results if r.status in ("fail", "error", "note")]
+    if rerun:
+        lines.append("")
+        lines.append("re-run one gate by hand:")
+        for r in rerun:
+            lines.append("  " + " ".join(r.command))
+
+    return "\n".join(lines)
+
+
+def build_json(results, classification, paths, args):
+    verdict, exit_code = overall(results, args)
+    counts = compute_counts(results)
+    gates = []
+    for r in results:
+        gates.append({
+            "key": r.key,
+            "title": r.title,
+            "status": r.status,
+            "advisory": r.advisory,
+            "exit_code": r.exit_code,
+            "duration_s": r.duration_s,
+            "command": r.command,
+            "headline": headline(r),
+            "stdout": r.stdout,
+            "stderr": r.stderr,
+            "skip_reason": r.skip_reason,
+            "fault": r.fault,
+        })
+    return {
+        "schema": SCHEMA,
+        "gear": args.gear,
+        "candidate": paths.candidate,
+        "root": paths.root,
+        "verdict": verdict,
+        "exit_code": exit_code,
+        "counts": counts,
+        "gates": gates,
+        "classification": classification,
+    }
+
+
+def _setup_error_json(errors, paths, args):
+    return {
+        "schema": SCHEMA,
+        "gear": args.gear,
+        "candidate": paths.candidate,
+        "root": paths.root,
+        "verdict": "setup_error",
+        "exit_code": 2,
+        "counts": {"pass": 0, "fail": 0, "skip": 0, "error": 0, "advisory_findings": 0},
+        "gates": [],
+        "classification": [],
+        "setup_errors": errors,
+    }
+
+
+def _write_json_out(path, obj):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(obj, fh, indent=2)
+        fh.write("\n")
+
+
+def main(argv=None):
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    paths = resolve_paths(args.gear, args.candidate, args.root)
+
+    errors = setup_errors(paths, args)
+    if errors:
+        obj = _setup_error_json(errors, paths, args)
+        line = JSON_MARKER + json.dumps(obj)
+        if args.json_out:
+            _write_json_out(args.json_out, obj)
+        if args.format == "json":
+            print(line)
+        else:
+            report = ["run_gates: %s  candidate=%s  root=%s"
+                      % (args.gear, paths.candidate, paths.root), "", "setup error:"]
+            report.extend("  - %s" % e for e in errors)
+            print("\n".join(report))
+            print(line)
+        return 2
+
+    plan = build_plan(paths, args)
+    results = execute(plan, paths, args)
+    classification = classify(results, paths)
+    fault_by_gate = {row["gate"]: row["fault"] for row in classification}
+    results = [dataclasses.replace(r, fault=fault_by_gate.get(r.key, r.fault))
+               for r in results]
+
+    obj = build_json(results, classification, paths, args)
+    line = JSON_MARKER + json.dumps(obj)
+    if args.json_out:
+        _write_json_out(args.json_out, obj)
+    if args.format == "json":
+        print(line)
+    else:
+        print(render_text(results, classification, paths, args))
+        print(line)
+    return obj["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/generate-gear/test_render_prompt.py
+++ b/.claude/skills/generate-gear/test_render_prompt.py
@@ -131,7 +131,7 @@ class CommittedTemplatesTest(unittest.TestCase):
         text = (SKILLS_ROOT / 'emit-gear' / 'prompt.md').read_text(encoding='utf-8')
         names = {
             name for name in re.findall(r'\w+\.py', text)
-            if name.startswith('check_') or name == 'pyright_check.py'
+            if name.startswith('check_') or name in ('pyright_check.py', 'run_gates.py')
         }
         self.assertTrue(names, 'emit prompt should name the gate scripts')
         for name in sorted(names):

--- a/.claude/skills/generate-gear/test_run_gates.py
+++ b/.claude/skills/generate-gear/test_run_gates.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Tests for run_gates.py.
+
+No test touches a real gear, a real pyright, or the real API database. Every test builds a
+throwaway repo in a tempfile.TemporaryDirectory() and points the runner at stub gate scripts
+by patching RUNNER.scripts_dir with unittest.mock.patch.object.
+"""
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+CHECKER_PATH = Path(__file__).with_name('run_gates.py')
+MODULE_SPEC = importlib.util.spec_from_file_location('run_gates', CHECKER_PATH)
+RUNNER = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(RUNNER)
+
+GEAR = 'spurgear'
+
+STUB_NAMES = {
+    'input_read': 'check_input_read.py',
+    'contract': 'check_contract.py',
+    'step_calls': 'check_step_calls.py',
+    'anchors': 'check_anchors.py',
+    'api_calls': 'check_api_calls.py',
+    'pyright': 'pyright_check.py',
+    'novel_types': 'check_novel_types.py',
+}
+
+STUB_HEADLINE = {
+    'input_read': 'input-read check: OK (0 inputs)',
+    'contract': 'contract check: OK',
+    'step_calls': 'step-call check: OK (0 named calls present, no stubs, no shared-point misuse)',
+    'anchors': 'anchor check: OK (0 anchors defined, 0 cited, 0 files)',
+    'api_calls': 'api-call check: OK',
+    'pyright': 'pyright_check spurgear.generated.py: 0 blocking, 0 review, 0 ignored',
+    'novel_types': 'novel-type check: 0 complaint(s) no shipped gear produces -- triage each',
+}
+
+
+def make_stub(directory, name, exit_code=0, stdout='', stderr='', sleep=0.0,
+              argv_marker=None):
+    """Write a gate script that prints `stdout`, prints `stderr` to stderr, optionally sleeps,
+    and exits `exit_code`. If `argv_marker` is given, writes sys.argv (minus argv[0]) as JSON
+    to that path, so a test can assert on the arguments the runner passed."""
+    path = os.path.join(directory, name)
+    lines = ['#!/usr/bin/env python3', 'import sys']
+    if argv_marker:
+        lines.append('import json')
+        lines.append('with open(%r, "w") as fh:' % argv_marker)
+        lines.append('    json.dump(sys.argv[1:], fh)')
+    if sleep:
+        lines.append('import time; time.sleep(%r)' % sleep)
+    if stdout:
+        for line in stdout.splitlines():
+            lines.append('print(%r)' % line)
+    if stderr:
+        for line in stderr.splitlines():
+            lines.append('print(%r, file=sys.stderr)' % line)
+    lines.append('sys.exit(%r)' % exit_code)
+    with open(path, 'w') as fh:
+        fh.write('\n'.join(lines) + '\n')
+    st = os.stat(path)
+    os.chmod(path, st.st_mode | stat.S_IEXEC)
+    return path
+
+
+def make_all_stubs(scripts, overrides=None):
+    """Write default-passing stubs for every gate script name, applying per-key overrides
+    (dict of key -> kwargs for make_stub). Returns the scripts dir."""
+    overrides = overrides or {}
+    for key, name in STUB_NAMES.items():
+        kwargs = dict(exit_code=0, stdout=STUB_HEADLINE[key])
+        kwargs.update(overrides.get(key, {}))
+        make_stub(scripts, name, **kwargs)
+    return scripts
+
+
+def make_repo(tmp, gear=GEAR, *, candidate='x = 1\n', steps='# steps\n', contract=None):
+    """Create <tmp>/.tmp/<gear>.generated.py, spec/<gear>/steps.md and, when `contract` is not
+    None, spec/<gear>/contract.json. Return the root path."""
+    root = tmp
+    os.makedirs(os.path.join(root, '.tmp'), exist_ok=True)
+    os.makedirs(os.path.join(root, 'spec', gear), exist_ok=True)
+    cand_path = os.path.join(root, '.tmp', '%s.generated.py' % gear)
+    with open(cand_path, 'w') as fh:
+        fh.write(candidate)
+    with open(os.path.join(root, 'spec', gear, 'steps.md'), 'w') as fh:
+        fh.write(steps)
+    if contract is not None:
+        with open(os.path.join(root, 'spec', gear, 'contract.json'), 'w') as fh:
+            fh.write(contract)
+    return root
+
+
+def run(root, scripts, *argv):
+    """patch scripts_dir -> scripts, capture stdout with contextlib.redirect_stdout, call
+    RUNNER.main([...]), return (exit_code, text, parsed_json)."""
+    buf = io.StringIO()
+    with mock.patch.object(RUNNER, 'scripts_dir', return_value=scripts):
+        with contextlib.redirect_stdout(buf):
+            exit_code = RUNNER.main(['--root', root] + list(argv))
+    text = buf.getvalue()
+    parsed = None
+    for line in text.splitlines():
+        if line.startswith(RUNNER.JSON_MARKER):
+            parsed = json.loads(line[len(RUNNER.JSON_MARKER):])
+    return exit_code, text, parsed
+
+
+class BaseGateTest(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.tmp = self._tmpdir.name
+        self.scripts = os.path.join(self.tmp, 'scripts')
+        os.makedirs(self.scripts, exist_ok=True)
+
+
+class HappyPathTests(BaseGateTest):
+    def test_all_gates_pass(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(parsed['verdict'], 'pass')
+        gate_keys = [g['key'] for g in parsed['gates']]
+        self.assertEqual(len(parsed['gates']), 8)
+        for g in parsed['gates']:
+            self.assertEqual(g['status'], 'pass', msg=g)
+        self.assertEqual(parsed['classification'], [])
+        # one line per gate in the human report
+        for key in gate_keys:
+            self.assertIn(key, text)
+
+    def test_json_line_is_parseable(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        json_out = os.path.join(self.tmp, 'v.json')
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--json-out', json_out)
+        last_line = [ln for ln in text.splitlines() if ln.strip()][-1]
+        self.assertTrue(last_line.startswith(RUNNER.JSON_MARKER))
+        self.assertEqual(parsed['schema'], 1)
+        with open(json_out) as fh:
+            written = json.load(fh)
+        self.assertEqual(written, parsed)
+
+    def test_format_json_prints_only_json(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--format', 'json')
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)
+        self.assertTrue(lines[0].startswith(RUNNER.JSON_MARKER))
+
+
+class ParseBarrierTests(BaseGateTest):
+    def test_syntax_error_skips_candidate_gates(self):
+        root = make_repo(self.tmp, candidate='def (:\n', contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 1)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['parse']['status'], 'fail')
+        for key in ('input_read', 'contract', 'step_calls', 'api_calls', 'pyright',
+                    'novel_types'):
+            self.assertEqual(by_key[key]['status'], 'skip')
+            self.assertIn('does not parse', by_key[key]['skip_reason'])
+        self.assertEqual(by_key['anchors']['status'], 'pass')
+        emit_rows = [c for c in parsed['classification'] if c['gate'] == 'parse']
+        self.assertEqual(len(emit_rows), 1)
+        self.assertEqual(emit_rows[0]['fault'], 'emit')
+        self.assertTrue(emit_rows[0]['certain'])
+
+    def test_parse_failure_message_carries_line(self):
+        root = make_repo(self.tmp, candidate='x = 1\ny = 2\ndef (:\n', contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertIn('L3', by_key['parse']['headline'])
+
+
+class ContinueTests(BaseGateTest):
+    def test_failure_does_not_stop_later_gates(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'input_read': dict(exit_code=1, stdout='input-read check: BLOCKING (1)'),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 1)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['input_read']['status'], 'fail')
+        self.assertEqual(by_key['api_calls']['status'], 'pass')
+        self.assertIsNotNone(by_key['api_calls']['duration_s'])
+        self.assertEqual(by_key['pyright']['status'], 'pass')
+        self.assertIsNotNone(by_key['pyright']['duration_s'])
+
+    def test_fail_fast_stops_scheduling(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'input_read': dict(exit_code=1, stdout='input-read check: BLOCKING (1)'),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--fail-fast')
+        self.assertEqual(exit_code, 1)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['api_calls']['status'], 'skip')
+        self.assertIn('--fail-fast', by_key['api_calls']['skip_reason'])
+        self.assertEqual(by_key['pyright']['status'], 'skip')
+        self.assertIn('--fail-fast', by_key['pyright']['skip_reason'])
+
+
+class ContractTests(BaseGateTest):
+    def test_missing_manifest_skips_and_passes(self):
+        root = make_repo(self.tmp)  # no contract
+        marker = os.path.join(self.tmp, 'contract-invoked.marker')
+        make_all_stubs(self.scripts, overrides={
+            'contract': dict(exit_code=0, stdout='contract check: OK', argv_marker=marker),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 0)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['contract']['status'], 'skip')
+        self.assertIn('spec/%s/contract.json' % GEAR, by_key['contract']['skip_reason'])
+        self.assertIn('--require-contract', by_key['contract']['skip_reason'])
+        self.assertFalse(os.path.exists(marker))
+
+    def test_require_contract_is_setup_error(self):
+        root = make_repo(self.tmp)  # no contract
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--require-contract')
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(parsed['verdict'], 'setup_error')
+
+    def test_manifest_present_runs_gate(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        by_key = {g['key']: g for g in parsed['gates']}
+        cmd = by_key['contract']['command']
+        manifest_idx = next(i for i, a in enumerate(cmd) if a.endswith('contract.json'))
+        candidate_idx = next(i for i, a in enumerate(cmd) if a.endswith('.generated.py'))
+        self.assertLess(manifest_idx, candidate_idx)
+
+
+class SetupErrorTests(BaseGateTest):
+    def test_gate_exit_two_is_setup_error(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'pyright': dict(exit_code=2, stdout='ERROR: pyright did not run'),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 2)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['pyright']['status'], 'error')
+        self.assertEqual(by_key['pyright']['fault'], 'setup')
+        self.assertEqual(by_key['novel_types']['status'], 'pass')
+
+    def test_missing_candidate(self):
+        root = make_repo(self.tmp, contract='{}')
+        os.remove(os.path.join(root, '.tmp', '%s.generated.py' % GEAR))
+        marker = os.path.join(self.tmp, 'never.marker')
+        make_all_stubs(self.scripts, overrides={
+            'input_read': dict(argv_marker=marker),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 2)
+        self.assertFalse(os.path.exists(marker))
+
+    def test_missing_steps_md(self):
+        root = make_repo(self.tmp, contract='{}')
+        os.remove(os.path.join(root, 'spec', GEAR, 'steps.md'))
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 2)
+        self.assertIn('spec/%s/steps.md' % GEAR, text)
+
+    def test_missing_gate_script(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        os.remove(os.path.join(self.scripts, 'check_anchors.py'))
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 2)
+        self.assertIn('check_anchors.py', text)
+
+    def test_timeout_is_error(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'pyright': dict(sleep=5),
+        })
+        start = __import__('time').monotonic()
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--timeout', '1')
+        elapsed = __import__('time').monotonic() - start
+        self.assertEqual(exit_code, 2)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['pyright']['status'], 'error')
+        self.assertLess(elapsed, 3)
+
+
+class ClassificationTests(BaseGateTest):
+    def test_deterministic_mapping(self):
+        cases = [
+            ('parse', 'emit'), ('pyright', 'emit'), ('input_read', 'emit'),
+            ('step_calls', 'emit'), ('anchors', 'compile'), ('contract', 'judgment'),
+        ]
+        for failing_key, expected_fault in cases:
+            with self.subTest(failing_key=failing_key):
+                tmp = tempfile.TemporaryDirectory()
+                self.addCleanup(tmp.cleanup)
+                scripts = os.path.join(tmp.name, 'scripts')
+                os.makedirs(scripts, exist_ok=True)
+                candidate = 'def (:\n' if failing_key == 'parse' else 'x = 1\n'
+                root = make_repo(tmp.name, candidate=candidate, contract='{}')
+                overrides = {}
+                if failing_key != 'parse':
+                    overrides[failing_key] = dict(exit_code=1, stdout='%s: BLOCKING (1)'
+                                                   % failing_key)
+                make_all_stubs(scripts, overrides=overrides)
+                exit_code, text, parsed = run(root, scripts, GEAR)
+                rows = [c for c in parsed['classification'] if c['gate'] == failing_key]
+                self.assertEqual(len(rows), 1, msg=parsed['classification'])
+                self.assertEqual(rows[0]['fault'], expected_fault)
+                if failing_key == 'contract':
+                    self.assertFalse(rows[0]['certain'])
+                else:
+                    self.assertTrue(rows[0]['certain'])
+
+    def test_api_fault_is_emit_when_step_list_is_silent(self):
+        root = make_repo(self.tmp, contract='{}', steps='# steps\nno calls named here.\n')
+        make_all_stubs(self.scripts, overrides={
+            'api_calls': dict(
+                exit_code=1,
+                stdout="api-call check: BLOCKING (1)\n"
+                       "  x.py:1 calls 'setExtentDefinition(' -- no such name in the "
+                       "Fusion API database, ..."),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        row = next(c for c in parsed['classification'] if c['gate'] == 'api_calls')
+        self.assertEqual(row['fault'], 'emit')
+        self.assertTrue(row['certain'])
+
+    def test_api_fault_needs_judgment_when_step_list_names_it(self):
+        root = make_repo(self.tmp, contract='{}',
+                          steps='# steps\nCall `setExtentDefinition(` here.\n')
+        make_all_stubs(self.scripts, overrides={
+            'api_calls': dict(
+                exit_code=1,
+                stdout="api-call check: BLOCKING (1)\n"
+                       "  x.py:1 calls 'setExtentDefinition(' -- no such name in the "
+                       "Fusion API database, ..."),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        row = next(c for c in parsed['classification'] if c['gate'] == 'api_calls')
+        self.assertEqual(row['fault'], 'judgment')
+        self.assertFalse(row['certain'])
+        self.assertIn('setExtentDefinition', row['why'])
+
+    def test_unreadable_step_list_falls_back_to_emit(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'api_calls': dict(
+                exit_code=1,
+                stdout="api-call check: BLOCKING (1)\n"
+                       "  x.py:1 calls 'setExtentDefinition(' -- no such name, ..."),
+        })
+        with mock.patch.object(RUNNER, 'steps_named_calls', return_value=None):
+            exit_code, text, parsed = run(root, self.scripts, GEAR)
+        row = next(c for c in parsed['classification'] if c['gate'] == 'api_calls')
+        self.assertEqual(row['fault'], 'emit')
+        self.assertIn('could not read the step list', row['why'])
+
+
+class AdvisoryTests(BaseGateTest):
+    def test_findings_do_not_fail_the_run(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'novel_types': dict(
+                exit_code=0,
+                stdout='novel-type check: 2 complaint(s) no shipped gear produces -- triage each'),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 0)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['novel_types']['status'], 'note')
+        self.assertEqual(parsed['counts']['advisory_findings'], 2)
+        self.assertTrue(any(c['gate'] == 'novel_types' and c['fault'] == 'judgment'
+                             for c in parsed['classification']))
+
+    def test_gate_novel_types_makes_it_blocking(self):
+        root = make_repo(self.tmp, contract='{}')
+        marker = os.path.join(self.tmp, 'novel-argv.json')
+        make_all_stubs(self.scripts, overrides={
+            'novel_types': dict(exit_code=1, stdout='novel-type check: 1 complaint(s) ...',
+                                 argv_marker=marker),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--gate-novel-types')
+        self.assertEqual(exit_code, 1)
+        with open(marker) as fh:
+            argv = json.load(fh)
+        self.assertIn('--gate', argv)
+
+    def test_no_advisory_skips_it(self):
+        root = make_repo(self.tmp, contract='{}')
+        marker = os.path.join(self.tmp, 'never.marker')
+        make_all_stubs(self.scripts, overrides={
+            'novel_types': dict(argv_marker=marker),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--no-advisory')
+        self.assertFalse(os.path.exists(marker))
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['novel_types']['status'], 'skip')
+
+
+class SelectionTests(BaseGateTest):
+    def test_only_runs_named_gates(self):
+        root = make_repo(self.tmp, contract='{}')
+        marker = os.path.join(self.tmp, 'step-calls.marker')
+        make_all_stubs(self.scripts, overrides={
+            'step_calls': dict(argv_marker=marker),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--only', 'step_calls')
+        self.assertTrue(os.path.exists(marker))
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['step_calls']['status'], 'pass')
+        for key in GATE_TITLES_MINUS('step_calls'):
+            self.assertEqual(by_key[key]['status'], 'skip')
+            self.assertIn('not selected', by_key[key]['skip_reason'])
+
+    def test_only_rejects_unknown_key(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--only', 'nope')
+        self.assertEqual(exit_code, 2)
+
+
+def GATE_TITLES_MINUS(*exclude):
+    return [k for k in RUNNER.GATE_ORDER if k not in exclude]
+
+
+class CommandShapeTests(BaseGateTest):
+    def test_commands_are_root_relative(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        for g in parsed['gates']:
+            for arg in g['command'][1:]:
+                self.assertFalse(arg.startswith('/'), msg=(g['key'], arg))
+
+    def test_cwd_is_repo_root(self):
+        root = make_repo(self.tmp, contract='{}')
+        cwd_marker = os.path.join(self.tmp, 'cwd.txt')
+        stub_path = os.path.join(self.scripts, 'check_anchors.py')
+        make_all_stubs(self.scripts)
+        with open(stub_path, 'w') as fh:
+            fh.write(
+                '#!/usr/bin/env python3\n'
+                'import os, sys\n'
+                'with open(%r, "w") as fh:\n'
+                '    fh.write(os.getcwd())\n'
+                'print(%r)\n'
+                'sys.exit(0)\n' % (cwd_marker, STUB_HEADLINE['anchors']))
+        st = os.stat(stub_path)
+        os.chmod(stub_path, st.st_mode | stat.S_IEXEC)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        with open(cwd_marker) as fh:
+            recorded = fh.read()
+        self.assertEqual(os.path.realpath(recorded), os.path.realpath(root))
+
+
+class OutputTests(BaseGateTest):
+    def test_failing_gate_body_is_in_text_report(self):
+        root = make_repo(self.tmp, contract='{}')
+        detail = ('step-call check: BLOCKING (3)\n'
+                   '  detail one\n'
+                   '  detail two\n'
+                   '  detail three')
+        make_all_stubs(self.scripts, overrides={
+            'step_calls': dict(exit_code=1, stdout=detail),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        for line in ('detail one', 'detail two', 'detail three'):
+            self.assertIn(line, text)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['step_calls']['stdout'].rstrip('\n'), detail)
+
+    def test_json_out_writes_file(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        json_out = os.path.join(self.tmp, 'out.json')
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--json-out', json_out)
+        with open(json_out) as fh:
+            written = json.load(fh)
+        self.assertEqual(written, parsed)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Replace seven manually-run gate commands with one deterministic runner and verdict.
- Wire `/emit-gear` to call `run_gates.py` instead of re-deriving the gate list in prose.
