### PR TITLE
bootstrap pyright into the cache when missing

### DIFF
--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -113,8 +113,10 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
      expand with `--review` only when chasing a specific runtime `AttributeError`/`NoneType`. Stubs
      come from `$FUSION_API_STUBS` (or `--stubs <dir>`); if neither is set the script **auto-clones**
      the `FusionAPIReference` repo (sparse/shallow/blobless — ~13M, not the full 338M) into
-     `~/.cache/fusion360-gear-generator/` on first run and reuses it. Install pyright once with
-     `python3 -m pip install --break-system-packages pyright`. Why standard mode, not `--strict`:
+     `~/.cache/fusion360-gear-generator/` on first run and reuses it. If pyright is missing the
+     script auto-installs the pyright wrapper into `~/.cache/fusion360-gear-generator/` (pass
+     `--no-install` to forbid network use); the wrapper's first run may additionally download
+     node / the pyright npm bundle. Why standard mode, not `--strict`:
      the stubs are intellisense-only and leave many return types unannotated, so `--strict` buries
      the file in thousands of `reportUnknown*` lines with zero extra real bugs. If the stubs are
      unavailable the script exits 2; fall back to a pyflakes undefined-name grep for the first bug

--- a/.claude/skills/generate-gear/pyright_boot.py
+++ b/.claude/skills/generate-gear/pyright_boot.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Shared resolution/bootstrap of pyright for the static-analysis gate.
+
+pyright_check.py needs two things: the Fusion API stub defs (fusion_stubs.py provisions those)
+and pyright itself. This module is the pyright half, and it follows the same rule: provision
+into ~/.cache/fusion360-gear-generator/ rather than ask a human to run pip.
+
+The `pyright` PyPI distribution is a pure-Python WRAPPER (pyright-python) around the real
+Node-based checker. Installing it is quick, but its FIRST execution locates node — bootstrapping
+one via nodeenv when there is none — and downloads the pinned pyright npm bundle into the
+wrapper's own cache. So a fresh provision costs a second, slower download at first run.
+
+Resolution precedence (see resolve_pyright):
+    1. importable module         `import pyright` works -> run it as-is (today's behaviour)
+    2. PATH binary               a `pyright` executable on $PATH (npm CLI or console script)
+    3. cached --target install   a previous bootstrap under the cache, put on PYTHONPATH
+    4. install                   else `pip install --target <cache>` pyright, then as (3)
+
+`--no-install` (threaded through as no_install=True) forbids step 4 and raises instead. The
+install is always `--target` under the cache, never `--break-system-packages`: the gate must
+not modify the user's Python environment.
+"""
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+
+MANUAL_HINT = "python3 -m pip install --break-system-packages pyright"
+
+
+class PyrightUnavailable(Exception):
+    """Raised when pyright cannot be resolved or bootstrapped. The message is
+    human-readable; callers map it to their own exit code / fallback."""
+
+
+def cache_pkg_dir():
+    """Target dir for the cached `pip install --target` of the pyright wrapper. The env var
+    is read at call time so a caller (or a test) can redirect the cache."""
+    cache = os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache")
+    return os.path.join(cache, "fusion360-gear-generator", "pyright-pkg")
+
+
+def _pythonpath_with(target):
+    """`target` prepended to any existing $PYTHONPATH — never dropping it — or `target` alone."""
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        return target + os.pathsep + existing
+    return target
+
+
+def _cached_install_present(target):
+    return os.path.isfile(os.path.join(target, "pyright", "__init__.py"))
+
+
+def _pip_install(target):
+    """Install the pyright wrapper (and its deps) into `target`. Module-level so tests can
+    stub it. Raises PyrightUnavailable on any failure, leaving no half-install behind."""
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--quiet", "--target", target, "pyright"],
+            check=True, capture_output=True, text=True, timeout=600)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            FileNotFoundError) as e:
+        # A partial target dir would be trusted by the cached-install branch on the next run.
+        shutil.rmtree(target, ignore_errors=True)
+        detail = getattr(e, "stderr", None) or str(e)
+        raise PyrightUnavailable(
+            f"failed to install pyright into {target} (offline? pip missing?): "
+            f"{str(detail).strip()[:300]} — install it yourself with `{MANUAL_HINT}` and retry")
+
+
+def resolve_pyright(no_install=False, quiet=False):
+    """Resolve pyright per the precedence documented at module level.
+
+    Returns `(argv_prefix, extra_env)`: the caller appends its own pyright arguments to
+    `argv_prefix` and merges `extra_env` over os.environ for the subprocess. Raises
+    PyrightUnavailable (with a descriptive message) on any failure, so each caller maps it
+    to its own exit code instead of exiting here."""
+    if importlib.util.find_spec("pyright") is not None:
+        return [sys.executable, "-m", "pyright"], {}
+
+    on_path = shutil.which("pyright")
+    if on_path:
+        return [on_path], {}
+
+    target = cache_pkg_dir()
+    if _cached_install_present(target):
+        return [sys.executable, "-m", "pyright"], {"PYTHONPATH": _pythonpath_with(target)}
+
+    if no_install:
+        raise PyrightUnavailable(
+            f"pyright not found and --no-install given; install it with `{MANUAL_HINT}` "
+            f"or unset --no-install")
+
+    if not quiet:
+        print(f"pyright not found; installing the pyright wrapper into {target}")
+        print("  (first pyright run may also download node / the pyright npm bundle into "
+              "its own cache)")
+    _pip_install(target)
+    return [sys.executable, "-m", "pyright"], {"PYTHONPATH": _pythonpath_with(target)}

--- a/.claude/skills/generate-gear/pyright_check.py
+++ b/.claude/skills/generate-gear/pyright_check.py
@@ -25,7 +25,17 @@ star-export becomes a phantom "undefined". So a candidate living elsewhere (the 
 `.tmp/<gear>.generated.py`) is copied to a throwaway module inside the package for the run.
 
 Usage:
-    python3 pyright_check.py <candidate.py> [--stubs <dir>] [--review]
+    python3 pyright_check.py <candidate.py> [--stubs <dir>] [--review] [--no-install]
+
+Pyright resolution order:
+    1. importable module        `import pyright` works -> run `python -m pyright` as-is
+    2. PATH binary              a `pyright` executable on $PATH
+    3. cached install           a previous `pip install --target` under
+                                ~/.cache/fusion360-gear-generator/, put on PYTHONPATH
+    4. auto-install             else pip-install the pyright wrapper into that cache
+`--no-install` forbids step 4 (no network, no provisioning) and exits 2 instead. Nothing outside
+the cache dir is ever written — the user's Python environment is left alone. The wrapper's first
+run may additionally download node / the pyright npm bundle into its own cache.
 
 Stubs dir resolution order:
     1. --stubs <dir>            (authoritative; a wrong path fails, no fallback)
@@ -39,7 +49,8 @@ auto-clone fetches ONLY `Fusion_API_Python_Reference/defs` via a blobless sparse
 Exit codes:
     0  no blocking findings (REVIEW items, if any, are printed for a human/agent glance)
     1  blocking findings (undefined name, wrong adsk module, or syntax error)
-    2  setup error (stubs unresolvable/clone failed, pyright missing, candidate missing)
+    2  setup error (stubs unresolvable/clone failed, pyright unresolvable/bootstrap failed,
+       candidate missing)
 """
 import json
 import os
@@ -50,6 +61,7 @@ import sys
 # Stub resolution/clone lives in a sibling module (sys.path[0] is this file's dir when run as a
 # script). One clone, one resolution policy.
 from fusion_stubs import resolve_defs, StubsUnavailable
+from pyright_boot import resolve_pyright, PyrightUnavailable
 
 
 def repo_root():
@@ -98,6 +110,9 @@ def main():
     show_review = "--review" in args
     if show_review:
         args.remove("--review")
+    no_install = "--no-install" in args
+    if no_install:
+        args.remove("--no-install")
     if len(args) != 1:
         print(__doc__)
         sys.exit(2)
@@ -121,6 +136,14 @@ def main():
         print("  Stub-free fallback: pyflakes for undefined names, and the fusion plugin's "
               "compiled database")
         print("  ('query_fusion_api.py show <Name>', see fusion_api.py) for the adsk submodule.")
+        sys.exit(2)
+
+    # Resolve pyright itself (shared policy): use it wherever it already is, otherwise
+    # bootstrap a copy into the cache — never into the user's Python environment.
+    try:
+        pyright_argv, extra_env = resolve_pyright(no_install=no_install)
+    except PyrightUnavailable as e:
+        print(f"ERROR: {e}")
         sys.exit(2)
 
     tmp = os.path.join(root, ".tmp")
@@ -150,11 +173,12 @@ def main():
         with open(config_path, "w") as fh:
             json.dump(config, fh)
         proc = subprocess.run(
-            [sys.executable, "-m", "pyright", "-p", config_path, "--outputjson"],
-            cwd=root, capture_output=True, text=True)
+            pyright_argv + ["-p", config_path, "--outputjson"],
+            cwd=root, capture_output=True, text=True, env={**os.environ, **extra_env})
         if proc.returncode not in (0, 1) or not proc.stdout.strip():
-            print("ERROR: pyright did not run. Install it with "
-                  "`python3 -m pip install --break-system-packages pyright`.")
+            print("ERROR: pyright did not run (it was resolved but failed to execute).")
+            print("  If this is the wrapper's first run it may have failed downloading node or the")
+            print("  pyright npm bundle; re-run, or install pyright yourself and retry.")
             print(proc.stderr.strip()[:500])
             sys.exit(2)
         data = json.loads(proc.stdout)

--- a/.claude/skills/generate-gear/test_pyright_boot.py
+++ b/.claude/skills/generate-gear/test_pyright_boot.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Regression tests for the pyright resolution/bootstrap module.
+
+No test here touches the network or runs a real pip: `_pip_install` (or the `subprocess.run`
+inside it) is always stubbed.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+BOOT = Path(__file__).with_name('pyright_boot.py')
+SPEC = importlib.util.spec_from_file_location('pyright_boot', BOOT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def make_marker(target):
+    """Create the file the cached-install branch looks for."""
+    pkg = Path(target) / 'pyright'
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / '__init__.py').write_text('')
+
+
+class CachePkgDirTests(unittest.TestCase):
+    def test_honours_xdg_cache_home(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.dict(os.environ, {'XDG_CACHE_HOME': directory}):
+                self.assertEqual(
+                    MODULE.cache_pkg_dir(),
+                    os.path.join(directory, 'fusion360-gear-generator', 'pyright-pkg'))
+
+    def test_falls_back_to_home_cache(self):
+        env = dict(os.environ)
+        env.pop('XDG_CACHE_HOME', None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                MODULE.cache_pkg_dir(),
+                os.path.join(os.path.expanduser('~'), '.cache',
+                             'fusion360-gear-generator', 'pyright-pkg'))
+
+
+class PythonPathTests(unittest.TestCase):
+    def test_prepends_to_existing_pythonpath(self):
+        with mock.patch.dict(os.environ, {'PYTHONPATH': '/already/here'}):
+            self.assertEqual(MODULE._pythonpath_with('/new'),
+                             '/new' + os.pathsep + '/already/here')
+
+    def test_returns_bare_target_when_unset(self):
+        env = dict(os.environ)
+        env.pop('PYTHONPATH', None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(MODULE._pythonpath_with('/new'), '/new')
+
+
+class ResolutionOrderTests(unittest.TestCase):
+    def setUp(self):
+        patch = mock.patch.object(MODULE, '_pip_install')
+        self.pip = patch.start()
+        self.addCleanup(patch.stop)
+
+    def test_importable_module_wins(self):
+        with mock.patch.object(MODULE.importlib.util, 'find_spec', return_value=object()):
+            argv, extra = MODULE.resolve_pyright()
+        self.assertEqual(argv, [sys.executable, '-m', 'pyright'])
+        self.assertEqual(extra, {})
+        self.pip.assert_not_called()
+
+    def test_path_binary_used_when_module_absent(self):
+        with mock.patch.object(MODULE.importlib.util, 'find_spec', return_value=None):
+            with mock.patch.object(MODULE.shutil, 'which', return_value='/usr/bin/pyright'):
+                argv, extra = MODULE.resolve_pyright()
+        self.assertEqual(argv, ['/usr/bin/pyright'])
+        self.assertEqual(extra, {})
+        self.pip.assert_not_called()
+
+    def test_cached_target_install_used_before_installing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.dict(os.environ, {'XDG_CACHE_HOME': directory}):
+                target = MODULE.cache_pkg_dir()
+                make_marker(target)
+                with mock.patch.object(MODULE.importlib.util, 'find_spec', return_value=None):
+                    with mock.patch.object(MODULE.shutil, 'which', return_value=None):
+                        argv, extra = MODULE.resolve_pyright()
+                self.assertEqual(argv, [sys.executable, '-m', 'pyright'])
+                self.assertTrue(extra['PYTHONPATH'].startswith(target))
+        self.pip.assert_not_called()
+
+    def test_no_install_refuses_to_provision(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.dict(os.environ, {'XDG_CACHE_HOME': directory}):
+                with mock.patch.object(MODULE.importlib.util, 'find_spec', return_value=None):
+                    with mock.patch.object(MODULE.shutil, 'which', return_value=None):
+                        with self.assertRaises(MODULE.PyrightUnavailable) as caught:
+                            MODULE.resolve_pyright(no_install=True)
+        self.assertIn('--no-install', str(caught.exception))
+        self.assertIn('pip install', str(caught.exception))
+        self.pip.assert_not_called()
+
+    def test_missing_pyright_is_installed_into_the_cache(self):
+        self.pip.side_effect = make_marker
+        with tempfile.TemporaryDirectory() as directory:
+            with mock.patch.dict(os.environ, {'XDG_CACHE_HOME': directory}):
+                target = MODULE.cache_pkg_dir()
+                with mock.patch.object(MODULE.importlib.util, 'find_spec', return_value=None):
+                    with mock.patch.object(MODULE.shutil, 'which', return_value=None):
+                        argv, extra = MODULE.resolve_pyright(quiet=True)
+                self.pip.assert_called_once_with(target)
+                self.assertEqual(argv, [sys.executable, '-m', 'pyright'])
+                self.assertTrue(extra['PYTHONPATH'].startswith(target))
+                self.assertTrue(os.path.isfile(os.path.join(target, 'pyright', '__init__.py')))
+
+
+class InstallFailureTests(unittest.TestCase):
+    def test_failed_install_is_cleaned_up_and_reported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = os.path.join(directory, 'pyright-pkg')
+            os.makedirs(target)
+            error = subprocess.CalledProcessError(1, 'pip', stderr='boom')
+            with mock.patch.object(MODULE.subprocess, 'run', side_effect=error):
+                with self.assertRaises(MODULE.PyrightUnavailable) as caught:
+                    MODULE._pip_install(target)
+            self.assertFalse(os.path.exists(target))
+        self.assertIn('boom', str(caught.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- The gate auto-clones the Fusion stubs already; pyright still needed a human to run pip.
- Provisions it the same way, into `~/.cache/fusion360-gear-generator/` and nowhere else.
- `--no-install` keeps the gate offline, exiting 2 with the manual command instead.
