### PR TITLE
check the environment before a stage runs

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -47,7 +47,10 @@ proof is where the next reader is looking for the missing check.
 
 ## Procedure
 
-1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Read this file,
+1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Run
+   `python3 .claude/skills/generate-gear/preflight.py <gear> --stage compile` and fix every
+   `[FAIL]` before drafting; it verifies the engines, the go toolchain and the API database so a
+   broken environment fails here instead of mid-run. Read this file,
    `PLAYBOOK.md`, the gear's spec end to end, and both harness APIs, `proof/proofkit/` and
    `proof/proofkit3d/`.
 

--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -16,7 +16,10 @@ the pipeline exists to make trustworthy.
 
 ## Procedure
 
-1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists.
+1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Run
+   `python3 .claude/skills/generate-gear/preflight.py <gear> --stage emit` and fix every `[FAIL]`
+   before drafting; it verifies the engines, the go toolchain and the API database so a broken
+   environment fails here instead of mid-run.
 
 2. **Check the inputs are current.** Run
    `python3 .claude/skills/generate-gear/check_compile.py <gear>`. Emitting from a stale step list

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -37,7 +37,9 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 ## Procedure
 
 1. **Setup.** Work in a worktree (per the repo's CLAUDE.md — never the root checkout). Ensure
-   `.tmp/` exists. Read this skill, `PLAYBOOK.md`, and the spec end-to-end. Skim the shared
+   `.tmp/` exists. Run `python3 .claude/skills/generate-gear/preflight.py <gear> --stage generate`
+   and fix every `[FAIL]` before drafting; it verifies the engines, the go toolchain and the API
+   database so a broken environment fails here instead of mid-run. Read this skill, `PLAYBOOK.md`, and the spec end-to-end. Skim the shared
    framework the output builds on: `lib/geargen/base.py`, `misc.py`, `utilities.py`, `solids.py`,
    `spurproxy.py`, `lib/fusion360utils/`, and `commands/<gear>/entry.py` (the same file set the
    standard generation prompt hands the subagent). Note the gear's sketch-first proof at

--- a/.claude/skills/generate-gear/preflight.py
+++ b/.claude/skills/generate-gear/preflight.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""One early verdict on whether this environment can run a gear stage.
+
+Each of the three skills opens with a setup step that asks the orchestrating model to verify
+the environment by hand: a worktree rather than the root checkout, `.tmp/`, the sketch and
+decad engine checkouts, a go toolchain, pyright, the Fusion API database. Nothing checked it,
+so a missing piece surfaced later as an exit-2 out of `proof/run.sh`, `pyright_check.py` or
+`check_compile.py`, after a drafting round had already been spent. This script asks every
+question at once, before the round starts.
+
+It reports, it does not repair. The only thing it writes is `.tmp/` under the root, because
+every stage needs that directory and creating it is cheaper than reporting it missing. It
+never clones the stubs, never installs pyright, never runs `go test`, and never touches the
+network. A check that cannot be answered without doing one of those says so and leaves the
+work to the tool that owns it.
+
+Resolution rules are borrowed, never re-derived: the engine directories resolve exactly as
+`proof/run.sh` resolves them ($SKETCH_DIR / $DECAD_DIR, else siblings of the main checkout),
+and the API database and the stubs are resolved by importing the sibling modules that own
+those policies (`fusion_api`, `fusion_stubs`).
+
+Usage:
+    python3 preflight.py <gear> [--stage {compile,emit,generate,all}]
+                                [--root DIR] [--format {text,json}]
+
+Exit codes:
+    0  ready (warnings are allowed; they name work to do, not a broken environment)
+    1  at least one FAIL
+    2  usage/setup error (bad gear name, unknown stage, --root is not the repo root)
+"""
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)  # fusion_api / fusion_stubs are siblings, imported lazily below
+
+GEAR_NAME = re.compile(r'[a-z][a-z0-9_]*\Z')  # same spelling stage.py accepts
+TIMEOUT = 10  # seconds; every subprocess here is a version probe
+
+OK = 'ok'
+WARN = 'warn'
+FAIL = 'fail'
+SKIP = 'skip'
+
+# The files the drafter is told to read before writing a gear. Root-relative.
+FRAMEWORK = (
+    os.path.join('lib', 'geargen', 'base.py'),
+    os.path.join('lib', 'geargen', 'misc.py'),
+    os.path.join('lib', 'geargen', 'utilities.py'),
+    os.path.join('lib', 'geargen', 'spurproxy.py'),
+    os.path.join('lib', 'fusion360utils'),
+)
+
+# What makes a directory the repo root, and so what --root must contain.
+ROOT_MARKERS = (
+    'spec',
+    os.path.join('lib', 'geargen'),
+    os.path.join('.claude', 'skills', 'generate-gear'),
+)
+
+
+class Usage(Exception):
+    """A bad invocation. Printed to stderr; always exit 2."""
+
+
+class Context(object):
+    """What every check is handed: the absolute root and the gear under test."""
+
+    def __init__(self, root, gear):
+        self.root = root
+        self.gear = gear
+
+    def path(self, *parts):
+        return os.path.join(self.root, *parts)
+
+    def spec(self, *parts):
+        return self.path('spec', self.gear, *parts)
+
+
+# --- subprocess helpers --------------------------------------------------------------------
+def _run(argv, cwd=None):
+    """Run a probe. Returns (ok, first line of output or the reason it failed)."""
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=TIMEOUT, cwd=cwd)
+    except FileNotFoundError:
+        return False, '%s is not on PATH' % argv[0]
+    except OSError as exc:
+        return False, '%s could not be run (%s)' % (argv[0], exc)
+    except subprocess.TimeoutExpired:
+        return False, '%s did not answer within %ds' % (argv[0], TIMEOUT)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or '').strip().splitlines()
+        return False, '%s exited %d%s' % (
+            ' '.join(argv), proc.returncode, ' (%s)' % detail[0] if detail else '')
+    out = (proc.stdout or '').strip()
+    return True, out.splitlines()[0] if out else ''
+
+
+def _git_paths(root):
+    """(git-dir, git-common-dir) as absolute paths, or None when git cannot answer."""
+    ok, out = _run(['git', '-C', root, 'rev-parse', '--path-format=absolute',
+                    '--git-dir', '--git-common-dir'])
+    if not ok:
+        return None
+    lines = out.splitlines()
+    if len(lines) != 2:
+        # One line means an older git ignored --path-format; re-ask without it.
+        ok, git_dir = _run(['git', '-C', root, 'rev-parse', '--absolute-git-dir'])
+        if not ok:
+            return None
+        ok, common = _run(['git', '-C', root, 'rev-parse', '--git-common-dir'])
+        if not ok:
+            return None
+        if not os.path.isabs(common):
+            common = os.path.join(root, common)
+        return os.path.abspath(git_dir), os.path.abspath(common)
+    return os.path.abspath(lines[0]), os.path.abspath(lines[1])
+
+
+def main_checkout(root):
+    """The main working tree, which is what `proof/run.sh` hangs the engine siblings off."""
+    paths = _git_paths(root)
+    if paths is None:
+        return None
+    return os.path.abspath(os.path.dirname(paths[1]))
+
+
+def _engine(ctx, name, env_var, sibling):
+    """Resolve one engine the way proof/run.sh does, and say whether it holds a module."""
+    override = os.environ.get(env_var)
+    if override:
+        resolved, source = os.path.abspath(override), '$%s' % env_var
+    else:
+        main = main_checkout(ctx.root)
+        if main is None:
+            return FAIL, ('cannot locate the main checkout (git failed), so %s falls back to '
+                          'nothing; set $%s to the %s checkout' % (name, env_var, name))
+        resolved = os.path.abspath(os.path.join(main, os.pardir, sibling))
+        source = 'sibling of %s' % main
+    if os.path.isfile(os.path.join(resolved, 'go.mod')):
+        return OK, '%s engine at %s (%s)' % (name, resolved, source)
+    return FAIL, ('no go.mod at %s (%s), which is where proof/run.sh looks for the %s engine; '
+                  'set $%s to a checkout' % (resolved, source, name, env_var))
+
+
+def _missing(ctx, paths):
+    return [p for p in paths if not os.path.exists(ctx.path(p))]
+
+
+# --- checks --------------------------------------------------------------------------------
+# Every check takes the context and returns (status, one-clause reason).
+def check_repo_root(ctx):
+    return OK, 'repository root at %s' % ctx.root
+
+
+def check_git(ctx):
+    ok, detail = _run(['git', '--version'])
+    if ok:
+        return OK, detail
+    return FAIL, ('%s; provenance hashing and the tracked-file gates need git' % detail)
+
+
+def check_tmp_dir(ctx):
+    tmp = ctx.path('.tmp')
+    if os.path.isdir(tmp):
+        return OK, '.tmp/ exists'
+    if os.path.exists(tmp):
+        return FAIL, '%s exists but is not a directory' % tmp
+    try:
+        os.makedirs(tmp)
+    except OSError as exc:
+        return FAIL, 'could not create %s (%s)' % (tmp, exc)
+    return OK, '.tmp/ (created)'
+
+
+def check_worktree(ctx):
+    paths = _git_paths(ctx.root)
+    if paths is None:
+        return WARN, 'git cannot say whether %s is a worktree' % ctx.root
+    git_dir, common = paths
+    if git_dir != common:
+        return OK, 'linked worktree (git dir %s)' % git_dir
+    return WARN, ('running in the root checkout; editing stages must run in a worktree '
+                  '(`$PROJECT/.worktrees/<branch>`), while read-only work may stay here')
+
+
+def check_spec(ctx):
+    path = ctx.spec('instructions.md')
+    if os.path.isfile(path):
+        return OK, 'spec at spec/%s/instructions.md' % ctx.gear
+    return FAIL, 'no spec at %s' % path
+
+
+def check_go(ctx):
+    ok, detail = _run(['go', 'version'])
+    if ok:
+        return OK, detail
+    return FAIL, '%s; the proof cannot be run without a go toolchain' % detail
+
+
+def check_sketch_engine(ctx):
+    return _engine(ctx, 'sketch', 'SKETCH_DIR', 'sketch')
+
+
+def check_decad_engine(ctx):
+    return _engine(ctx, 'decad', 'DECAD_DIR', 'decad')
+
+
+def check_proof_harness(ctx):
+    wanted = (os.path.join('proof', 'run.sh'), os.path.join('proof', 'proofkit'),
+              os.path.join('proof', 'proofkit3d'), os.path.join('proof', 'involute'))
+    missing = _missing(ctx, wanted)
+    if missing:
+        return FAIL, 'the proof harness is incomplete: %s missing' % ', '.join(missing)
+    return OK, 'proof harness present (run.sh, proofkit, proofkit3d, involute)'
+
+
+def check_revision_pin(ctx):
+    if os.environ.get('PROOF_VERIFY_REVISIONS') != '1':
+        return OK, 'PROOF_VERIFY_REVISIONS is unset, so proof/run.sh pins no revision'
+    unset = [v for v in ('SKETCH_COMMIT', 'DECAD_COMMIT') if not os.environ.get(v)]
+    if unset:
+        return FAIL, ('PROOF_VERIFY_REVISIONS=1 requires %s, which proof/run.sh reads with a `:?` '
+                      'guard' % ' and '.join('$' + v for v in unset))
+    return OK, 'revisions pinned to $SKETCH_COMMIT and $DECAD_COMMIT'
+
+
+def check_api_db(ctx):
+    try:
+        import fusion_api
+    except ImportError as exc:
+        return FAIL, 'the sibling module fusion_api could not be imported (%s)' % exc
+    # The module memoises the resolved script; preflight must report the environment as it is
+    # now rather than as an earlier import in this process saw it.
+    fusion_api._script = None
+    try:
+        return OK, 'API database query script at %s' % fusion_api.query_script()
+    except fusion_api.Unavailable as exc:
+        return FAIL, str(exc)
+
+
+def check_steps(ctx):
+    path = ctx.spec('steps.md')
+    if os.path.isfile(path):
+        return OK, 'step list at spec/%s/steps.md' % ctx.gear
+    return FAIL, 'no step list at %s; run /compile-gear %s first' % (path, ctx.gear)
+
+
+def check_proof_dir(ctx):
+    path = ctx.path('proof', ctx.gear)
+    if not os.path.isdir(path):
+        return FAIL, 'no proof at %s; run /compile-gear %s first' % (path, ctx.gear)
+    sources = [n for n in sorted(os.listdir(path)) if n.endswith('.go')]
+    if not sources:
+        return FAIL, '%s holds no .go file, so there is no proof to read' % path
+    return OK, 'proof/%s/ holds %d .go file(s)' % (ctx.gear, len(sources))
+
+
+def check_contract_manifest(ctx):
+    path = ctx.spec('contract.json')
+    if os.path.isfile(path):
+        return OK, 'contract manifest at spec/%s/contract.json' % ctx.gear
+    return SKIP, 'no spec/%s/contract.json, so the contract gate will be prose-checked' % ctx.gear
+
+
+def check_framework(ctx):
+    missing = _missing(ctx, FRAMEWORK)
+    if missing:
+        return FAIL, 'the drafter must read these, and they are missing: %s' % ', '.join(missing)
+    return OK, 'framework sources present (%s)' % ', '.join(os.path.basename(p.rstrip(os.sep))
+                                                            for p in FRAMEWORK)
+
+
+def check_pyright(ctx):
+    if importlib.util.find_spec('pyright') is not None:
+        return OK, 'pyright is importable'
+    return WARN, ('pyright is not installed; install it with '
+                  '`python3 -m pip install --break-system-packages pyright`')
+
+
+def check_stubs(ctx):
+    try:
+        import fusion_stubs
+    except ImportError as exc:
+        return FAIL, 'the sibling module fusion_stubs could not be imported (%s)' % exc
+    env = os.environ.get('FUSION_API_STUBS')
+    if env:
+        # $FUSION_API_STUBS is authoritative for pyright_check.py: a wrong path there is an
+        # exit 2, never a fallback, so it is a failure here too.
+        defs = fusion_stubs.defs_at(env)
+        if defs:
+            return OK, 'Fusion API stubs at %s ($FUSION_API_STUBS)' % defs
+        return FAIL, ('$FUSION_API_STUBS=%s has no adsk/core.py, and pyright_check.py will exit 2 '
+                      'on it rather than fall back' % env)
+    cached = fusion_stubs.defs_at(fusion_stubs.cache_repo_dir())
+    if cached:
+        return OK, 'Fusion API stubs cached at %s' % cached
+    return WARN, ('Fusion API stubs are not cached; pyright_check.py will auto-clone them '
+                  '(~13M) on its first run')
+
+
+def check_sketch_bench(ctx):
+    path = ctx.spec('sketch', 'run.sh')
+    if os.path.isfile(path):
+        return OK, 'sketch bench at spec/%s/sketch/run.sh' % ctx.gear
+    return WARN, ('no sketch bench at %s; the skill builds one from the spec\'s recipes, so this '
+                  'is work rather than a broken environment' % path)
+
+
+def has_sketch_bench(ctx):
+    return os.path.isfile(ctx.spec('sketch', 'run.sh'))
+
+
+# --- the stage matrix ----------------------------------------------------------------------
+# (key, check, downgrade) per stage. `downgrade` says whether a FAIL from the check is only a
+# warning for this stage; it is a bool, or a predicate on the context for the cases where the
+# stage's own state decides (the generate stage needs an engine only once a bench exists).
+# Checks that grade themselves (stubs) are never downgraded.
+COMMON = (
+    ('repo-root', check_repo_root, False),
+    ('git', check_git, False),
+    ('tmp-dir', check_tmp_dir, False),
+    ('worktree', check_worktree, False),
+)
+
+STAGES = {
+    'compile': COMMON + (
+        ('spec', check_spec, False),
+        ('go', check_go, False),
+        ('sketch-engine', check_sketch_engine, False),
+        ('decad-engine', check_decad_engine, False),
+        ('proof-harness', check_proof_harness, False),
+        ('revision-pin', check_revision_pin, False),
+        ('api-db', check_api_db, False),
+    ),
+    'emit': COMMON + (
+        ('steps', check_steps, False),
+        ('proof-dir', check_proof_dir, False),
+        ('api-db', check_api_db, False),
+        ('contract-manifest', check_contract_manifest, False),
+        ('framework', check_framework, False),
+        ('pyright', check_pyright, False),
+        ('stubs', check_stubs, False),
+    ),
+    'generate': COMMON + (
+        ('spec', check_spec, False),
+        ('sketch-bench', check_sketch_bench, False),
+        ('sketch-engine', check_sketch_engine, lambda ctx: not has_sketch_bench(ctx)),
+        ('go', check_go, lambda ctx: not has_sketch_bench(ctx)),
+        ('framework', check_framework, False),
+        ('pyright', check_pyright, False),
+        ('stubs', check_stubs, False),
+        # The database is the documented fallback for this stage's API questions, not an input
+        # to a gate, so its absence costs accuracy rather than the run.
+        ('api-db', check_api_db, True),
+    ),
+}
+
+STAGE_ORDER = ('compile', 'emit', 'generate')
+
+
+def plan(stage):
+    """The checks to run, in order. `all` is the union, each key once, graded as strictly as
+    any stage that asks for it."""
+    if stage != 'all':
+        return list(STAGES[stage])
+    merged = []
+    index = {}
+    for name in STAGE_ORDER:
+        for key, check, downgrade in STAGES[name]:
+            if key in index:
+                # A key any stage grades strictly is graded strictly for the union.
+                position = index[key]
+                if merged[position][2] is not False and downgrade is False:
+                    merged[position] = (key, check, False)
+                continue
+            index[key] = len(merged)
+            merged.append((key, check, downgrade))
+    return merged
+
+
+def run_checks(ctx, stage):
+    """Every check for the stage, as [{'key', 'status', 'detail'}]."""
+    results = []
+    for key, check, downgrade in plan(stage):
+        status, detail = check(ctx)
+        if status == FAIL and (downgrade(ctx) if callable(downgrade) else downgrade):
+            status = WARN
+        results.append({'key': key, 'status': status, 'detail': detail})
+    return results
+
+
+# --- reporting -----------------------------------------------------------------------------
+MARK = {OK: '[ok]', WARN: '[warn]', FAIL: '[FAIL]', SKIP: '[skip]'}
+
+
+def failures(results):
+    return [r for r in results if r['status'] == FAIL]
+
+
+def render_text(gear, stage, results):
+    lines = ['%-6s %s: %s' % (MARK[r['status']], r['key'], r['detail']) for r in results]
+    broken = failures(results)
+    if broken:
+        lines.append('preflight %s (%s): NOT READY (%d failure%s)'
+                     % (gear, stage, len(broken), '' if len(broken) == 1 else 's'))
+    else:
+        lines.append('preflight %s (%s): READY' % (gear, stage))
+    return '\n'.join(lines)
+
+
+def render_json(gear, stage, results):
+    return json.dumps({'gear': gear, 'stage': stage, 'ready': not failures(results),
+                       'checks': results})
+
+
+# --- entry point ---------------------------------------------------------------------------
+def repo_root():
+    """Three levels above this file, the same rule run_gates.repo_root() uses."""
+    return os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, os.pardir))
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='preflight.py',
+        description='Check that this environment can run a gear stage, before the round starts.')
+    parser.add_argument('gear')
+    parser.add_argument('--stage', choices=['compile', 'emit', 'generate', 'all'], default='all')
+    parser.add_argument('--root', default=None)
+    parser.add_argument('--format', choices=['text', 'json'], default='text')
+    return parser.parse_args(argv)
+
+
+def resolve_root(root_arg):
+    root = os.path.abspath(root_arg) if root_arg else repo_root()
+    missing = [m for m in ROOT_MARKERS if not os.path.isdir(os.path.join(root, m))]
+    if missing:
+        raise Usage('%s is not the repository root: %s missing' % (root, ', '.join(missing)))
+    return root
+
+
+def main(argv):
+    args = parse_args(argv)
+    if not GEAR_NAME.match(args.gear):
+        raise Usage("'%s' is not a gear name; expected %s" % (args.gear, GEAR_NAME.pattern))
+    ctx = Context(resolve_root(args.root), args.gear)
+    results = run_checks(ctx, args.stage)
+    render = render_json if args.format == 'json' else render_text
+    print(render(args.gear, args.stage, results))
+    return 1 if failures(results) else 0
+
+
+def cli(argv):
+    """main() plus the usage-error mapping, so the exit contract is testable as one call."""
+    try:
+        return main(argv)
+    except Usage as error:
+        sys.stderr.write('preflight.py: %s\n' % error)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(cli(sys.argv[1:]))

--- a/.claude/skills/generate-gear/test_preflight.py
+++ b/.claude/skills/generate-gear/test_preflight.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Regression tests for the per-stage environment check.
+
+Two properties matter more than the individual verdicts. The first is that a warning never
+costs a run: pyright, the stub cache and the root checkout are all things a stage can proceed
+without, and grading any of them a failure would stop a round that would have succeeded. The
+second is that the check writes nothing but `.tmp/` — it stands in front of tools that clone
+and install, and a preflight that quietly did their work would hide the cost it exists to
+report.
+
+Everything runs against a fixture repository in a tempdir, so no test depends on the machine
+having the engines, the stubs or the plugin database.
+"""
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+CHECKER = Path(__file__).with_name('preflight.py')
+SPEC = importlib.util.spec_from_file_location('preflight', CHECKER)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+GEAR = 'testgear'
+
+
+def git(root, *args):
+    subprocess.run(['git', '-C', str(root)] + list(args),
+                   check=True, capture_output=True, text=True)
+
+
+def make_repo(root, gear=GEAR):
+    """A repository shaped enough for every check to reach a verdict on it."""
+    for rel in ('spec/%s' % gear, 'lib/geargen', 'lib/fusion360utils',
+                '.claude/skills/generate-gear', 'proof/%s' % gear, 'proof/proofkit',
+                'proof/proofkit3d', 'proof/involute'):
+        (root / rel).mkdir(parents=True, exist_ok=True)
+    (root / 'spec' / gear / 'instructions.md').write_text('# spec\n')
+    for name in ('base.py', 'misc.py', 'utilities.py', 'spurproxy.py'):
+        (root / 'lib' / 'geargen' / name).write_text('')
+    (root / 'lib' / 'fusion360utils' / '__init__.py').write_text('')
+    (root / 'proof' / 'run.sh').write_text('#!/usr/bin/env bash\n')
+    git(root, 'init', '-q')
+    (root / 'README.md').write_text('fixture\n')
+    git(root, 'add', '-A')
+    git(root, '-c', 'user.name=t', '-c', 'user.email=t@example.com',
+        'commit', '-q', '-m', 'fixture')
+    return root
+
+
+def stub_defs(root):
+    """A directory that satisfies fusion_stubs.defs_at()."""
+    defs = root / 'defs'
+    (defs / 'adsk').mkdir(parents=True)
+    (defs / 'adsk' / 'core.py').write_text('')
+    return defs
+
+
+class Fixture(unittest.TestCase):
+    """A fixture repo plus a context pointed at it."""
+
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        # The repo sits one level down so that its parent — where the engine siblings would
+        # live — belongs to the test and not to the machine's temp directory.
+        self.root = make_repo(Path(directory.name) / 'repo')
+        self.ctx = MODULE.Context(str(self.root), GEAR)
+
+    def run_cli(self, *argv):
+        """(exit code, stdout) for one invocation, with stderr swallowed."""
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = MODULE.cli(list(argv))
+        return code, out.getvalue()
+
+    def resolved(self, gear=GEAR):
+        """An environment in which the two machine-wide dependencies are satisfied."""
+        query = self.root / 'query_fusion_api.py'
+        query.write_text('')
+        return {'FUSION_QUERY_API': str(query),
+                'FUSION_API_STUBS': str(stub_defs(self.root))}
+
+
+class UsageTests(Fixture):
+    """Exit 2 is for an invocation the script refuses, never for a failed check."""
+
+    def test_bad_gear_name_is_a_usage_error(self):
+        code, _ = self.run_cli('Spur Gear', '--root', str(self.root))
+
+        self.assertEqual(code, 2)
+
+    def test_unknown_stage_is_a_usage_error(self):
+        with self.assertRaises(SystemExit) as raised:
+            with redirect_stderr(io.StringIO()):
+                MODULE.cli([GEAR, '--stage', 'polish', '--root', str(self.root)])
+
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_root_without_the_repository_layout_is_a_usage_error(self):
+        with tempfile.TemporaryDirectory() as elsewhere:
+            code, _ = self.run_cli(GEAR, '--root', elsewhere)
+
+        self.assertEqual(code, 2)
+
+    def test_root_naming_the_repository_is_accepted(self):
+        self.assertEqual(MODULE.resolve_root(str(self.root)), str(self.root))
+
+
+class EmitStageTests(Fixture):
+    """The emit stage stands or falls on the compiled artifacts."""
+
+    def test_missing_step_list_fails_the_stage(self):
+        with mock.patch.dict(os.environ, self.resolved()):
+            code, out = self.run_cli(GEAR, '--stage', 'emit', '--root', str(self.root))
+
+        self.assertEqual(code, 1)
+        self.assertIn('[FAIL] steps:', out)
+        self.assertIn('NOT READY', out)
+
+    def test_step_list_and_proof_make_the_stage_ready(self):
+        (self.root / 'spec' / GEAR / 'steps.md').write_text('# steps\n')
+        (self.root / 'proof' / GEAR / 'x.go').write_text('package proof\n')
+
+        with mock.patch.dict(os.environ, self.resolved()):
+            code, out = self.run_cli(GEAR, '--stage', 'emit', '--root', str(self.root))
+
+        self.assertEqual(code, 0, out)
+        self.assertIn('READY', out)
+
+    def test_empty_proof_directory_fails(self):
+        (self.root / 'spec' / GEAR / 'steps.md').write_text('# steps\n')
+
+        status, detail = MODULE.check_proof_dir(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('no .go file', detail)
+
+    def test_absent_contract_manifest_is_skipped_not_failed(self):
+        status, detail = MODULE.check_contract_manifest(self.ctx)
+
+        self.assertEqual(status, MODULE.SKIP)
+        self.assertIn('prose-checked', detail)
+
+
+class TmpDirTests(Fixture):
+    """The one thing the check is allowed to write."""
+
+    def test_missing_tmp_dir_is_created_and_reported(self):
+        status, detail = MODULE.check_tmp_dir(self.ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertIn('created', detail)
+        self.assertTrue((self.root / '.tmp').is_dir())
+
+    def test_existing_tmp_dir_is_not_reported_as_created(self):
+        (self.root / '.tmp').mkdir()
+
+        status, detail = MODULE.check_tmp_dir(self.ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertNotIn('created', detail)
+
+
+class WorktreeTests(Fixture):
+    """The root checkout is a warning, because read-only work legitimately runs there."""
+
+    def test_root_checkout_warns(self):
+        status, detail = MODULE.check_worktree(self.ctx)
+
+        self.assertEqual(status, MODULE.WARN)
+        self.assertIn('worktree', detail)
+
+    def test_linked_worktree_does_not_warn(self):
+        linked = self.root / '.worktrees' / 'b'
+        git(self.root, 'worktree', 'add', '-q', str(linked), '-b', 'b')
+
+        status, _ = MODULE.check_worktree(MODULE.Context(str(linked), GEAR))
+
+        self.assertEqual(status, MODULE.OK)
+
+
+class EngineTests(Fixture):
+    """Engine resolution copies proof/run.sh: the override wins, and go.mod decides."""
+
+    def test_override_pointing_at_a_module_resolves(self):
+        engine = self.root / 'sketch'
+        engine.mkdir()
+        (engine / 'go.mod').write_text('module x\n')
+
+        with mock.patch.dict(os.environ, {'SKETCH_DIR': str(engine)}):
+            status, detail = MODULE.check_sketch_engine(self.ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertIn(str(engine), detail)
+
+    def test_override_without_a_go_mod_fails_and_names_the_path(self):
+        empty = self.root / 'not-an-engine'
+        empty.mkdir()
+
+        with mock.patch.dict(os.environ, {'DECAD_DIR': str(empty)}):
+            status, detail = MODULE.check_decad_engine(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn(str(empty), detail)
+        self.assertIn('DECAD_DIR', detail)
+
+    def test_without_an_override_the_main_checkout_sibling_is_used(self):
+        sibling = self.root.parent / 'sketch'
+        sibling.mkdir()
+        (sibling / 'go.mod').write_text('module x\n')
+
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('SKETCH_DIR', None)
+            status, detail = MODULE.check_sketch_engine(self.ctx)
+
+        self.assertEqual(status, MODULE.OK, detail)
+        self.assertIn(str(sibling), detail)
+
+
+class ToolTests(Fixture):
+    """A missing toolchain is read off PATH, never installed."""
+
+    def empty_path(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        return {'PATH': directory.name}
+
+    def test_git_missing_fails(self):
+        with mock.patch.dict(os.environ, self.empty_path()):
+            status, detail = MODULE.check_git(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('PATH', detail)
+
+    def test_go_missing_fails_the_compile_stage(self):
+        with mock.patch.dict(os.environ, self.empty_path()):
+            status, _ = MODULE.check_go(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+
+    def test_go_missing_only_warns_for_generate_without_a_sketch_bench(self):
+        with mock.patch.dict(os.environ, self.empty_path()):
+            results = MODULE.run_checks(self.ctx, 'generate')
+
+        by_key = {r['key']: r for r in results}
+        self.assertEqual(by_key['go']['status'], MODULE.WARN)
+        self.assertEqual(by_key['sketch-bench']['status'], MODULE.WARN)
+
+    def test_go_missing_fails_generate_once_a_sketch_bench_exists(self):
+        bench = self.root / 'spec' / GEAR / 'sketch'
+        bench.mkdir()
+        (bench / 'run.sh').write_text('#!/usr/bin/env bash\n')
+
+        with mock.patch.dict(os.environ, self.empty_path()):
+            results = MODULE.run_checks(self.ctx, 'generate')
+
+        by_key = {r['key']: r for r in results}
+        self.assertEqual(by_key['go']['status'], MODULE.FAIL)
+        self.assertEqual(by_key['sketch-bench']['status'], MODULE.OK)
+
+    def test_pyright_absence_is_a_warning(self):
+        with mock.patch.object(MODULE.importlib.util, 'find_spec', return_value=None):
+            status, detail = MODULE.check_pyright(self.ctx)
+
+        self.assertEqual(status, MODULE.WARN)
+        self.assertIn('pip install', detail)
+
+
+class ApiDatabaseTests(Fixture):
+    """The database is resolved by the module that owns the policy, not re-derived here."""
+
+    def test_existing_query_script_resolves(self):
+        query = self.root / 'query_fusion_api.py'
+        query.write_text('')
+
+        with mock.patch.dict(os.environ, {'FUSION_QUERY_API': str(query)}):
+            status, detail = MODULE.check_api_db(self.ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertIn(str(query), detail)
+
+    def test_missing_query_script_fails_with_the_module_s_own_message(self):
+        with mock.patch.dict(os.environ, {'FUSION_QUERY_API': str(self.root / 'nowhere.py')}):
+            status, detail = MODULE.check_api_db(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('does not exist', detail)
+
+    def test_the_generate_stage_downgrades_it_to_a_warning(self):
+        with mock.patch.dict(os.environ, {'FUSION_QUERY_API': str(self.root / 'nowhere.py')}):
+            results = MODULE.run_checks(self.ctx, 'generate')
+
+        by_key = {r['key']: r for r in results}
+        self.assertEqual(by_key['api-db']['status'], MODULE.WARN)
+
+    def test_the_union_keeps_the_strictest_grade(self):
+        with mock.patch.dict(os.environ, {'FUSION_QUERY_API': str(self.root / 'nowhere.py')}):
+            results = MODULE.run_checks(self.ctx, 'all')
+
+        by_key = {r['key']: r for r in results}
+        self.assertEqual(by_key['api-db']['status'], MODULE.FAIL)
+        self.assertEqual(len(by_key), len(results))  # each key runs once
+
+
+class StubTests(Fixture):
+    """$FUSION_API_STUBS is authoritative; a cold cache is not a broken environment."""
+
+    def test_set_but_wrong_env_var_fails(self):
+        with mock.patch.dict(os.environ, {'FUSION_API_STUBS': str(self.root / 'nowhere')}):
+            status, detail = MODULE.check_stubs(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('exit 2', detail)
+
+    def test_set_and_correct_env_var_resolves(self):
+        with mock.patch.dict(os.environ, {'FUSION_API_STUBS': str(stub_defs(self.root))}):
+            status, _ = MODULE.check_stubs(self.ctx)
+
+        self.assertEqual(status, MODULE.OK)
+
+    def test_cold_cache_warns_and_clones_nothing(self):
+        cache = self.root / 'cache'
+        cache.mkdir()
+        env = {'XDG_CACHE_HOME': str(cache)}
+        with mock.patch.dict(os.environ, env):
+            os.environ.pop('FUSION_API_STUBS', None)
+            status, detail = MODULE.check_stubs(self.ctx)
+
+        self.assertEqual(status, MODULE.WARN)
+        self.assertIn('auto-clone', detail)
+        self.assertEqual(os.listdir(str(cache)), [])
+
+
+class ReportTests(Fixture):
+    """The two output shapes, and the promise that warnings alone still exit 0."""
+
+    def test_json_keys_every_check_and_matches_the_exit_code(self):
+        with mock.patch.dict(os.environ, self.resolved()):
+            code, out = self.run_cli(GEAR, '--stage', 'emit', '--root', str(self.root),
+                                     '--format', 'json')
+
+        report = json.loads(out)
+        self.assertEqual(report['gear'], GEAR)
+        self.assertEqual(report['stage'], 'emit')
+        self.assertEqual(report['ready'], code == 0)
+        keys = [c['key'] for c in report['checks']]
+        self.assertEqual(sorted(keys), sorted(k for k, _, _ in MODULE.STAGES['emit']))
+        for check in report['checks']:
+            self.assertIn(check['status'], (MODULE.OK, MODULE.WARN, MODULE.FAIL, MODULE.SKIP))
+            self.assertTrue(check['detail'])
+
+    def test_warnings_alone_leave_the_exit_code_at_zero(self):
+        cache = self.root / 'cache'
+        cache.mkdir()
+        env = {'XDG_CACHE_HOME': str(cache),
+               'FUSION_QUERY_API': str(self.root / 'nowhere.py')}
+        with mock.patch.dict(os.environ, env):
+            os.environ.pop('FUSION_API_STUBS', None)
+            os.environ.pop('SKETCH_DIR', None)
+            code, out = self.run_cli(GEAR, '--stage', 'generate', '--root', str(self.root))
+
+        self.assertEqual(code, 0, out)
+        self.assertIn('[warn]', out)
+        self.assertNotIn('[FAIL]', out)
+        self.assertIn('READY', out)
+
+    def test_text_report_counts_the_failures(self):
+        with mock.patch.dict(os.environ, self.resolved()):
+            code, out = self.run_cli(GEAR, '--stage', 'emit', '--root', str(self.root))
+
+        self.assertEqual(code, 1)
+        self.assertIn('NOT READY (2 failures)', out)  # steps.md and the proof directory
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- A missing engine, toolchain or API database fails at step 1, not mid-round.
- Each stage asks only for what it needs; the rest is a warning.
- It reports and never repairs: `.tmp/` is the only thing it writes.
