### PR TITLE
route generate-gear validation through run_gates

### DIFF
--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -99,71 +99,50 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
      override one only with a stated reason.
 
 5. **Validate (reference-free).** The output is checked against the **spec**, not against any
-   implementation:
-   - **Parse:** `python3 -c "import ast; ast.parse(open('.tmp/<gear>.generated.py').read())"`.
-     (Fusion's `adsk` modules can't be imported here; the repo has no runnable tests — parse is
-     the available mechanical gate.)
-   - **Static analysis (pyright + Fusion API stubs).** Run
-     `python3 .claude/skills/generate-gear/pyright_check.py .tmp/<gear>.generated.py`. With the
-     Fusion stubs on the path, pyright (standard mode) resolves `adsk.core`/`adsk.fusion` and the
-     framework's `from .misc import *` star-exports, so one tool catches both bug classes:
-     **undefined names / typos** (`NameError`) and
-     **wrong adsk submodule** (`adsk.fusion.SurfaceTypes` → `adsk.core`). Only **BLOCKING** findings
-     (exit 1) gate — they are real; fix the **spec/playbook** and regenerate. **REVIEW** findings are
-     advisory stub pessimism (idiomatic downcasts, Optional-typed API returns); correct code like
-     `spurgear.py` emits ~27 with zero real bugs, so **never gate or thrash the spec on them** —
-     expand with `--review` only when chasing a specific runtime `AttributeError`/`NoneType`. Stubs
-     come from `$FUSION_API_STUBS` (or `--stubs <dir>`); if neither is set the script **auto-clones**
-     the `FusionAPIReference` repo (sparse/shallow/blobless — ~13M, not the full 338M) into
-     `~/.cache/fusion360-gear-generator/` on first run and reuses it. If pyright is missing the
-     script auto-installs the pyright wrapper into `~/.cache/fusion360-gear-generator/` (pass
-     `--no-install` to forbid network use); the wrapper's first run may additionally download
-     node / the pyright npm bundle. Why standard mode, not `--strict`:
-     the stubs are intellisense-only and leave many return types unannotated, so `--strict` buries
-     the file in thousands of `reportUnknown*` lines with zero extra real bugs. If the stubs are
-     unavailable the script exits 2; fall back to a pyflakes undefined-name grep for the first bug
-     class, and to `fusion:query-api` `show <Name>` ([PB-ADSK-MODULES]) for the second. That lookup
-     reads the plugin's compiled database, so it needs no stubs and answers the module outright.
-   - **Contract self-check:** every class name, hook method, tooth/profile-generator entry point,
-     `ctx` field, Fusion user-parameter name, and dialog input id the spec's Contract sections
-     declare is present in the generated file. If the spec declares dependent gears, confirm the
-     surface those dependents bind to (by name) exists unchanged. Where the gear carries a
-     machine-readable manifest `spec/<gear>/contract.json`, run
-     `python3 .claude/skills/generate-gear/check_contract.py spec/<gear>/contract.json
-     .tmp/<gear>.generated.py` — it mechanically gates (exit 1 = BLOCKING) the manifest's classes,
-     bases, pinned methods, `ctx` fields, module-level constants (the Python identifiers
-     dependents import AND their exact string values — the breakage class no other gate sees), and
-     its `source_guards`, which pin the constraint recipes the spec chose over an alternative that
-     also solves, in the generated module and in the hand-written sources that teach it. The
-     spec **prose** stays authoritative; the manifest mirrors its Contract sections, and a
-     spec/manifest mismatch is a spec bug — fix both together. Prose-check whatever the manifest
-     doesn't carry. (`spec/spurgear/contract.json` is the worked example; gears without a manifest
-     get the full prose check.)
-   - **Anchor check:** run `python3 .claude/skills/generate-gear/check_anchors.py` (repo root).
-     Every `[PB-…]`/`[<GEAR>-F-…]` anchor cited anywhere in `spec/` or the playbook must resolve to
-     a defined anchor, defined in exactly one file, with no truncated cites. Exit 1 gates: an
-     unresolved cite silently unbinds the rule at that point of use.
-   - **Dependency resolution:** every name the generated file imports from another gear or
-     framework module actually exists in that module. (`check_contract.py` verifies this
-     mechanically for `lib/geargen/` imports, plus the no-`import *` module-layout rule.)
-   - **Helper-shadowing check:** the generated file must not re-define (via `def` or `class`) any
-     name the framework helper library provides (PLAYBOOK "Shared geargen helper library":
-     `find_profile_by_curve_counts`, `find_circle_by_radius`, the `solids.*` functions,
-     `VirtualSpurProxy`/`Val`), nor carry a private re-implementation of one. A shadow or
-     re-implementation means the spec/playbook failed to direct the generator to the helper — fix
-     there and regenerate. (`check_contract.py` catches the literal re-definition case
-     mechanically; private re-implementations under a different name still need the prose check.)
-   - **Input-read consistency check:** run
-     `python3 .claude/skills/generate-gear/check_input_read.py .tmp/<gear>.generated.py`. It pairs
-     each `add*Input(id, …)` declaration in `configure()` with the `get_*(inputs, id, …)` read by
-     input id and **exits 1 (BLOCKING)** on a type mismatch — reading an `addBoolValueInput` with
-     `get_value` (a runtime `AttributeError: 'BoolValueCommandInput' has no attribute 'expression'`),
-     a value input with `get_boolean`, etc. The pyright gate **cannot** catch this — the readers
-     resolve the input by a runtime string key, so the concrete input type is invisible to static
-     typing. A mismatch means the spec under-specified how that input is read (`[PB-INPUT-READ]`);
-     fix the spec/playbook and regenerate.
+   implementation. Run the mechanical battery with one command from the repo root:
 
-6. **Iterate.** A parse error, a missing contract item, or an unresolved dependency means the
+   ```
+   python3 .claude/skills/generate-gear/run_gates.py <gear> --skip-missing-steps
+   ```
+
+   It runs parse, input-read pairing, the contract manifest (auto-skipped with a note when the
+   gear has no `spec/<gear>/contract.json`), step-calls (auto-skipped when the gear has no
+   compiled `spec/<gear>/steps.md`, which is what `--skip-missing-steps` permits), anchors,
+   API-call existence, and pyright with the Fusion stubs, then prints one verdict plus the
+   advisory novel-type report. Exit 0 means every gate that ran passed; exit 1 means a gate
+   failed on content — fix the **spec/playbook** and regenerate (step 4), never the generated
+   file; exit 2 means a setup problem (missing candidate, unreachable stubs or API database)
+   that no new draft can fix. Ignore the runner's emit-vs-compile fault labels at this stage:
+   in the one-shot workflow every content failure routes the same way, to a spec or playbook
+   fix followed by a regeneration. Two reading notes carry over from the per-check era:
+
+   - **pyright:** only **BLOCKING** findings gate. **REVIEW** findings are advisory stub
+     pessimism (idiomatic downcasts, Optional-typed API returns); correct code like
+     `spurgear.py` emits ~27 with zero real bugs, so never gate or thrash the spec on them.
+     Stubs come from `$FUSION_API_STUBS`; on first run the check auto-clones a sparse copy of
+     `FusionAPIReference` into `~/.cache/fusion360-gear-generator/` and auto-installs pyright
+     there. If the stubs are unavailable (the gate reports a setup error), fall back to a
+     pyflakes undefined-name grep and to `fusion:query-api` `show <Name>`
+     ([PB-ADSK-MODULES]) for submodule questions.
+   - **Novel types:** read each advisory finding and decide; record stub noise with
+     `check_novel_types.py --accept N --why "<reason>"`. It is the only check that has caught
+     a method called on a class that does not define it.
+
+   The runner cannot see prose, so after it passes, prose-check what no gate carries:
+
+   - **Contract (no manifest):** for a gear without `spec/<gear>/contract.json`, check every
+     class name, hook method, tooth/profile-generator entry point, `ctx` field, Fusion
+     user-parameter name, and dialog input id the spec's Contract sections declare, and the
+     surface any declared dependent gears bind to. (`spec/spurgear/contract.json` is the
+     worked example of moving this into the manifest.)
+   - **Helper shadowing:** the manifest gate catches a literal re-definition of a framework
+     helper (PLAYBOOK "Shared geargen helper library"), but a private re-implementation under
+     a different name still needs a prose check. A shadow means the spec/playbook failed to
+     direct the generator to the helper; fix there and regenerate.
+   - **Dependency resolution:** `check_contract.py` verifies `lib/geargen/` imports
+     mechanically; confirm any other imported surface the spec's Dependencies section names.
+
+6. **Iterate.** A failed gate, a missing contract item, or an unresolved dependency means the
    **spec or playbook** is incomplete or wrong — fix it there (never hand-edit the generated file,
    never copy from an existing implementation) and regenerate from the Generate step (step 4).
    Repeat up to ~3 rounds. Converges when the output parses and satisfies the full declared contract.

--- a/.claude/skills/generate-gear/run_gates.py
+++ b/.claude/skills/generate-gear/run_gates.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Run the whole emit-gear gate battery for one gear and print one verdict.
+"""Run the whole gate battery for one gear and print one verdict.
 
-Why this exists: `/emit-gear` step 4 used to ask the orchestrating LLM to run seven gate
-commands one at a time, then classify any failure by hand against the fault table in
+It serves both stages that validate a candidate module: `/emit-gear` step 4 and
+`/generate-gear` step 5. Both used to ask the orchestrating LLM to run the gate commands one
+at a time, then (at the emit stage) classify any failure by hand against the fault table in
 `.claude/skills/emit-gear/SKILL.md`. Every part of that is mechanical — the commands are
 fixed, their arguments are derived from `<gear>`, their exit codes already say pass/fail —
 and leaving it to the model meant gates silently dropped under context pressure, argument
@@ -29,6 +30,10 @@ options:
   --fail-fast            stop scheduling gates after the first failure. Off by default.
   --require-contract     a missing spec/<gear>/contract.json fails the run instead of
                          skipping the contract gate.
+  --skip-missing-steps   a missing spec/<gear>/steps.md skips the step_calls gate instead
+                         of being a setup error. This is what /generate-gear passes: it
+                         runs from the prose spec, so a gear may have no compiled step
+                         list. When steps.md exists the gate runs as usual.
   --gate-novel-types     pass --gate to check_novel_types.py, making its findings
                          blocking (this is what CI does).
   --no-advisory          do not run check_novel_types.py at all.
@@ -158,7 +163,7 @@ def _root_relative(abs_path, root):
 def parse_args(argv):
     p = argparse.ArgumentParser(
         prog="run_gates.py",
-        description="Run the emit-gear gate battery for one gear and print one verdict.")
+        description="Run the gate battery for one gear and print one verdict.")
     p.add_argument("gear")
     p.add_argument("candidate", nargs="?", default=None)
     p.add_argument("--root", default=None)
@@ -166,6 +171,9 @@ def parse_args(argv):
                     help="comma-separated gate keys to run; the rest are skipped")
     p.add_argument("--fail-fast", action="store_true")
     p.add_argument("--require-contract", action="store_true")
+    p.add_argument("--skip-missing-steps", action="store_true",
+                    help="a missing spec/<gear>/steps.md skips the step_calls gate instead "
+                         "of being a setup error (generate stage)")
     p.add_argument("--gate-novel-types", action="store_true")
     p.add_argument("--no-advisory", action="store_true")
     p.add_argument("--json-out", default=None)
@@ -203,7 +211,8 @@ def _active_keys(args):
 
 def setup_errors(paths, args):
     """Pre-flight, returns human messages. Checks: root is a directory; candidate exists;
-    steps.md exists; every gate script the plan needs exists in scripts_dir();
+    steps.md exists unless --skip-missing-steps; every gate script the plan needs exists in
+    scripts_dir();
     --require-contract implies contract.json exists; --only names are known keys."""
     errors = []
     if not os.path.isdir(paths.root):
@@ -219,11 +228,12 @@ def setup_errors(paths, args):
     if not os.path.isfile(cand_abs):
         errors.append("candidate not found: %s" % paths.candidate)
 
-    steps_abs = _abs(paths.root, paths.steps)
-    if not os.path.isfile(steps_abs):
-        errors.append(
-            "step list not found: %s -- /emit-gear cannot run without it; "
-            "run /compile-gear first" % paths.steps)
+    if not args.skip_missing_steps:
+        steps_abs = _abs(paths.root, paths.steps)
+        if not os.path.isfile(steps_abs):
+            errors.append(
+                "step list not found: %s -- /emit-gear cannot run without it; "
+                "run /compile-gear first" % paths.steps)
 
     if args.require_contract:
         contract_abs = _abs(paths.root, paths.contract)
@@ -272,7 +282,8 @@ def gate_command(key, paths, args):
 
 def build_plan(paths, args):
     """(key, title, command, skip_reason). Command is None exactly when skip_reason is set.
-    Applies --only, --no-advisory, --gate-novel-types, and the missing-contract skip.
+    Applies --only, --no-advisory, --gate-novel-types, the missing-contract skip, and (under
+    --skip-missing-steps) the missing-step-list skip.
     Order is GATE_ORDER."""
     active = set(_active_keys(args))
     plan = []
@@ -286,6 +297,13 @@ def build_plan(paths, args):
                 "no manifest at %s -- the prose contract check is the reviewing agent's "
                 "job (generate-gear/SKILL.md); pass --require-contract to make this fatal"
                 % paths.contract)
+            plan.append((key, title, None, reason))
+            continue
+        if key == "step_calls" and args.skip_missing_steps \
+                and not os.path.isfile(_abs(paths.root, paths.steps)):
+            reason = ("no compiled step list at %s -- the generate stage runs from the "
+                      "prose spec; omit --skip-missing-steps to make this fatal"
+                      % paths.steps)
             plan.append((key, title, None, reason))
             continue
         plan.append((key, title, gate_command(key, paths, args), None))

--- a/.claude/skills/generate-gear/test_run_gates.py
+++ b/.claude/skills/generate-gear/test_run_gates.py
@@ -84,16 +84,17 @@ def make_all_stubs(scripts, overrides=None):
 
 
 def make_repo(tmp, gear=GEAR, *, candidate='x = 1\n', steps='# steps\n', contract=None):
-    """Create <tmp>/.tmp/<gear>.generated.py, spec/<gear>/steps.md and, when `contract` is not
-    None, spec/<gear>/contract.json. Return the root path."""
+    """Create <tmp>/.tmp/<gear>.generated.py and, when the argument is not None,
+    spec/<gear>/steps.md and spec/<gear>/contract.json. Return the root path."""
     root = tmp
     os.makedirs(os.path.join(root, '.tmp'), exist_ok=True)
     os.makedirs(os.path.join(root, 'spec', gear), exist_ok=True)
     cand_path = os.path.join(root, '.tmp', '%s.generated.py' % gear)
     with open(cand_path, 'w') as fh:
         fh.write(candidate)
-    with open(os.path.join(root, 'spec', gear, 'steps.md'), 'w') as fh:
-        fh.write(steps)
+    if steps is not None:
+        with open(os.path.join(root, 'spec', gear, 'steps.md'), 'w') as fh:
+            fh.write(steps)
     if contract is not None:
         with open(os.path.join(root, 'spec', gear, 'contract.json'), 'w') as fh:
             fh.write(contract)
@@ -301,6 +302,59 @@ class SetupErrorTests(BaseGateTest):
         by_key = {g['key']: g for g in parsed['gates']}
         self.assertEqual(by_key['pyright']['status'], 'error')
         self.assertLess(elapsed, 3)
+
+
+class SkipMissingStepsTests(BaseGateTest):
+    """--skip-missing-steps: the generate stage runs from the prose spec, so a gear with no
+    compiled spec/<gear>/steps.md skips the step_calls gate instead of erroring out."""
+
+    def test_missing_steps_skips_step_calls(self):
+        root = make_repo(self.tmp, steps=None, contract='{}')
+        marker = os.path.join(self.tmp, 'step-calls-invoked.marker')
+        make_all_stubs(self.scripts, overrides={
+            'step_calls': dict(argv_marker=marker),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--skip-missing-steps')
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(parsed['verdict'], 'pass')
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['step_calls']['status'], 'skip')
+        self.assertIn('spec/%s/steps.md' % GEAR, by_key['step_calls']['skip_reason'])
+        self.assertIn('--skip-missing-steps', by_key['step_calls']['skip_reason'])
+        self.assertFalse(os.path.exists(marker))
+        for key in ('parse', 'input_read', 'contract', 'anchors', 'api_calls', 'pyright',
+                    'novel_types'):
+            self.assertEqual(by_key[key]['status'], 'pass', msg=by_key[key])
+
+    def test_missing_steps_without_flag_still_errors(self):
+        root = make_repo(self.tmp, steps=None, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(parsed['verdict'], 'setup_error')
+        self.assertIn('spec/%s/steps.md' % GEAR, text)
+
+    def test_flag_with_steps_present_runs_gate(self):
+        root = make_repo(self.tmp, contract='{}')
+        make_all_stubs(self.scripts)
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--skip-missing-steps')
+        self.assertEqual(exit_code, 0)
+        by_key = {g['key']: g for g in parsed['gates']}
+        self.assertEqual(by_key['step_calls']['status'], 'pass')
+
+    def test_api_fault_classification_survives_missing_step_list(self):
+        root = make_repo(self.tmp, steps=None, contract='{}')
+        make_all_stubs(self.scripts, overrides={
+            'api_calls': dict(
+                exit_code=1,
+                stdout="api-call check: BLOCKING (1)\n"
+                       "  x.py:1 calls 'setExtentDefinition(' -- no such name, ..."),
+        })
+        exit_code, text, parsed = run(root, self.scripts, GEAR, '--skip-missing-steps')
+        self.assertEqual(exit_code, 1)
+        row = next(c for c in parsed['classification'] if c['gate'] == 'api_calls')
+        self.assertEqual(row['fault'], 'emit')
+        self.assertIn('could not read the step list', row['why'])
 
 
 class ClassificationTests(BaseGateTest):


### PR DESCRIPTION
- step 5 hand-ran five gates one at a time; `run_gates.py` already does that in one verdict
- opt-in `--skip-missing-steps` skips step_calls for a gear with no compiled `steps.md`
- emit stage is unchanged: without the flag a missing step list is still a setup error
