### PR TITLE
blame unresolved API calls on prose or draft

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -122,7 +122,9 @@ proof is where the next reader is looking for the missing check.
 
 The two bold API rows are the same check with different blame. When the spec itself writes
 `setByOffset(plane, 0)` and the signature wants a `ValueInput`, the drafter is right to reproduce
-it and the spec is what needs fixing.
+it and the spec is what needs fixing. For the "does not exist" half, `check_compile.py` prints the
+blame itself as a `fault: prose`/`fault: draft` line under each unresolved call, naming the spec
+file and line when one names the call, so the row needs no manual spec search.
 
 A prose fault ends the run with a report. Never edit `instructions.md` or `fusion.md` from inside
 this skill: a compiler that rewrites its own source removes the thing being checked.

--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -20,7 +20,12 @@ Four checks gate, and one is reported:
      an unchecked one. A call to a run method the harness does not declare is reported wherever it
      is written, registration or not, because Go calls that `undefined` wherever it sits.
   3. API CALLS ARE REAL. Every Fusion call the step list names exists in the API database the
-     `fusion` plugin ships. Catches a spec that names a method Fusion does not have.
+     `fusion` plugin ships. Catches a spec that names a method Fusion does not have. Each
+     unresolved call carries a second `fault:` line saying whether a prose source names it: a
+     word-boundary search of the provenance input set decides `fault: prose` (a spec file or the
+     playbook wrote the name, so the fix belongs there) from `fault: draft` (only the step list
+     under test wrote it, so the failure goes back to the drafter). That is the compile-gear
+     fault table's own discriminator, so the reader no longer has to grep the spec by hand.
   4. INPUTS HAVE NOT DRIFTED. The provenance table contains and matches the existing instructions,
      optional fusion sidecar, playbook, and auxiliary documents referenced by the specs,
      so an edited source cannot leave a stale step list looking healthy.
@@ -274,6 +279,39 @@ def api_owner_matches_receiver(hits, receiver):
     return any(
         qualified.rsplit('.', 2)[-2].lower() == receiver_name
         for qualified, _ in hits)
+
+
+def spec_namings(names, gear):
+    """Map each bare call name to the spec sources that name it, as 'path:line' strings.
+
+    The sources are the provenance input set: the gear's instructions, its fusion sidecar,
+    the playbook, and the auxiliary documents those reference. The step list under test is
+    not a source. A name counts wherever it appears as a whole word, call syntax or not,
+    because the fault table's bar is only that the prose named it.
+    """
+    names = sorted(set(names))
+    if not names:
+        return {}
+    patterns = [(name, re.compile(r'(?<!\w)%s(?!\w)' % re.escape(name))) for name in names]
+    found = {name: [] for name in names}
+    # One read per file, however many names are failing, and one hit per file: the annotation
+    # points the reader at a source to fix, not at every mention inside it.
+    for path in sorted(provenance_inputs(gear)):
+        lines = read(path).splitlines()
+        for name, pattern in patterns:
+            for number, line in enumerate(lines, 1):
+                if pattern.search(line):
+                    found[name].append('%s:%d' % (path, number))
+                    break
+    return found
+
+
+def fault_note(namings):
+    """The second line under an unresolved call, blaming the prose or the draft."""
+    if namings:
+        return ("\n    fault: prose — named in %s — fix the spec, not the draft"
+                % ', '.join(namings))
+    return "\n    fault: draft — no spec source names it — send the failure back to the drafter"
 
 
 def proof_paths(src):
@@ -1432,25 +1470,28 @@ def main(argv):
     except fusion_api.Unavailable as exc:
         print('check_compile: %s' % exc, file=sys.stderr)
         return 2
+    namings = spec_namings(candidates, gear) if candidates else {}
     for call in candidates:
         wrong_receivers = wrong_watchlist_receivers.get(call, ())
         if (hits[call]
                 and all(api_owner_matches_receiver(hits[call], receiver)
                         for receiver in wrong_receivers)):
             continue
+        note = fault_note(namings.get(call, []))
         if hits[call] and wrong_receivers:
             owners = sorted({qualified.rsplit('.', 2)[-2] for qualified, _ in hits[call]})
             for receiver in sorted(wrong_receivers, key=lambda value: value or ''):
                 if not api_owner_matches_receiver(hits[call], receiver):
                     problems.append(
                         "  the step list names '%s(' on receiver '%s', but the Fusion API "
-                        "database declares it on %s"
-                        % (call, receiver, ', '.join(owners)))
+                        "database declares it on %s%s"
+                        % (call, receiver, ', '.join(owners), note))
             continue
         near = fusion_api.similar(call)
-        problems.append("  the step list names '%s(', which the Fusion API database does not have%s"
+        problems.append("  the step list names '%s(', which the Fusion API database does not "
+                        "have%s%s"
                         % (call, '' if not near else
-                           '; the nearest names it does have are %s' % ', '.join(near)))
+                           '; the nearest names it does have are %s' % ', '.join(near), note))
 
     # 4. inputs have not drifted
     stamped = dict(STAMPED_ROW.findall(src))

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -314,20 +314,23 @@ class CheckCompileTest(unittest.TestCase):
     def run_checker(self, provenance=None, from_line='**From:** `spec/gear/instructions.md` L1',
                     proof_body=None, proof_filename='proof_test.go', step_body=None,
                     include_fusion=True, auxiliary=False, mutate_auxiliary=False,
-                    api_lookup=None, unverified_findings=None, proof_directories=()):
+                    api_lookup=None, unverified_findings=None, proof_directories=(),
+                    instruction_text=None, fusion_text=None, api_similar=None):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / 'spec' / 'gear').mkdir(parents=True)
             (root / 'proof' / 'gear').mkdir(parents=True)
             (root / '.claude' / 'skills' / 'generate-gear').mkdir(parents=True)
-            instruction_text = 'source\nline two\nline three\n'
+            if instruction_text is None:
+                instruction_text = 'source\nline two\nline three\n'
+                if auxiliary:
+                    instruction_text = 'source\nSee `trace.md` for details.\nline three\n'
             if auxiliary:
-                instruction_text = 'source\nSee `trace.md` for details.\nline three\n'
                 (root / 'spec' / 'gear' / 'trace.md').write_text('trace\n')
             (root / 'spec' / 'gear' / 'instructions.md').write_text(instruction_text)
             if include_fusion:
                 (root / 'spec' / 'gear' / 'fusion.md').write_text(
-                    'source\nline two\nline three\n')
+                    'source\nline two\nline three\n' if fusion_text is None else fusion_text)
             (root / '.claude' / 'skills' / 'generate-gear' / 'PLAYBOOK.md').write_text(
                 'source\nline two\nline three\n')
             if provenance is None:
@@ -374,7 +377,13 @@ class CheckCompileTest(unittest.TestCase):
                 findings_patch = mock.patch.object(
                     COMPILE_CHECKER.fusion_api, 'unverified_findings',
                     return_value=[] if unverified_findings is None else unverified_findings)
-                with lookup_patch, findings_patch, contextlib.redirect_stdout(output):
+                # The nonexistent-call branch asks the database for near names, which shells out
+                # to the plugin. A fixture reaching that branch must not depend on it.
+                similar_patch = mock.patch.object(
+                    COMPILE_CHECKER.fusion_api, 'similar',
+                    return_value=[] if api_similar is None else api_similar)
+                with lookup_patch, findings_patch, similar_patch, \
+                        contextlib.redirect_stdout(output):
                     result = COMPILE_CHECKER.main(['check_compile.py', 'gear'])
             finally:
                 os.chdir(prior)
@@ -1611,6 +1620,95 @@ class CheckCompileTest(unittest.TestCase):
                       output)
         self.assertNotIn('in a shape this gate does not read', output)
 
+    # Who is to blame for a call the API database cannot resolve. The compile-gear fault table
+    # separates the two API rows by one question — did the prose name the call, or only the
+    # draft? — and these hold the gate answering it from the provenance input set rather than
+    # leaving the search to the reader.
+
+    def call_step(self, span):
+        """One `[GO]` step whose body names `span` in a code span, otherwise canonical."""
+        return ('## S1 `[GO]` One — `stepOne`\n\n'
+                'Call `%s`.\n\n'
+                '**From:** `spec/gear/instructions.md` L1\n\n' % span)
+
+    def test_nonexistent_call_named_by_spec_is_a_prose_fault(self):
+        result, output = self.run_checker(
+            instruction_text='source\ncall frobnicate here\nline three\n',
+            step_body=self.call_step('thing.frobnicate(1)'),
+            api_lookup={'frobnicate': []})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn("the step list names 'frobnicate(', which the Fusion API database does not "
+                      "have", output)
+        self.assertIn('fault: prose — named in spec/gear/instructions.md:2', output)
+        self.assertIn('fix the spec', output)
+
+    def test_nonexistent_call_only_in_steps_is_a_draft_fault(self):
+        result, output = self.run_checker(
+            step_body=self.call_step('thing.frobnicate(1)'),
+            api_lookup={'frobnicate': []})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('fault: draft', output)
+        self.assertIn('send the failure back to the drafter', output)
+        self.assertNotIn('fault: prose', output)
+
+    def test_prose_fault_names_every_spec_file_that_hits(self):
+        result, output = self.run_checker(
+            instruction_text='source\ncall frobnicate here\nline three\n',
+            fusion_text='source\nline two\nfrobnicate again\n',
+            step_body=self.call_step('thing.frobnicate(1)'),
+            api_lookup={'frobnicate': []})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('fault: prose — named in spec/gear/fusion.md:3, '
+                      'spec/gear/instructions.md:2', output)
+
+    def test_wrong_receiver_problem_carries_the_same_fault_line(self):
+        """The receiver variant is the same fault-table row, so it gets the same blame line."""
+        watchlist = (('frobnicate', 'adsk.fusion.SketchCurves', ('SketchCurves',),
+                      'a watchlist entry so the receiver mismatch reaches the database'),)
+        with mock.patch.object(COMPILE_CHECKER.fusion_api, 'UNVERIFIED_CALLS', watchlist):
+            result, output = self.run_checker(
+                instruction_text='source\ncall frobnicate here\nline three\n',
+                step_body=self.call_step('sketch.frobnicate(1)'),
+                api_lookup={'frobnicate': [('adsk.fusion.SketchCurves.frobnicate', 'method')]})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn("the step list names 'frobnicate(' on receiver 'sketch', but the Fusion API "
+                      "database declares it on SketchCurves", output)
+        self.assertIn('fault: prose — named in spec/gear/instructions.md:2', output)
+
+    def test_bare_prose_mention_counts_as_a_naming(self):
+        """The bar is that the prose named it, so a mention with no call syntax still counts."""
+        result, output = self.run_checker(
+            instruction_text='source\nfrobnicate\nline three\n',
+            step_body=self.call_step('thing.frobnicate(1)'),
+            api_lookup={'frobnicate': []})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('fault: prose — named in spec/gear/instructions.md:2', output)
+
+    def test_substring_does_not_count_as_a_naming(self):
+        """`frobnicateAll` is a different name, so it does not move the blame to the prose."""
+        result, output = self.run_checker(
+            instruction_text='source\ncall frobnicateAll here\nline three\n',
+            step_body=self.call_step('thing.frobnicate(1)'),
+            api_lookup={'frobnicate': []})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('fault: draft', output)
+        self.assertNotIn('fault: prose', output)
+
+    def test_the_fault_line_does_not_change_the_blocking_count(self):
+        """The blame rides on the problem string, so one unresolved call is still one problem."""
+        result, output = self.run_checker(
+            step_body=self.call_step('thing.frobnicate(1)'),
+            api_lookup={'frobnicate': []})
+
+        self.assertEqual(result, 1, output)
+        self.assertIn('compile check: BLOCKING (1)', output)
+
 
 # The proof-side probe. The gate's answers about where a line may start are only worth anything
 # next to what Go does with the same file, so each case below is a real proof file handed to the
@@ -1937,6 +2035,8 @@ class GoPatternClassTest(unittest.TestCase):
             'from_block, the From block under a step heading',
         r'<!--\s*check-compile:\s*ignore\s+([^>]*?)-->':
             'named_calls and named_call_shapes, an HTML comment waiving a named call',
+        r'(?<!\w)%s(?!\w)':
+            'spec_namings, a call name written as a whole word anywhere in a spec source',
         r'(?<![\w./-])(?:proof|\.tmp)/[\w./-]+':
             'proof_paths, a proof path named in the step-list summary',
         r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|':


### PR DESCRIPTION
- The fault table splits its two API rows on whether the prose named the call; the gate answers that itself now.
- Blame comes from a word-boundary search of the provenance input set, never the step list under test.
- Each unresolved call gains a `fault: prose`/`fault: draft` line; counts and exit codes are unchanged.
