### PR TITLE
gate the sketch bench by exit code

### DIFF
--- a/.claude/skills/generate-gear/PLAYBOOK.md
+++ b/.claude/skills/generate-gear/PLAYBOOK.md
@@ -361,11 +361,18 @@ for exactly this question, so the scheme is proven on the bench before it is com
 **Where it lives.** The proof is a small, committed, runnable Go program per gear at
 `spec/<gear>/sketch/` (module + `main.go` + `run.sh` + `README.md`). It reproduces the gear's
 constraint-bearing sketch(es) from the same `[SPUR-F-…]`/spec recipes the Fusion code will use, runs
-the solver, and prints a pass/fail gate. `spec/spurgear/sketch/` is the worked example (the spur
+the solver, and reports the verdict **as an exit code**: exit **0** with a final line starting
+`ALL PASS` when every case passes the primary gate, exit **1** with a line starting `FAIL` when any
+case fails it, and exit **2** for environment trouble (the engine checkout not found). `run.sh` uses
+`set -euo pipefail` so the Go program's exit status propagates. Every gear's bench MUST implement
+this contract — it is what lets `.claude/skills/generate-gear/run_sketch_bench.py` gate mechanically
+instead of a human or model reading the output. Run it via that wrapper
+(`python3 .claude/skills/generate-gear/run_sketch_bench.py <gear>`), not by eyeballing `./run.sh`
+output. `spec/spurgear/sketch/` is the worked example (the spur
 Gear Profile: four circles, involute flanks, ribs, spine, flank-to-root lines). `run.sh` resolves a
 local checkout of the engine (source-available, not go-gettable) via `$SKETCH_DIR` or a sibling
 `<repo>/../sketch` located with `git --git-common-dir`, injecting the replace through a throwaway
-`GOWORK` so the committed `go.mod` stays portable. Run it with `./run.sh`.
+`GOWORK` so the committed `go.mod` stays portable.
 
 **The gate.** Build geometry from points, add the constraints, `Solve()`, then read `Verify()`:
 

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -53,11 +53,16 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
    they bind to as part of the required contract.
 
 3. **Prove the sketch fully constrains (sketch-first gate — `[PB-SKETCH-FIRST]`).** If the gear's
-   profile is a non-trivial constrained sketch, run its bench proof at `spec/<gear>/sketch/`
-   (`./run.sh`) and confirm the **primary gate passes** — `Status == FullyConstrained` and healthy
-   conditioning (`DOF == 0`, no redundant/conflicting constraints). This proves the constraint scheme
-   is sound *before* any Fusion code is emitted; the advisory signals (`ProfilesValid`,
-   `Probe.Ambiguous()`) are reported and interpreted, not hard-blocking (see `[PB-SKETCH-FIRST]`).
+   profile is a non-trivial constrained sketch, run
+   `python3 .claude/skills/generate-gear/run_sketch_bench.py <gear>` and act on the exit code:
+   **0** the primary gate passed (the bench proved `Status == FullyConstrained` with healthy
+   conditioning) — proceed; **1** the constraint scheme does not fully constrain — a spec/playbook
+   defect to fix here, never inside Fusion; **2** a setup problem (no bench yet, missing
+   sketch-engine checkout, a bench that does not build, or a bench that printed no verdict) — fix
+   the environment or build the bench first. This proves the constraint scheme is sound *before*
+   any Fusion code is emitted; the advisory signals (`ProfilesValid`, `Probe.Ambiguous()`) remain
+   in the bench output and are reported and interpreted, not hard-blocking
+   (see `[PB-SKETCH-FIRST]`).
    If the proof does not yet exist for this gear, build it from the spec's sketch recipes (the spur
    `spec/spurgear/sketch/` is the worked example) — a scheme that cannot reach `DOF == 0` on the
    bench is a spec/playbook defect to fix here, not to discover inside Fusion. Requires a local

--- a/.claude/skills/generate-gear/run_sketch_bench.py
+++ b/.claude/skills/generate-gear/run_sketch_bench.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Run one gear's sketch-first bench and turn its verdict into an exit code.
+
+Why this exists: `/generate-gear` step 3 (the sketch-first gate, `[PB-SKETCH-FIRST]`) used to
+tell the orchestrating LLM to run `spec/<gear>/sketch/run.sh` and *read the output* to confirm
+`Status == FullyConstrained` and healthy conditioning. Reading output is the failure mode the
+gate runners were built to remove: the verdict gets skimmed, the advisory lines
+(`ProfilesValid`, `Probe.Ambiguous()`) get mistaken for the gate, and nothing pins the
+bench's own contract. This script runs the bench once and reports the result in the same
+0/1/2 convention the other scripts in this directory use, so the orchestrator acts on an exit
+code instead of on prose.
+
+Classification uses the bench's exit code **plus** a verdict sentinel scanned from its output
+(a line whose stripped text starts with `ALL PASS` or with `FAIL`). The sentinel is what
+separates "the constraint scheme failed the gate" from "the bench itself is broken": a `go`
+build failure inside `run.sh` also exits 1, and without the sentinel that would read as a
+scheme defect. It also forces a future gear's bench to actually print a verdict rather than
+exiting 0 after printing diagnostics only.
+
+Bench output is passed through untouched; no advisory line is ever parsed, and nothing but
+the final `[GATE]`/`[SETUP]` line is added.
+
+Usage:
+    run_sketch_bench.py <gear> [--root PATH] [--timeout SECONDS]
+
+positional:
+  gear                  gear name, e.g. spurgear. Names spec/<gear>/sketch/run.sh.
+
+options:
+  --root PATH           repo root. Default: three levels above this script.
+  --timeout SECONDS     wall-clock limit for the bench. Default 900. The first run compiles
+                        the sketch engine from source, so do not lower it casually.
+
+Exit codes:
+    0  the primary gate passed: the bench exited 0 and printed an `ALL PASS` verdict line.
+       The constraint scheme fully constrains; proceed to generation.
+    1  the primary gate failed: the bench exited nonzero and printed a `FAIL` verdict line.
+       The constraint scheme does not fully constrain. That is a spec/playbook defect to fix
+       here, never inside Fusion; never proceed to generation.
+    2  setup error: no bench for this gear yet, the sketch-engine checkout was not found, the
+       bench did not build, the bench timed out, or the bench ran but printed no verdict
+       line. Fix the environment or build the bench; this is not a verdict on the scheme.
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+DEFAULT_TIMEOUT = 900
+PASS_SENTINEL = "ALL PASS"
+FAIL_SENTINEL = "FAIL"
+
+
+def repo_root():
+    """Three levels above this script, the same rule run_gates.py uses."""
+    return os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                        "..", "..", ".."))
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(
+        prog="run_sketch_bench.py",
+        description="Run a gear's sketch-first bench and report its verdict as an exit code.")
+    p.add_argument("gear", help="gear name, e.g. spurgear")
+    p.add_argument("--root", default=None, help="repo root (default: three levels above "
+                                                "this script)")
+    p.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT,
+                   help="wall-clock limit in seconds (default %d)" % DEFAULT_TIMEOUT)
+    return p.parse_args(argv)
+
+
+def bench_paths(root, gear):
+    """(bench directory, run.sh path, root-relative run.sh path) for one gear."""
+    rel = os.path.join("spec", gear, "sketch", "run.sh")
+    script = os.path.join(root, rel)
+    return os.path.dirname(script), script, rel
+
+
+def verdict_sentinel(output):
+    """The bench's verdict as 'pass', 'fail', or None when it printed neither.
+
+    Matching is prefix-based on each stripped line, so the spur bench's real
+    `ALL PASS — the spur Gear Profile constraint scheme fully constrains across sizes.`
+    matches. `ALL PASS` is checked first because it also starts no `FAIL` line. The last
+    verdict line in the output wins, so a per-case line cannot outvote the final one.
+    """
+    verdict = None
+    for line in (output or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith(PASS_SENTINEL):
+            verdict = "pass"
+        elif stripped.startswith(FAIL_SENTINEL):
+            verdict = "fail"
+    return verdict
+
+
+def last_meaningful_line(output):
+    """The last non-empty line of the bench output, for quoting in a setup message."""
+    for line in reversed((output or "").splitlines()):
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def run_bench(bench_dir, script, timeout):
+    """Run `bash run.sh` in the bench directory, capturing stdout and stderr together.
+
+    Returns (exit_code, output) with exit_code None when the bench timed out.
+    """
+    try:
+        proc = subprocess.run(["bash", script], cwd=bench_dir, capture_output=True,
+                              text=True, timeout=timeout, env=os.environ)
+    except subprocess.TimeoutExpired as exc:
+        return None, _decoded(exc.stdout) + _decoded(exc.stderr)
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def _decoded(chunk):
+    if chunk is None:
+        return ""
+    if isinstance(chunk, bytes):
+        return chunk.decode("utf-8", "replace")
+    return chunk
+
+
+def classify(exit_code, output, rel_script, timeout):
+    """(verdict line, exit code) for a bench that ran. `exit_code` None means it timed out."""
+    if exit_code is None:
+        return ("[SETUP] bench timed out after %gs; raise --timeout, or fix a bench that "
+                "does not terminate" % timeout, 2)
+
+    verdict = verdict_sentinel(output)
+
+    if exit_code == 0 and verdict == "pass":
+        return "[GATE] sketch bench: PASS", 0
+
+    if exit_code != 0 and verdict == "fail":
+        return ("[GATE] sketch bench: FAIL — the constraint scheme does not fully constrain; "
+                "this is a spec/playbook defect, fix there and re-run (never proceed to "
+                "generation)", 1)
+
+    if exit_code == 0:
+        return ("[SETUP] %s exited 0 but printed no 'ALL PASS' verdict line; the bench does "
+                "not implement the [PB-SKETCH-FIRST] verdict contract" % rel_script, 2)
+
+    if exit_code == 2:
+        return ("[SETUP] %s exited 2 (environment trouble, usually the sketch-engine checkout "
+                "not found): %s" % (rel_script, last_meaningful_line(output)), 2)
+
+    return ("[SETUP] %s exited %d but printed no 'FAIL' verdict line, so this is not a gate "
+            "verdict — most likely the bench did not build: %s"
+            % (rel_script, exit_code, last_meaningful_line(output)), 2)
+
+
+def main(argv):
+    args = parse_args(argv)
+    root = os.path.abspath(args.root) if args.root else repo_root()
+    bench_dir, script, rel_script = bench_paths(root, args.gear)
+
+    if not os.path.isfile(script):
+        print("[SETUP] no sketch bench at %s; build it from the spec's sketch recipes "
+              "([PB-SKETCH-FIRST]) — spec/spurgear/sketch/ is the worked example" % rel_script)
+        return 2
+
+    exit_code, output = run_bench(bench_dir, script, args.timeout)
+    if output:
+        sys.stdout.write(output if output.endswith("\n") else output + "\n")
+
+    line, code = classify(exit_code, output, rel_script, args.timeout)
+    print(line)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/generate-gear/test_run_sketch_bench.py
+++ b/.claude/skills/generate-gear/test_run_sketch_bench.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Tests for run_sketch_bench.py.
+
+No test runs a real sketch bench or needs the Go toolchain: every case writes a tiny
+executable `run.sh` into a throwaway `<tmp>/spec/<gear>/sketch/` and calls `main([...])`
+in-process, asserting on the exit code and the captured output.
+"""
+import contextlib
+import importlib.util
+import io
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name('run_sketch_bench.py')
+SPEC = importlib.util.spec_from_file_location('run_sketch_bench', MODULE_PATH)
+RUNNER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RUNNER)
+
+GEAR = 'spurgear'
+
+
+def make_bench(root, body, gear=GEAR):
+    """Write an executable spec/<gear>/sketch/run.sh with `body` as its script text."""
+    bench_dir = Path(root) / 'spec' / gear / 'sketch'
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    script = bench_dir / 'run.sh'
+    script.write_text('#!/usr/bin/env bash\n' + body)
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return script
+
+
+def run(root, *argv):
+    """Call main() with --root <root>, returning (exit_code, captured stdout)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        code = RUNNER.main(['--root', str(root)] + list(argv))
+    return code, buf.getvalue()
+
+
+class BenchRunnerTest(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmpdir.name)
+        self.addCleanup(self._tmpdir.cleanup)
+
+    def test_missing_bench_is_a_setup_error(self):
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 2)
+        self.assertIn('spec/spurgear/sketch/run.sh', out)
+        self.assertIn('[PB-SKETCH-FIRST]', out)
+        self.assertTrue(out.strip().splitlines()[-1].startswith('[SETUP]'))
+
+    def test_pass_verdict_exits_zero(self):
+        make_bench(self.root,
+                   'echo "case 1 OK"\n'
+                   'echo "ALL PASS — the spur Gear Profile constraint scheme fully '
+                   'constrains across sizes."\n'
+                   'exit 0\n')
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip().splitlines()[-1], '[GATE] sketch bench: PASS')
+
+    def test_fail_verdict_exits_one(self):
+        make_bench(self.root,
+                   'echo "FAIL — case N=17 is under-constrained (DOF 2)"\n'
+                   'exit 1\n')
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 1)
+        last = out.strip().splitlines()[-1]
+        self.assertTrue(last.startswith('[GATE] sketch bench: FAIL'))
+        self.assertIn('spec/playbook defect', last)
+
+    def test_engine_missing_is_not_a_gate_failure(self):
+        make_bench(self.root,
+                   'echo "sketch repo not found at: /nowhere/sketch" >&2\n'
+                   'echo "set SKETCH_DIR=/path/to/lestrrat-3d/sketch and re-run" >&2\n'
+                   'exit 2\n')
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 2)
+        last = out.strip().splitlines()[-1]
+        self.assertTrue(last.startswith('[SETUP]'))
+        self.assertIn('exited 2', last)
+        self.assertNotIn('[GATE]', out)
+
+    def test_build_failure_is_a_setup_error(self):
+        make_bench(self.root,
+                   'echo "main.go:41:2: undefined: sketch.NewAngel" >&2\n'
+                   'exit 1\n')
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 2)
+        last = out.strip().splitlines()[-1]
+        self.assertTrue(last.startswith('[SETUP]'))
+        self.assertIn("no 'FAIL' verdict line", last)
+
+    def test_zero_exit_without_verdict_is_a_contract_violation(self):
+        make_bench(self.root, 'echo "case 1 solved, DOF 0"\nexit 0\n')
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 2)
+        last = out.strip().splitlines()[-1]
+        self.assertIn("no 'ALL PASS' verdict line", last)
+        self.assertIn('[PB-SKETCH-FIRST]', last)
+
+    def test_timeout_is_a_setup_error(self):
+        make_bench(self.root, 'sleep 60\n')
+        code, out = run(self.root, GEAR, '--timeout', '1')
+        self.assertEqual(code, 2)
+        self.assertIn('bench timed out after', out.strip().splitlines()[-1])
+
+    def test_bench_output_is_passed_through(self):
+        make_bench(self.root,
+                   'echo "using sketch engine at: /somewhere/sketch"\n'
+                   'echo "MARKER-advisory ProfilesValid=true probeAmbiguous=true"\n'
+                   'echo "ALL PASS — everything holds"\n'
+                   'exit 0\n')
+        code, out = run(self.root, GEAR)
+        self.assertEqual(code, 0)
+        self.assertIn('using sketch engine at: /somewhere/sketch', out)
+        self.assertIn('MARKER-advisory ProfilesValid=true probeAmbiguous=true', out)
+
+
+class SentinelTest(unittest.TestCase):
+    def test_real_spur_pass_line_matches(self):
+        output = ('using sketch engine at: /home/u/sketch\n'
+                  'ALL PASS — the spur Gear Profile constraint scheme fully constrains '
+                  'across sizes.\nCleared to generate Fusion add-in code.\n')
+        self.assertEqual(RUNNER.verdict_sentinel(output), 'pass')
+
+    def test_indented_fail_line_matches(self):
+        self.assertEqual(RUNNER.verdict_sentinel('  FAIL — module 2 N=17\n'), 'fail')
+
+    def test_no_verdict_line(self):
+        self.assertIsNone(RUNNER.verdict_sentinel('solved 6 cases\nDOF 0\n'))
+
+    def test_last_verdict_line_wins(self):
+        self.assertEqual(
+            RUNNER.verdict_sentinel('ALL PASS — round 1\nFAIL — round 2\n'), 'fail')
+
+    def test_verdict_must_start_the_line(self):
+        self.assertIsNone(RUNNER.verdict_sentinel('the run did not ALL PASS\n'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/spec/spurgear/sketch/README.md
+++ b/spec/spurgear/sketch/README.md
@@ -33,6 +33,16 @@ ALL PASS — the spur Gear Profile constraint scheme fully constrains across siz
 Cleared to generate Fusion add-in code.
 ```
 
+**Exit codes.** `run.sh` reports the verdict as its exit status: **0** = every case passes
+the primary gate (final `ALL PASS` line), **1** = some case fails it (final `FAIL` line),
+**2** = the sketch engine checkout was not found. This is the contract every gear's bench
+implements ([PB-SKETCH-FIRST]). The canonical way to run the gate is the repo-side wrapper,
+which turns that status into the house 0/1/2 verdict convention:
+
+```sh
+python3 .claude/skills/generate-gear/run_sketch_bench.py spurgear
+```
+
 ## What it models
 
 `main.go` rebuilds the spur **Gear Profile** sketch exactly as

--- a/spec/spurgear/steps.md
+++ b/spec/spurgear/steps.md
@@ -4,18 +4,12 @@ This step list is proven by `proof/spurgear/geometry_test.go`, `proof/spurgear/s
 
 ## Provenance
 
-| Input | `git hash-object` |
+| file | `git hash-object` |
 |---|---|
 | `spec/spurgear/instructions.md` | `f5ffe3451454bb3b187b1318e47b92281d9f0bb0` |
 | `spec/spurgear/fusion.md` | `ea678245854cfec80055d67c46a8788772b0f9d4` |
-| `.claude/skills/generate-gear/PLAYBOOK.md` | `29c38dc687f7d6b88f7c36ff3275482b2eff051f` |
 | `spec/helicalgear/fusion.md` | `83fac920272341e3c4584f16031478a69b7472e7` |
-
-Steps 1–5 are the module surface — classes, dialog, parameters, orchestration — which
-Fusion's timeline never shows but the emitted module cannot exist without. Steps 6–20 are
-the build itself, one timeline entry (or control-flow gate) each. Lengths in Fusion's
-internal units are cm; the proof models the same geometry in mm, which scales lengths and
-changes no count, ratio or angle.
+| `.claude/skills/generate-gear/PLAYBOOK.md` | `4b5b47887e4c8b26b12ec7de679f922bc2d474c2` |
 
 ## 1 `[PROSE]` Module surface and exported constants
 


### PR DESCRIPTION
- step 3 read bench output to judge the sketch-first gate; a wrapper now decides it by exit code (0/1/2).
- an `ALL PASS`/`FAIL` sentinel tells a failed gate from a broken bench, and is pinned as a bench contract.
- `main.go` and `run.sh` already conformed and are untouched; advisory signals stay printed, non-blocking.
- a live spur bench run through the wrapper passes (exit 0), as do the checker tests and the anchor check.
