### PR TITLE
add machine-readable modes to the step-call gate

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -87,8 +87,9 @@ proof is where the next reader is looking for the missing check.
    Then, **only if `lib/geargen/<gear>.py` already exists**, run
    `python3 .claude/skills/generate-gear/check_step_calls.py spec/<gear>/steps.md
    lib/geargen/<gear>.py`. That gate runs in CI against the checked-in module, so a recompiled step
-   list that disagrees with it breaks the build even though both other checks are green. Read its
-   output as a list of call names to classify, and pass only the names back to the drafter: a name
+   list that disagrees with it breaks the build even though both other checks are green. Run it
+   with `--names`, which prints exactly the missing call names, one per line; classify each name
+   and pass only the names back to the drafter: a name
    the step list mentions without requiring takes the exemption directive, and a call the module
    genuinely fails to make is work for `/emit-gear`, not for this stage. Never hand the drafter
    anything the module does or does not contain, and never let it read the module — the pipeline

--- a/.claude/skills/generate-gear/check_step_calls.py
+++ b/.claude/skills/generate-gear/check_step_calls.py
@@ -30,9 +30,20 @@ None of these prove the geometry is right. They prove the generator did what the
 which is the layer that was entirely unguarded.
 
 Usage:
-    python3 check_step_calls.py spec/<gear>/steps.md .tmp/<gear>.generated.py
+    python3 check_step_calls.py [--names | --json] spec/<gear>/steps.md .tmp/<gear>.generated.py
 
-Exit 0 = OK, 1 = BLOCKING.
+Exit 0 = OK, 1 = BLOCKING, 2 = usage error.
+
+Without a flag the report is prose, for a human. Two machine-readable modes exist so a caller
+does not have to parse that prose:
+
+  --names  print only the bare names of the missing calls, sorted and de-duplicated, one per
+           line. That is the form the `<!-- check-step-calls: ignore ... -->` directive takes,
+           and the only thing `/compile-gear` step 5 is allowed to pass on to its drafter.
+  --json   print one JSON object carrying everything the prose report carries.
+
+Neither flag changes the exit code: a run whose only problems are stub markers prints no names
+and still exits 1.
 
 The step list may exempt a name it mentions but does not require — a call the framework makes on
 the generator's behalf, or one named only to forbid it. Calls in code spans introduced by a
@@ -42,6 +53,7 @@ exemption uses a line of the form:
     <!-- check-step-calls: ignore nameOne nameTwo -->
 """
 import ast
+import json
 import re
 import sys
 
@@ -394,21 +406,50 @@ def actual_call_shapes(gen_tree):
     return ReachableCallCollector(gen_tree).collect(gen_tree)
 
 
+def _usage_error():
+    print('usage: check_step_calls.py <steps.md> <generated.py>', file=sys.stderr)
+    return 2
+
+
+def _parse_argv(argv):
+    """Split argv into the two output-mode flags and the two positionals.
+
+    Hand-rolled on purpose. argparse raises SystemExit on a bad argument, and every caller of
+    ``main`` — the tests included — expects an int back instead.
+
+    Returns ``(names_mode, json_mode, positionals)``, or None when the usage is wrong.
+    """
+    names_mode = False
+    json_mode = False
+    positionals = []
+    for argument in argv[1:]:
+        if argument == '--names':
+            names_mode = True
+        elif argument == '--json':
+            json_mode = True
+        elif argument.startswith('--'):
+            return None
+        else:
+            positionals.append(argument)
+    if len(positionals) != 2 or (names_mode and json_mode):
+        return None
+    return names_mode, json_mode, positionals
+
+
 def main(argv):
-    if len(argv) != 3:
-        print('usage: check_step_calls.py <steps.md> <generated.py>', file=sys.stderr)
-        return 2
-    steps_path, gen_path = argv[1], argv[2]
+    parsed = _parse_argv(argv)
+    if parsed is None:
+        return _usage_error()
+    names_mode, json_mode, (steps_path, gen_path) = parsed
     steps_src = open(steps_path).read()
     gen_src = open(gen_path).read()
 
-    problems = []
-
     wanted = named_call_shapes(steps_src)
+    parse_error = None
     try:
         gen_tree = ast.parse(gen_src, filename=gen_path)
     except SyntaxError as err:
-        problems.append("  generated candidate is not valid Python: %s" % err)
+        parse_error = str(err)
         actual = set()
     else:
         actual = actual_call_shapes(gen_tree)
@@ -416,34 +457,72 @@ def main(argv):
     # Keep the textual scan only to explain whether a missing reachable call has a misleading
     # match in a comment or string. The AST result above is the coverage gate.
     textual = {name for name, _ in wanted if name + '(' in gen_src}
-    missing = sorted(
+    missing_shapes = sorted(
         ((name, has_receiver) for name, has_receiver in wanted
          if not any(actual_name == name and (not has_receiver or actual_receiver)
                     for actual_name, actual_receiver in actual)),
         key=lambda row: (row[0], row[1] or ''))
-    for name, has_receiver in missing:
-        note = " (textual match exists, but it is not a reachable executable call)" if name in textual else ""
-        call = ('receiver.%s' if has_receiver else '%s') % name
-        problems.append(
-                "  named-call coverage: '%s(' is named in %s but has no reachable executable %s call in %s%s"
-            % (call, steps_path, 'method' if has_receiver else 'function', gen_path, note))
+    missing = [
+        {'name': name, 'has_receiver': bool(has_receiver), 'textual_match': name in textual}
+        for name, has_receiver in missing_shapes]
 
+    stubs = []
     for lineno, line in enumerate(gen_src.splitlines(), 1):
         hit = STUB_PATTERN.search(line)
         if hit:
-            problems.append(
-                "  stub marker: %s:%d carries '%s' — %s"
-                % (gen_path, lineno, hit.group(1), line.strip()))
+            stubs.append({'line': lineno, 'marker': hit.group(1), 'text': line.strip()})
 
     # Scan the whole source, not line by line: these calls routinely wrap, and the argument
     # lands on the following line.
+    shared_point = []
     for match in SHARE_CALL.finditer(gen_src):
         arg = match.group(1)
         if arg.endswith('.geometry'):
-            lineno = gen_src.count('\n', 0, match.start()) + 1
-            problems.append(
-                "  shared-point misuse: %s:%d passes '%s' where the SketchPoint itself "
-                "must be shared ([PB-SHARE-XOR-COINCIDENT])" % (gen_path, lineno, arg))
+            shared_point.append(
+                {'line': gen_src.count('\n', 0, match.start()) + 1, 'argument': arg})
+
+    # The prose report is rendered from those records, in the order it has always used, so the
+    # flagless output stays byte for byte what it was.
+    problems = []
+    if parse_error is not None:
+        problems.append("  generated candidate is not valid Python: %s" % parse_error)
+    for record in missing:
+        note = (" (textual match exists, but it is not a reachable executable call)"
+                if record['textual_match'] else "")
+        call = ('receiver.%s' if record['has_receiver'] else '%s') % record['name']
+        problems.append(
+                "  named-call coverage: '%s(' is named in %s but has no reachable executable %s call in %s%s"
+            % (call, steps_path, 'method' if record['has_receiver'] else 'function', gen_path, note))
+    for record in stubs:
+        problems.append(
+            "  stub marker: %s:%d carries '%s' — %s"
+            % (gen_path, record['line'], record['marker'], record['text']))
+    for record in shared_point:
+        problems.append(
+            "  shared-point misuse: %s:%d passes '%s' where the SketchPoint itself "
+            "must be shared ([PB-SHARE-XOR-COINCIDENT])"
+            % (gen_path, record['line'], record['argument']))
+
+    if json_mode:
+        print(json.dumps({
+            'ok': not problems,
+            'named_calls': len(wanted),
+            'missing': missing,
+            'stubs': stubs,
+            'shared_point': shared_point,
+            'parse_error': parse_error,
+        }, sort_keys=True))
+        return 1 if problems else 0
+
+    if names_mode:
+        # A name is all the caller may forward, so the parse error goes to stderr rather than
+        # contaminating the list.
+        if parse_error is not None:
+            print('check_step_calls: candidate is not valid Python: %s' % parse_error,
+                  file=sys.stderr)
+        for name in sorted({record['name'] for record in missing}):
+            print(name)
+        return 1 if problems else 0
 
     if problems:
         print('step-call check: BLOCKING (%d)' % len(problems))

--- a/.claude/skills/generate-gear/test_check_step_calls.py
+++ b/.claude/skills/generate-gear/test_check_step_calls.py
@@ -3,6 +3,7 @@
 import contextlib
 import importlib.util
 import io
+import json
 import os
 import sys
 import tempfile
@@ -29,18 +30,28 @@ COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
 
 
 class CheckStepCallsTest(unittest.TestCase):
-    def run_checker(self, steps, candidate):
+    def run_checker_argv(self, steps, candidate, flags=(), flags_first=False):
+        """Run the checker with optional output-mode flags, capturing stdout and stderr."""
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             steps_path = root / 'steps.md'
             candidate_path = root / 'candidate.py'
             steps_path.write_text(steps)
             candidate_path.write_text(candidate)
+            positionals = [str(steps_path), str(candidate_path)]
+            flags = list(flags)
+            tail = flags + positionals if flags_first else positionals + flags
             output = io.StringIO()
-            with warnings.catch_warnings(), contextlib.redirect_stdout(output):
+            errors = io.StringIO()
+            with warnings.catch_warnings(), contextlib.redirect_stdout(output), \
+                    contextlib.redirect_stderr(errors):
                 warnings.simplefilter('ignore', ResourceWarning)
-                result = CHECKER.main(['check_step_calls.py', str(steps_path), str(candidate_path)])
-            return result, output.getvalue()
+                result = CHECKER.main(['check_step_calls.py'] + tail)
+            return result, output.getvalue(), errors.getvalue()
+
+    def run_checker(self, steps, candidate):
+        result, output, _ = self.run_checker_argv(steps, candidate)
+        return result, output
 
     def test_forbidden_call_is_not_required(self):
         steps = 'Call `safeCall()`. Do not read the direction via `getTangent(0)`.'
@@ -275,6 +286,130 @@ class CheckStepCallsTest(unittest.TestCase):
         result, output = self.run_checker(steps, candidate)
 
         self.assertEqual(result, 0, output)
+
+
+    # The two machine-readable modes `/compile-gear` step 5 consumes.
+
+    def test_names_prints_bare_names_of_missing_calls(self):
+        steps = 'Call `sketch.addByTwoPoints(start, end)` and `helperCall(value)`.'
+
+        result, output, errors = self.run_checker_argv(steps, 'pass\n', flags=['--names'])
+
+        self.assertEqual(result, 1, output)
+        self.assertEqual(output, 'addByTwoPoints\nhelperCall\n')
+        self.assertEqual(errors, '')
+
+    def test_names_is_empty_but_still_blocking_for_a_stub_marker(self):
+        steps = 'Call `safeCall()`.'
+
+        result, output, _ = self.run_checker_argv(
+            steps, 'safeCall()\n# TODO fill in\n', flags=['--names'])
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, '')
+
+    def test_names_is_empty_on_a_green_pair(self):
+        steps = 'Call `safeCall()`.'
+
+        result, output, _ = self.run_checker_argv(steps, 'safeCall()\n', flags=['--names'])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(output, '')
+
+    def test_names_deduplicates_the_bare_and_dotted_shapes_of_one_name(self):
+        steps = 'Call `foo()` and `obj.foo()`.'
+
+        result, output, _ = self.run_checker_argv(steps, 'pass\n', flags=['--names'])
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, 'foo\n')
+
+    def test_names_sends_a_parse_error_to_stderr_and_still_lists_names(self):
+        steps = 'Call `safeCall()`.'
+
+        result, output, errors = self.run_checker_argv(
+            steps, 'def broken(:\n', flags=['--names'])
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, 'safeCall\n')
+        self.assertIn('check_step_calls: candidate is not valid Python:', errors)
+
+    def test_json_green_case(self):
+        steps = 'Call `safeCall()`.'
+
+        result, output, _ = self.run_checker_argv(steps, 'safeCall()\n', flags=['--json'])
+        report = json.loads(output)
+
+        self.assertEqual(result, 0)
+        self.assertTrue(report['ok'])
+        self.assertEqual(report['named_calls'], 1)
+        self.assertEqual(report['missing'], [])
+        self.assertEqual(report['stubs'], [])
+        self.assertEqual(report['shared_point'], [])
+        self.assertIsNone(report['parse_error'])
+
+    def test_json_reports_every_problem_category(self):
+        steps = 'Call `sketch.missingCall(entity)`.'
+        candidate = (
+            '# missingCall(entity)\n'
+            'circles.addByCenterRadius(center.geometry, radius)\n'
+            '# TODO wire the rest\n')
+
+        result, output, _ = self.run_checker_argv(steps, candidate, flags=['--json'])
+        report = json.loads(output)
+
+        self.assertEqual(result, 1)
+        self.assertFalse(report['ok'])
+        self.assertEqual(report['named_calls'], 1)
+        self.assertEqual(
+            report['missing'],
+            [{'name': 'missingCall', 'has_receiver': True, 'textual_match': True}])
+        self.assertEqual(
+            report['stubs'],
+            [{'line': 3, 'marker': 'TODO', 'text': '# TODO wire the rest'}])
+        self.assertEqual(
+            report['shared_point'], [{'line': 2, 'argument': 'center.geometry'}])
+        self.assertIsNone(report['parse_error'])
+
+    def test_json_reports_a_syntax_error_and_counts_every_call_missing(self):
+        steps = 'Call `safeCall()` and `sketch.otherCall(entity)`.'
+
+        result, output, _ = self.run_checker_argv(steps, 'def broken(:\n', flags=['--json'])
+        report = json.loads(output)
+
+        self.assertEqual(result, 1)
+        self.assertFalse(report['ok'])
+        self.assertIsInstance(report['parse_error'], str)
+        self.assertTrue(report['parse_error'])
+        self.assertEqual(report['named_calls'], 2)
+        self.assertEqual(
+            sorted(record['name'] for record in report['missing']),
+            ['otherCall', 'safeCall'])
+
+    def test_both_output_modes_at_once_is_a_usage_error(self):
+        result, output, errors = self.run_checker_argv(
+            'Call `safeCall()`.', 'safeCall()\n', flags=['--names', '--json'])
+
+        self.assertEqual(result, 2)
+        self.assertEqual(output, '')
+        self.assertIn('usage: check_step_calls.py', errors)
+
+    def test_unknown_flag_is_a_usage_error(self):
+        result, output, errors = self.run_checker_argv(
+            'Call `safeCall()`.', 'safeCall()\n', flags=['--bogus'])
+
+        self.assertEqual(result, 2)
+        self.assertEqual(output, '')
+        self.assertIn('usage: check_step_calls.py', errors)
+
+    def test_a_flag_is_position_independent(self):
+        steps = 'Call `helperCall(value)`.'
+
+        trailing = self.run_checker_argv(steps, 'pass\n', flags=['--names'])
+        leading = self.run_checker_argv(steps, 'pass\n', flags=['--names'], flags_first=True)
+
+        self.assertEqual(trailing, (1, 'helperCall\n', ''))
+        self.assertEqual(leading, trailing)
 
 
 class CheckApiCallsTest(unittest.TestCase):


### PR DESCRIPTION
- `--names` gives `/compile-gear` step 5 the bare call names directly, instead of hand-parsed prose.
- `--json` gives script consumers the whole report in one document.
- Flagless output and exit codes are unchanged, so `run_gates.py` and CI are unaffected.
