### PR TITLE
generate the provenance table instead of typing it

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -51,12 +51,17 @@ proof is where the next reader is looking for the missing check.
    `PLAYBOOK.md`, the gear's spec end to end, and both harness APIs, `proof/proofkit/` and
    `proof/proofkit3d/`.
 
-2. **Record provenance.** Use the provenance input set owned by
-   `.claude/skills/generate-gear/check_compile.py`: existing `spec/<gear>/instructions.md`, optional
+2. **Stamp provenance.** The provenance table is generated, never typed. After each drafting round
+   in step 3, run `python3 .claude/skills/generate-gear/gen_provenance.py <gear> --write
+   .tmp/<gear>.steps.md` from the repo root. It computes the input set owned by
+   `.claude/skills/generate-gear/check_compile.py` — existing `spec/<gear>/instructions.md`, optional
    `spec/<gear>/fusion.md`, `.claude/skills/generate-gear/PLAYBOOK.md`, and existing auxiliary Markdown
-   documents referenced by those two spec files. Take `git hash-object` of every member and put each
-   row in the step list's provenance table. Step 5 checks them. The playbook belongs there because
-   steps cite its rules by anchor, so a playbook fix leaves every step list stale until it is recompiled.
+   documents referenced by those two spec files — and writes the table under the heading the draft
+   left empty. The table travels with the file when it is copied, so nothing else needs stamping,
+   and step 5 checks the result. A hash mismatch there means a source changed after the stamp: run
+   the same command against the copy the check reads, then check again. The playbook belongs in the
+   set because steps cite its rules by anchor, so a playbook fix leaves every step list stale until
+   it is recompiled.
 
 3. **Draft.** Spawn a subagent with the verbatim prompt in the appendix, substituting only
    `<gear>`. It writes `.tmp/<gear>.steps.md` and the proof files under `.tmp/<gear>-proof/`. Do
@@ -100,7 +105,7 @@ proof is where the next reader is looking for the missing check.
 | A step and its proof function disagree | Draft fault |
 | A step names a call the module is not required to make | Draft fault |
 | A named API call does not exist, and the spec did not name it | Draft fault |
-| A provenance hash does not match | Draft fault, or someone edited the spec mid-run |
+| A provenance hash does not match | A source changed after the table was stamped; re-run `gen_provenance.py` and check again |
 | **A named API call does not exist, and the spec named it** | **Prose fault** |
 | **The proof cannot fully constrain after three rounds** | **Prose fault** |
 | **The proof cannot build a sound solid after three rounds** | **Prose fault** |
@@ -149,11 +154,12 @@ this skill: a compiler that rewrites its own source removes the thing being chec
 > heading for those paths and requires each one to exist and be committed, so a sentence written
 > below that heading, or one naming bare file names, leaves the gate with nothing to check.
 >
-> **Under the `## Provenance` heading comes the provenance table** of each file in the provenance
-> input set owned by `.claude/skills/generate-gear/check_compile.py`, with its `git hash-object`
-> value, in a two-column markdown table with both cells in backticks. The set covers the gear's
-> `instructions.md`, its `fusion.md` if present, the playbook, and existing auxiliary Markdown
-> documents referenced by the two spec files.
+> **Write the `## Provenance` heading and leave its section empty.** The provenance table is
+> generated from the spec files after you finish, by
+> `.claude/skills/generate-gear/gen_provenance.py`, and written into that section. Never run
+> `git hash-object` and never type a hash: a hand-copied hash is a defect the gate can only report
+> as drift. Put the heading below the sentence naming the proof files and above the first step
+> heading, since a gate reads the text above it for those paths and the generator writes below it.
 >
 > **Each step carries** a heading of the form `## <id> `[GO]` <title>` or with `[PROSE]`, the
 > instructions themselves, a `**From:**` line naming the spec files and line ranges you compiled it

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -53,61 +53,14 @@ REPO_ROOT = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, os.pardir))
 sys.path.insert(0, HERE)
 import fusion_api  # noqa: E402  (sibling module; sys.path is fixed up just above)
 from call_parser import call_shapes  # noqa: E402
+from provenance import (  # noqa: E402  (sibling module; sys.path is fixed up just above)
+    DOCUMENT_REF, STAMPED_ROW, blob_hash, provenance_inputs, read, referenced_documents)
 
 PATH_REF = r'[\w./-]+\.(?:md|go|py|json|sh)'
 PATH_TOKEN = re.compile(r'`(%s)`' % PATH_REF)
 
-# The edges here are not symmetric, and that is left as it is. The lookbehind excludes `.`, `/`
-# and `-` while `\b` on the right excludes only word characters, so a name that continues past the
-# extension yields the `.md` prefix inside it. What that costs is one extra path in the provenance
-# input set, which is a file the table must stamp; the complaint is BLOCKING and names the file,
-# so the failure is loud. Closing it by excluding `.` on the right would drop a reference at the
-# end of a sentence, and a reference dropped from that set is a source whose edit leaves a stale
-# step list looking healthy, which is the silent direction this gate must not fail in.
-DOCUMENT_REF = re.compile(r'(?<![\w./-])[\w./-]+\.md\b')
 INLINE_CITATION = re.compile(r'`(%s):(\d+)(?:\s*[-\u2013]\s*(\d+))?`' % PATH_REF)
 LINE_RANGE = re.compile(r'\bL(\d+)(?:\s*[-\u2013]\s*(\d+))?\b')
-
-
-def referenced_documents(path):
-    """Return existing Markdown documents referenced from one gear's input spec."""
-    found = set()
-    for reference in DOCUMENT_REF.findall(read(path)):
-        candidates = (
-            os.path.normpath(os.path.join(os.path.dirname(path), reference)),
-            os.path.normpath(reference),
-        )
-        for candidate in candidates:
-            if not os.path.isfile(candidate):
-                continue
-            if candidate != path:
-                found.add(candidate)
-            break
-    return found
-
-
-def provenance_inputs(gear):
-    """Existing source files whose hashes define a compiled step list."""
-    instructions = os.path.join('spec', gear, 'instructions.md')
-    fusion = os.path.join('spec', gear, 'fusion.md')
-    playbook = os.path.join('.claude', 'skills', 'generate-gear', 'PLAYBOOK.md')
-    specs = [path for path in (instructions, fusion) if os.path.isfile(path)]
-    inputs = {
-        path for path in (instructions, fusion, playbook) if os.path.isfile(path)
-    }
-    for path in specs:
-        inputs.update(referenced_documents(path))
-    return inputs
-
-
-def read(path):
-    with open(path) as fh:
-        return fh.read()
-
-
-def blob_hash(path):
-    return subprocess.run(['git', 'hash-object', path],
-                          capture_output=True, text=True).stdout.strip()
 
 
 def steps_of(src):
@@ -1500,7 +1453,7 @@ def main(argv):
                            '; the nearest names it does have are %s' % ', '.join(near)))
 
     # 4. inputs have not drifted
-    stamped = dict(re.findall(r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|', src))
+    stamped = dict(STAMPED_ROW.findall(src))
     if not stamped:
         problems.append("  the step list carries no provenance table, so staleness cannot be seen")
     for path in sorted(provenance_inputs(gear) - set(stamped)):

--- a/.claude/skills/generate-gear/gen_provenance.py
+++ b/.claude/skills/generate-gear/gen_provenance.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate the `## Provenance` table of a compiled step list, so nothing hand-types a hash.
+
+`provenance.py` owns the input set for one gear (the gear's `instructions.md`, its optional
+`fusion.md`, the shared `PLAYBOOK.md`, and any auxiliary Markdown document those reference) and the
+`git hash-object` of each one. `check_compile.py` shares that same module to gate a step list's
+provenance table against drift. This script is the other side of that gate: it renders the table
+and, with `--write`, replaces the provenance section of a step list with it in place.
+
+No language model should ever type a hash into a step list. Run this instead, from the repo root:
+
+    python3 gen_provenance.py <gear>                       # print the table
+    python3 gen_provenance.py <gear> --write PATH           # stamp it into PATH
+
+Run from the repo root, like every other script in this directory: every path in the input set is
+built relative to the current working directory.
+
+Exit 0 = the table was printed or written. Exit 2 = bad usage, a missing or unreadable input, a
+target with no `## Provenance` heading, or a `git hash-object` failure — message on stderr,
+prefixed `gen_provenance:`. Exit 1 is deliberately unused; this script makes no findings about an
+artifact, so it never gates anything. That is check 4 of `check_compile.py`, and a second copy
+here could disagree with it.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import provenance  # noqa: E402  (sibling module; sys.path is fixed up just above)
+
+USAGE = 'usage: gen_provenance.py <gear> [--write <steps.md>]'
+
+
+def parse_args(argv):
+    """Return (gear, write_path or None), or raise ProvenanceError on a bad argument list.
+
+    Hand-rolled to match the other scripts in this directory (check_compile, check_step_calls,
+    check_input_read all test len(argv) and print a usage line); argparse is not used here.
+    Accepts `--write PATH` and `--write=PATH`. Any other flag, a missing gear, or extra
+    positionals is a usage error.
+    """
+    args = list(argv[1:])
+    if not args:
+        raise provenance.ProvenanceError(USAGE)
+    gear = args[0]
+    if gear.startswith('-'):
+        raise provenance.ProvenanceError(USAGE)
+    rest = args[1:]
+    write_path = None
+    if rest:
+        first = rest[0]
+        if first == '--write':
+            if len(rest) != 2:
+                raise provenance.ProvenanceError(USAGE)
+            write_path = rest[1]
+        elif first.startswith('--write='):
+            if len(rest) != 1:
+                raise provenance.ProvenanceError(USAGE)
+            write_path = first[len('--write='):]
+        else:
+            raise provenance.ProvenanceError(USAGE)
+        if not write_path:
+            raise provenance.ProvenanceError(USAGE)
+    return gear, write_path
+
+
+def write_section(path, gear):
+    """Stamp one step list. Reads path, replaces the section, writes it back.
+
+    Returns the number of rows written, for the summary line.
+    """
+    try:
+        src = provenance.read(path)
+    except OSError as exc:
+        raise provenance.ProvenanceError('%s: %s' % (path, exc.strerror or exc)) from exc
+    rows = provenance.table_rows(provenance.ordered_provenance_inputs(gear))
+    section = '%s\n\n%s' % (provenance.HEADING, provenance.render_table(rows))
+    updated = provenance.replace_section(src, section)
+    with open(path, 'w') as fh:
+        fh.write(updated)
+    return len(rows)
+
+
+def main(argv):
+    """Parse argv, dispatch, translate ProvenanceError and OSError into exit 2.
+
+    argv[0] is the program name, matching check_compile.main so tests can call
+    main(['gen_provenance.py', 'gear']) the way they already call the checker.
+    """
+    try:
+        gear, write_path = parse_args(argv)
+        instructions = os.path.join('spec', gear, 'instructions.md')
+        if not os.path.isfile(instructions):
+            raise provenance.ProvenanceError(
+                '%s does not exist; is %r a real gear?' % (instructions, gear))
+        if write_path is None:
+            rows = provenance.table_rows(provenance.ordered_provenance_inputs(gear))
+            print('%s\n\n%s' % (provenance.HEADING, provenance.render_table(rows)))
+            return 0
+        count = write_section(write_path, gear)
+        print('gen_provenance: stamped %d source(s) into %s' % (count, write_path))
+        return 0
+    except provenance.ProvenanceError as exc:
+        print('gen_provenance: %s' % exc, file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print('gen_provenance: %s' % exc, file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/.claude/skills/generate-gear/provenance.py
+++ b/.claude/skills/generate-gear/provenance.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""The provenance input set, its hashes, and the table format that stamps them.
+
+This module owns the one definition of what a compiled step list's `## Provenance` table must
+contain and how that table is rendered. `check_compile.py` imports the discovery functions from
+here to gate a step list's provenance table against drift; `gen_provenance.py` imports the same
+functions, plus the table-rendering ones below, to generate that table instead of asking an LLM
+to hand-type `git hash-object` output. Both callers must run from the repository root, since every
+path here is built relative to the current working directory.
+"""
+import os
+import re
+import subprocess
+
+# The edges here are not symmetric, and that is left as it is. The lookbehind excludes `.`, `/`
+# and `-` while `\b` on the right excludes only word characters, so a name that continues past the
+# extension yields the `.md` prefix inside it. What that costs is one extra path in the provenance
+# input set, which is a file the table must stamp; the complaint is BLOCKING and names the file,
+# so the failure is loud. Closing it by excluding `.` on the right would drop a reference at the
+# end of a sentence, and a reference dropped from that set is a source whose edit leaves a stale
+# step list looking healthy, which is the silent direction this gate must not fail in.
+DOCUMENT_REF = re.compile(r'(?<![\w./-])[\w./-]+\.md\b')
+
+
+def referenced_documents(path):
+    """Return existing Markdown documents referenced from one gear's input spec."""
+    found = set()
+    for reference in DOCUMENT_REF.findall(read(path)):
+        candidates = (
+            os.path.normpath(os.path.join(os.path.dirname(path), reference)),
+            os.path.normpath(reference),
+        )
+        for candidate in candidates:
+            if not os.path.isfile(candidate):
+                continue
+            if candidate != path:
+                found.add(candidate)
+            break
+    return found
+
+
+PLAYBOOK = os.path.join('.claude', 'skills', 'generate-gear', 'PLAYBOOK.md')
+
+
+def provenance_inputs(gear):
+    """Existing source files whose hashes define a compiled step list."""
+    instructions = os.path.join('spec', gear, 'instructions.md')
+    fusion = os.path.join('spec', gear, 'fusion.md')
+    playbook = PLAYBOOK
+    specs = [path for path in (instructions, fusion) if os.path.isfile(path)]
+    inputs = {
+        path for path in (instructions, fusion, playbook) if os.path.isfile(path)
+    }
+    for path in specs:
+        inputs.update(referenced_documents(path))
+    return inputs
+
+
+def read(path):
+    with open(path) as fh:
+        return fh.read()
+
+
+def blob_hash(path):
+    return subprocess.run(['git', 'hash-object', path],
+                          capture_output=True, text=True).stdout.strip()
+
+
+HEADING = '## Provenance'
+TABLE_HEADER = ('| file | `git hash-object` |', '|---|---|')
+BLOB_HASH = re.compile(r'^[0-9a-f]{40}$')
+STAMPED_ROW = re.compile(r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|')
+SECTION_END = re.compile(r'^##\s', re.M)
+
+
+class ProvenanceError(Exception):
+    """A provenance input cannot be hashed, or a step list has nowhere to put the table."""
+
+
+def ordered_provenance_inputs(gear):
+    """The provenance input set in the order the table writes it.
+
+    Returns a list: the gear's instructions, its fusion sidecar if present, every other
+    member sorted, and the playbook last. Order is cosmetic to check_compile.py, which reads
+    the rows into a dict, and load-bearing here: a stable order makes a regenerated table a
+    no-op diff when nothing changed.
+    """
+    inputs = provenance_inputs(gear)
+    instructions = os.path.join('spec', gear, 'instructions.md')
+    fusion = os.path.join('spec', gear, 'fusion.md')
+    ordered = []
+    if instructions in inputs:
+        ordered.append(instructions)
+    if fusion in inputs:
+        ordered.append(fusion)
+    remainder = inputs - {instructions, fusion, PLAYBOOK}
+    ordered.extend(sorted(remainder))
+    if PLAYBOOK in inputs:
+        ordered.append(PLAYBOOK)
+    return ordered
+
+
+def table_rows(paths):
+    """[(path, blob hash)] for paths, in the order given.
+
+    Raises ProvenanceError naming the path when `git hash-object` returns anything that is not
+    40 hex characters, so a broken git never silently produces a table with an empty cell.
+    """
+    rows = []
+    for path in paths:
+        digest = blob_hash(path)
+        if not BLOB_HASH.match(digest):
+            raise ProvenanceError(
+                "%s: `git hash-object` did not return a 40-character hash (got %r)"
+                % (path, digest))
+        rows.append((path, digest))
+    return rows
+
+
+def render_table(rows):
+    """The two-column markdown table, header included, with no trailing newline."""
+    lines = list(TABLE_HEADER)
+    lines.extend('| `%s` | `%s` |' % (path, digest) for path, digest in rows)
+    return '\n'.join(lines)
+
+
+def provenance_section(gear):
+    """`## Provenance`, a blank line, and the table for one gear. No trailing newline."""
+    rows = table_rows(ordered_provenance_inputs(gear))
+    return '%s\n\n%s' % (HEADING, render_table(rows))
+
+
+def replace_section(src, section):
+    """Return src with its provenance section replaced by `section`.
+
+    The section runs from the `## Provenance` heading to the next line starting `## ` or to
+    the end of the file. Raises ProvenanceError when src has no such heading: the heading's
+    position is the drafter's decision (check_compile.py reads proof paths from the text above
+    it), so this never invents one.
+    """
+    start = src.find(HEADING)
+    if start < 0:
+        raise ProvenanceError("no `%s` heading found; the drafter must write it" % HEADING)
+    after_heading = start + len(HEADING)
+    match = SECTION_END.search(src, after_heading)
+    end = match.start() if match else len(src)
+    before = src[:start]
+    tail = src[end:]
+    if tail:
+        return '%s%s\n\n%s' % (before, section, tail)
+    return '%s%s\n' % (before, section)

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 
 COMPILE_CHECKER_PATH = Path(__file__).with_name('check_compile.py')
+PROVENANCE_MODULE_PATH = Path(__file__).with_name('provenance.py')
 COMPILE_MODULE_SPEC = importlib.util.spec_from_file_location('check_compile', COMPILE_CHECKER_PATH)
 COMPILE_CHECKER = importlib.util.module_from_spec(COMPILE_MODULE_SPEC)
 COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
@@ -1940,6 +1941,8 @@ class GoPatternClassTest(unittest.TestCase):
             'proof_paths, a proof path named in the step-list summary',
         r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|':
             'stamped, a row of the provenance table',
+        r'^##\s':
+            'SECTION_END, the next `## ` heading after a step list\'s provenance section',
     }
 
     # The two classes that say what a Go identifier rune is. They are written as `\w` with what
@@ -1980,7 +1983,11 @@ class GoPatternClassTest(unittest.TestCase):
             if PYTHON_CHARACTER_CLASS.search(text) and text not in allowed)
 
     def checker_source(self):
-        return COMPILE_CHECKER_PATH.read_text()
+        # provenance.py is a sibling module check_compile.py imports its Markdown-matching
+        # patterns from (DOCUMENT_REF, STAMPED_ROW); this scan follows them there so an
+        # allowlist entry for either still points at a pattern that is actually written down,
+        # just no longer inside check_compile.py itself.
+        return COMPILE_CHECKER_PATH.read_text() + '\n' + PROVENANCE_MODULE_PATH.read_text()
 
     def test_no_pattern_that_reads_go_source_spells_a_python_class(self):
         """The gate itself, under its own rule."""

--- a/.claude/skills/generate-gear/test_gen_provenance.py
+++ b/.claude/skills/generate-gear/test_gen_provenance.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Regression tests for the provenance-table generator.
+
+`gen_provenance.py` exists so no language model ever hand-types a `git hash-object` value into a
+step list's `## Provenance` table. These tests hold it to reproducing the same table
+`check_compile.py`'s gate would accept, and to never touching its target file on a failure.
+"""
+import contextlib
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HERE = Path(__file__).parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, HERE / filename)
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec so that check_compile.py's own `from provenance import (...)` and
+    # gen_provenance.py's own `import provenance` resolve to this exact module object rather than
+    # a second copy, which is what test_checker_and_generator_share_one_input_set pins.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+PROVENANCE = _load('provenance', 'provenance.py')
+COMPILE_CHECKER = _load('check_compile', 'check_compile.py')
+GENERATOR = _load('gen_provenance', 'gen_provenance.py')
+
+DEFAULT_STEPS = (
+    '# Steps\n\n'
+    'The proof is `proof/gear/proof_test.go`.\n\n'
+    '## Provenance\n\n'
+    '## S1 `[GO]` One — `stepOne`\n\n'
+    'Build the thing.\n\n'
+    '**From:** `spec/gear/instructions.md` L1\n')
+
+PROOF_BODY = (
+    'func TestOne(t *testing.T) {\n'
+    '\tproofkit.Run(t, profileCases, stepOne)\n'
+    '}\n\n'
+    'func stepOne() {}\n')
+
+
+def git_hash_object(path):
+    """The independent ground truth this test file computes for itself.
+
+    Deliberately not `PROVENANCE.blob_hash`: reusing the function under test to check its own
+    output would not catch a regression in that function.
+    """
+    return subprocess.run(
+        ['git', 'hash-object', str(path)], capture_output=True, text=True).stdout.strip()
+
+
+class GenProvenanceTest(unittest.TestCase):
+    def repo(self, fusion=True, auxiliary=False, steps=None):
+        """Build a miniature repo and chdir into it.
+
+        `spec/gear/instructions.md`, an optional `spec/gear/fusion.md`, the shared
+        `PLAYBOOK.md`, an optional `trace.md` referenced by `instructions.md` (`auxiliary=True`)
+        or by `fusion.md` (`auxiliary='fusion'`), and a drafted `spec/gear/steps.md` whose
+        provenance section is empty unless `steps` overrides it.
+
+        cwd is restored and the tree is removed on test teardown via addCleanup. Returns the
+        repo root as a Path.
+        """
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        (root / 'spec' / 'gear').mkdir(parents=True)
+        (root / 'proof' / 'gear').mkdir(parents=True)
+        (root / '.claude' / 'skills' / 'generate-gear').mkdir(parents=True)
+
+        instructions_text = 'source\nline two\nline three\n'
+        fusion_text = 'source\nline two\nline three\n'
+        if auxiliary is True:
+            instructions_text = 'source\nSee `trace.md` for details.\nline three\n'
+        elif auxiliary == 'fusion':
+            fusion_text = 'source\nSee `trace.md` for details.\nline three\n'
+        if auxiliary:
+            (root / 'spec' / 'gear' / 'trace.md').write_text('trace\n')
+        (root / 'spec' / 'gear' / 'instructions.md').write_text(instructions_text)
+        if fusion:
+            (root / 'spec' / 'gear' / 'fusion.md').write_text(fusion_text)
+        (root / '.claude' / 'skills' / 'generate-gear' / 'PLAYBOOK.md').write_text(
+            'playbook\nline two\nline three\n')
+
+        (root / 'spec' / 'gear' / 'steps.md').write_text(DEFAULT_STEPS if steps is None else steps)
+
+        prior = os.getcwd()
+        os.chdir(root)
+        self.addCleanup(os.chdir, prior)
+        return root
+
+    def run_generator(self, argv):
+        out = io.StringIO()
+        err = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            result = GENERATOR.main(argv)
+        return result, out.getvalue(), err.getvalue()
+
+    def parse_rows(self, output):
+        return PROVENANCE.STAMPED_ROW.findall(output)
+
+    # -- table content and shape --------------------------------------------------------------
+
+    def test_table_lists_every_provenance_input(self):
+        self.repo()
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        rows = self.parse_rows(out)
+        self.assertEqual(len(rows), 3)
+        for path, digest in rows:
+            self.assertEqual(digest, git_hash_object(path))
+
+    def test_rows_are_ordered_instructions_fusion_auxiliary_playbook(self):
+        self.repo(auxiliary=True)
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        paths = [path for path, _ in self.parse_rows(out)]
+        self.assertEqual(paths, [
+            'spec/gear/instructions.md',
+            'spec/gear/fusion.md',
+            'spec/gear/trace.md',
+            '.claude/skills/generate-gear/PLAYBOOK.md',
+        ])
+
+    def test_absent_fusion_sidecar_is_omitted(self):
+        self.repo(fusion=False)
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        rows = self.parse_rows(out)
+        self.assertEqual(len(rows), 2)
+        self.assertNotIn('spec/gear/fusion.md', out)
+
+    def test_auxiliary_document_referenced_by_the_fusion_sidecar_is_included(self):
+        self.repo(auxiliary='fusion')
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        paths = [path for path, _ in self.parse_rows(out)]
+        self.assertEqual(paths, [
+            'spec/gear/instructions.md',
+            'spec/gear/fusion.md',
+            'spec/gear/trace.md',
+            '.claude/skills/generate-gear/PLAYBOOK.md',
+        ])
+
+    def test_header_and_separator_match_the_committed_step_list(self):
+        self.repo()
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        lines = out.splitlines()
+        self.assertEqual(lines[2], '| file | `git hash-object` |')
+        self.assertEqual(lines[3], '|---|---|')
+
+    def test_stdout_form_prints_the_heading_and_touches_no_file(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+        before = steps_path.read_bytes()
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        self.assertTrue(out.startswith('## Provenance\n\n'))
+        self.assertEqual(steps_path.read_bytes(), before)
+
+    # -- agreement with the checker ------------------------------------------------------------
+
+    def test_generated_table_satisfies_the_compile_check(self):
+        root = self.repo()
+        (root / 'proof' / 'gear' / 'proof_test.go').write_text(PROOF_BODY)
+        # check_compile.py requires the proof path the summary names to be tracked or committed,
+        # which a plain tempdir is neither; `git add` (no commit needed) satisfies `git ls-files`.
+        subprocess.run(['git', 'init', '--quiet'], cwd=root, check=True)
+        subprocess.run(['git', 'add', 'proof/gear/proof_test.go'], cwd=root, check=True)
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+
+        write_result, _, write_err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+        self.assertEqual(write_result, 0, write_err)
+
+        out = io.StringIO()
+        lookup_patch = mock.patch.object(COMPILE_CHECKER.fusion_api, 'lookup_many', return_value={})
+        findings_patch = mock.patch.object(
+            COMPILE_CHECKER.fusion_api, 'unverified_findings', return_value=[])
+        with lookup_patch, findings_patch, contextlib.redirect_stdout(out):
+            result = COMPILE_CHECKER.main(['check_compile.py', 'gear'])
+
+        self.assertEqual(result, 0, out.getvalue())
+        self.assertIn('compile check: OK', out.getvalue())
+
+    def test_generated_rows_parse_with_the_checker_row_pattern(self):
+        self.repo(auxiliary=True)
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'gear'])
+
+        self.assertEqual(result, 0, err)
+        parsed = dict(PROVENANCE.STAMPED_ROW.findall(out))
+        self.assertEqual(set(parsed), PROVENANCE.provenance_inputs('gear'))
+
+    def test_checker_and_generator_share_one_input_set(self):
+        self.assertIs(COMPILE_CHECKER.provenance_inputs, PROVENANCE.provenance_inputs)
+        self.assertIs(COMPILE_CHECKER.blob_hash, PROVENANCE.blob_hash)
+
+    # -- writing into a step list --------------------------------------------------------------
+
+    def test_write_fills_an_empty_provenance_section(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+
+        result, out, err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+
+        self.assertEqual(result, 0, err)
+        text = steps_path.read_text()
+        self.assertIn('The proof is `proof/gear/proof_test.go`.', text)
+        self.assertIn('## S1 `[GO]` One — `stepOne`', text)
+        self.assertEqual(len(PROVENANCE.STAMPED_ROW.findall(text)), 3)
+
+    def test_write_replaces_a_stale_table_rather_than_appending(self):
+        stale = (
+            '# Steps\n\n'
+            'The proof is `proof/gear/proof_test.go`.\n\n'
+            '## Provenance\n\n'
+            '| file | `git hash-object` |\n'
+            '|---|---|\n'
+            '| `spec/gear/instructions.md` | `0000000000000000000000000000000000000000` |\n\n'
+            '## S1 `[GO]` One — `stepOne`\n\n'
+            'Build the thing.\n\n'
+            '**From:** `spec/gear/instructions.md` L1\n')
+        root = self.repo(steps=stale)
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+
+        result, out, err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+
+        self.assertEqual(result, 0, err)
+        text = steps_path.read_text()
+        self.assertEqual(text.count('## Provenance'), 1)
+        self.assertNotIn('0000000000000000000000000000000000000000', text)
+
+    def test_write_is_idempotent(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+
+        first_result, _, first_err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+        self.assertEqual(first_result, 0, first_err)
+        first = steps_path.read_bytes()
+
+        second_result, _, second_err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+        self.assertEqual(second_result, 0, second_err)
+        second = steps_path.read_bytes()
+
+        self.assertEqual(first, second)
+
+    def test_write_keeps_the_proof_summary_readable_by_the_checker(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+
+        result, out, err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+
+        self.assertEqual(result, 0, err)
+        text = steps_path.read_text()
+        self.assertEqual(COMPILE_CHECKER.proof_paths(text), ['proof/gear/proof_test.go'])
+
+    def test_write_prints_a_summary_line(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+
+        result, out, err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+
+        self.assertEqual(result, 0, err)
+        self.assertIn('gen_provenance: stamped 3 source(s) into %s' % steps_path, out)
+
+    # -- failure modes: exit 2, target untouched -------------------------------------------------
+
+    def test_missing_gear_instructions_exit_2(self):
+        self.repo()
+
+        result, out, err = self.run_generator(['gen_provenance.py', 'nosuchgear'])
+
+        self.assertEqual(result, 2)
+        self.assertIn('spec/nosuchgear/instructions.md', err)
+
+    def test_missing_target_file_exits_2(self):
+        root = self.repo()
+        missing = root / 'spec' / 'gear' / 'nope.md'
+
+        result, out, err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(missing)])
+
+        self.assertEqual(result, 2)
+        self.assertIn(str(missing), err)
+        self.assertFalse(missing.exists())
+
+    def test_target_without_a_provenance_heading_exits_2(self):
+        root = self.repo(steps='# Steps\n\nNo heading here.\n')
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+        before = steps_path.read_bytes()
+
+        result, out, err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+
+        self.assertEqual(result, 2)
+        self.assertIn('## Provenance', err)
+        self.assertEqual(steps_path.read_bytes(), before)
+
+    def test_unhashable_source_exits_2_without_writing(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+        before = steps_path.read_bytes()
+
+        with mock.patch.object(PROVENANCE, 'blob_hash', return_value=''):
+            result, out, err = self.run_generator(
+                ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+
+        self.assertEqual(result, 2)
+        self.assertIn('spec/gear/instructions.md', err)
+        self.assertEqual(steps_path.read_bytes(), before)
+
+    def test_usage_errors_exit_2(self):
+        self.repo()
+        cases = (
+            [],
+            ['gen_provenance.py'],
+            ['gen_provenance.py', 'gear', 'extra'],
+            ['gen_provenance.py', 'gear', '--wat'],
+            ['gen_provenance.py', 'gear', '--write'],
+        )
+        for argv in cases:
+            with self.subTest(argv=argv):
+                result, out, err = self.run_generator(argv)
+
+                self.assertEqual(result, 2)
+                self.assertIn('usage:', err)
+
+    def test_write_accepts_both_flag_spellings(self):
+        root = self.repo()
+        steps_path = root / 'spec' / 'gear' / 'steps.md'
+        space_result, _, space_err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write', str(steps_path)])
+        self.assertEqual(space_result, 0, space_err)
+        space_form = steps_path.read_bytes()
+
+        root2 = self.repo()
+        steps_path2 = root2 / 'spec' / 'gear' / 'steps.md'
+        equals_result, _, equals_err = self.run_generator(
+            ['gen_provenance.py', 'gear', '--write=%s' % steps_path2])
+        self.assertEqual(equals_result, 0, equals_err)
+        equals_form = steps_path2.read_bytes()
+
+        self.assertEqual(space_form, equals_form)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- an LLM's only job in a provenance table was transcribing `git hash-object`, and copying is the failure this removes
- `provenance.py` gives the checker and the new `gen_provenance.py` one shared input-set definition
- the orchestrator, not the drafter, stamps the table after each drafting round, so no hash is hand-typed
