### PR TITLE
resolve the deploy target instead of hardcoding it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .vscode
 .env
+.deploy.conf
 .tmp/
 .gauntlet/
 .worktrees/

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,13 +1,59 @@
 #!/usr/bin/env bash
-# Deploy the add-in to the Windows Fusion AddIns folder.
+# Deploy the add-in to Fusion's AddIns folder.
 # Fusion's Aug 2026 update stopped loading add-ins from \\wsl.localhost paths,
-# so the repo (WSL) is the source of truth and this copies the runtime files out.
+# so the repo is the source of truth and this copies the runtime files out.
+#
+# Destination resolution, first hit wins:
+#   1. $FUSION_ADDIN_DIR — the "Gear Generator" folder itself, not its parent.
+#   2. .deploy.conf next to this script (untracked), a shell fragment that
+#      sets FUSION_ADDIN_DIR.
+#   3. Auto-discovery of the one "Gear Generator" folder under the standard
+#      per-OS AddIns locations listed in standard_addin_parents below.
 set -euo pipefail
 
 SRC="$(cd "$(dirname "$0")" && pwd)"
-DEST="/mnt/c/Users/lestr/AppData/Roaming/Autodesk/Autodesk Fusion 360/API/AddIns/Gear Generator"
 
-mkdir -p "$DEST"
+if [[ -z "${FUSION_ADDIN_DIR:-}" && -f "$SRC/.deploy.conf" ]]; then
+    # shellcheck source=/dev/null
+    source "$SRC/.deploy.conf"
+fi
+
+standard_addin_parents() {
+    # WSL view of a Windows install, any Windows user profile.
+    local d
+    for d in /mnt/c/Users/*/AppData/Roaming/Autodesk/"Autodesk Fusion 360"/API/AddIns; do
+        [[ -d "$d" ]] && printf '%s\n' "$d"
+    done
+    # Native Windows shells (Git Bash / MSYS) expose APPDATA.
+    if [[ -n "${APPDATA:-}" && -d "$APPDATA/Autodesk/Autodesk Fusion 360/API/AddIns" ]]; then
+        printf '%s\n' "$APPDATA/Autodesk/Autodesk Fusion 360/API/AddIns"
+    fi
+    # macOS.
+    if [[ -d "$HOME/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns" ]]; then
+        printf '%s\n' "$HOME/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns"
+    fi
+}
+
+if [[ -z "${FUSION_ADDIN_DIR:-}" ]]; then
+    mapfile -t parents < <(standard_addin_parents)
+    if [[ ${#parents[@]} -eq 1 ]]; then
+        FUSION_ADDIN_DIR="${parents[0]}/Gear Generator"
+        echo "Auto-detected AddIns folder: ${parents[0]}"
+    else
+        {
+            echo "deploy.sh: cannot pick a destination (${#parents[@]} standard AddIns folders found)."
+            echo "Set FUSION_ADDIN_DIR to the 'Gear Generator' folder, either in the environment"
+            echo "or in $SRC/.deploy.conf (a line: FUSION_ADDIN_DIR=/path/to/AddIns/Gear Generator)."
+            echo "Fusion's standard AddIns locations:"
+            echo "  Windows (from WSL): /mnt/c/Users/<you>/AppData/Roaming/Autodesk/Autodesk Fusion 360/API/AddIns"
+            echo "  Windows (native):   %APPDATA%\\Autodesk\\Autodesk Fusion 360\\API\\AddIns"
+            echo "  macOS:              ~/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns"
+        } >&2
+        exit 2
+    fi
+fi
+
+mkdir -p "$FUSION_ADDIN_DIR"
 rsync -r --delete \
     --exclude '__pycache__' \
     --include '/Gear Generator.py' \
@@ -17,6 +63,6 @@ rsync -r --delete \
     --include '/lib/***' \
     --include '/diag_*.py' \
     --exclude '*' \
-    "$SRC/" "$DEST/"
+    "$SRC/" "$FUSION_ADDIN_DIR/"
 
-echo "Deployed to $DEST"
+echo "Deployed to $FUSION_ADDIN_DIR"

--- a/diag_dimsign.py
+++ b/diag_dimsign.py
@@ -85,8 +85,20 @@ try:
             log('   profile %d loop %d curve types: %s' % (i, j, kinds))
 finally:
     text = '\n'.join(lines)
-    out = 'C:/Users/lestr/AppData/Roaming/Autodesk/Autodesk Fusion 360/API/AddIns/Gear Generator/diag_dimsign_out.txt'
-    with open(out, 'w') as f:
-        f.write(text)
+    # The console print is the primary output; the file beside the deployed
+    # add-in (found via the standard per-OS AddIns location) is a convenience.
+    import os
+    appdata = os.environ.get('APPDATA')
+    if appdata:
+        addin = os.path.join(appdata, 'Autodesk', 'Autodesk Fusion 360', 'API',
+                             'AddIns', 'Gear Generator')
+    else:
+        addin = os.path.expanduser('~/Library/Application Support/Autodesk/'
+                                   'Autodesk Fusion 360/API/AddIns/Gear Generator')
+    try:
+        with open(os.path.join(addin, 'diag_dimsign_out.txt'), 'w') as f:
+            f.write(text)
+    except OSError:
+        pass
     print(text)
     doc.close(False)

--- a/diag_profile.py
+++ b/diag_profile.py
@@ -67,7 +67,19 @@ else:
             s.x, s.y, math.hypot(s.x, s.y), e.x, e.y, math.hypot(e.x, e.y)))
 
 text = '\n'.join(lines)
-out = 'C:/Users/lestr/AppData/Roaming/Autodesk/Autodesk Fusion 360/API/AddIns/Gear Generator/diag_profile_out.txt'
-with open(out, 'w') as f:
-    f.write(text)
+# The console print is the primary output; the file beside the deployed
+# add-in (found via the standard per-OS AddIns location) is a convenience.
+import os
+appdata = os.environ.get('APPDATA')
+if appdata:
+    addin = os.path.join(appdata, 'Autodesk', 'Autodesk Fusion 360', 'API',
+                         'AddIns', 'Gear Generator')
+else:
+    addin = os.path.expanduser('~/Library/Application Support/Autodesk/'
+                               'Autodesk Fusion 360/API/AddIns/Gear Generator')
+try:
+    with open(os.path.join(addin, 'diag_profile_out.txt'), 'w') as f:
+        f.write(text)
+except OSError:
+    pass
 print(text)


### PR DESCRIPTION
- deploy.sh hardcoded one user's AddIns path; resolve via env var, .deploy.conf, or standard locations
- the diagnostic scripts find the add-in folder through APPDATA rather than a username
