### PR TITLE
add a compile target to stage.py

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -81,11 +81,14 @@ proof is where the next reader is looking for the missing check.
    draft fault, handled as step 6 handles one. The two tools have separate jobs: `scaffold_proof.py`
    generates that one file, and `stage.py` places every drafted file including it.
 
-   Then run `python3 .claude/skills/generate-gear/stage.py <gear> proof` from the repo root. It
-   copies every drafted proof file from `.tmp/<gear>-proof/` into `proof/<gear>/`, deletes any
-   `.go` file there the draft no longer produces, and indexes the result so step 5's
-   tracked-or-committed check can see a first-time proof. Exit 2 means the placement was refused
-   and nothing moved. Do not pass `--run`; the gate runner below runs the proof.
+   Then run `python3 .claude/skills/generate-gear/stage.py <gear> compile` from the repo root. It
+   places both drafted artifacts in one call: `.tmp/<gear>.steps.md` at `spec/<gear>/steps.md`,
+   and every drafted proof file from `.tmp/<gear>-proof/` into `proof/<gear>/`, deleting any `.go`
+   file there the draft no longer produces and indexing the result so step 5's
+   tracked-or-committed check can see a first-time proof. The step list must be placed here too,
+   because `check_compile.py` reads `spec/<gear>/steps.md`, never the draft in `.tmp/`. The
+   command refuses both placements if it would refuse either; exit 2 means nothing moved. There
+   is no `--run`; the gate runner below runs the proof.
 
    Then run `python3 .claude/skills/generate-gear/run_compile_gates.py <gear>` from the repo root.
    It runs `bash proof/run.sh`, then `check_compile.py <gear>`, then — only when
@@ -114,11 +117,11 @@ proof is where the next reader is looking for the missing check.
 6. **Diagnose and loop.** Classify any failure with the table below. A draft fault goes back to
    step 3 with the failure text appended, up to about three rounds. A prose fault stops the run.
 
-7. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> steps` and
-   `python3 .claude/skills/generate-gear/stage.py <gear> proof` from the repo root. They put the
-   drafted step list and every drafted proof file into the working tree and report what moved; the
-   proof call repeats step 4's placement, so it should report every file unchanged. This writes
-   files and the git index only; it does not commit, push, or touch Fusion's add-in directory.
+7. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> compile`
+   from the repo root. It repeats step 4's placement of the step list and the proof, so it
+   should report every file unchanged; it exists as a step so a run whose gates were green
+   ends with the working tree verified to match the draft. This writes files and the git index
+   only; it does not commit, push, or touch Fusion's add-in directory.
 
 8. **Report.** State what was produced, the coverage list, and every prose fault found.
 

--- a/.claude/skills/generate-gear/stage.py
+++ b/.claude/skills/generate-gear/stage.py
@@ -9,7 +9,8 @@ first-time proof that fails `check_compile`'s tracked-or-committed gate for
 reasons that have nothing to do with the draft. This script replaces the
 shell moves with one mechanical, atomic, idempotent placement per target.
 
-Three subcommands, one per artifact this pipeline stages:
+Four subcommands, one per artifact this pipeline stages plus one that
+places a whole stage's artifacts together:
 
   stage.py <gear> proof  [--run] [--no-index] [--force] [--dry-run]
       Copies every `*.go` file from `.tmp/<gear>-proof/` into `proof/<gear>/`,
@@ -24,6 +25,12 @@ Three subcommands, one per artifact this pipeline stages:
   stage.py <gear> module [--force] [--dry-run]
       Copies `.tmp/<gear>.generated.py` to `lib/geargen/<gear>.py`.
 
+  stage.py <gear> compile [--no-index] [--force] [--dry-run]
+      Places the compile stage's two artifacts in one call: `steps` then
+      `proof`, exactly as the two single-target commands would, refusing
+      both if it would refuse either. There is no `--run`; the compile
+      gate runner (`run_compile_gates.py`) runs the proof.
+
 `--root DIR` (default `.`) is the repo root; every path above is relative to
 it. `--force` overwrites a destination file that is neither this script's
 own prior output nor clean against HEAD. `--dry-run` validates and reports
@@ -34,7 +41,7 @@ idempotent: running it again over the same draft reports every file
 unchanged.
 
 Usage:
-    python3 stage.py [--root DIR] <gear> {proof,steps,module} [options]
+    python3 stage.py [--root DIR] <gear> {proof,steps,module,compile} [options]
 
 Run from the repo root.
 
@@ -63,6 +70,10 @@ class Refusal(Exception):
 Plan = collections.namedtuple(
     'Plan', 'target gear source destination sources_are_dir')
 Actions = collections.namedtuple('Actions', 'write unchanged prune extra')
+PlannedTarget = collections.namedtuple(
+    'PlannedTarget', 'plan sources existing actions')
+
+COMPILE_TARGETS = ('steps', 'proof')
 
 
 def _joined(root, *parts):
@@ -301,6 +312,23 @@ def plan_actions(sources, existing):
     return Actions(sorted(write), sorted(unchanged), sorted(prune), [])
 
 
+def plan_target(root, gear, target, force):
+    """Everything one target does before `apply_actions`. Raises `Refusal`.
+
+    Pulling phase 1 out of `main` is what lets a composite target plan every
+    child before any of them writes, so a refusal anywhere leaves the whole
+    working tree untouched.
+    """
+    plan = gear_paths(root, gear, target)
+    sources = read_sources(plan)
+    existing = existing_destination(plan)
+    extras = destination_extras(plan)
+    receipt = load_receipt(root, gear, plan.target)
+    classify_destination(plan, existing, receipt, force, root)
+    actions = plan_actions(sources, existing)._replace(extra=extras)
+    return PlannedTarget(plan, sources, existing, actions)
+
+
 def _temp_path(path):
     directory = os.path.dirname(path) or '.'
     base = os.path.basename(path)
@@ -372,6 +400,21 @@ def apply_actions(plan, actions, sources, existing):
         raise
 
 
+def rollback_target(planned):
+    """Undo a target that `apply_actions` already completed.
+
+    `apply_actions` unwinds its own target when it fails part way through, so
+    this exists only for a composite run: when a later child refuses to
+    place, an earlier child that already succeeded has to go back to the
+    bytes it replaced (or be removed again, when there were none).
+    """
+    plan = planned.plan
+    for name in list(planned.actions.write) + list(planned.actions.prune):
+        full = (os.path.join(plan.destination, name)
+                if plan.sources_are_dir else plan.destination)
+        _restore(full, planned.existing.get(name))
+
+
 def index_paths(root, plan):
     """`git add -A -- proof/<gear>`. Returns False (with a printed note) if git fails."""
     relpath = os.path.relpath(plan.destination, root)
@@ -435,8 +478,8 @@ def report(plan, actions, dry_run, sources):
 def build_parser():
     parser = argparse.ArgumentParser(
         prog='stage.py',
-        description='Stage a drafted gear artifact (proof, steps or module) into the '
-                     'working tree.')
+        description='Stage a drafted gear artifact (proof, steps or module), or a whole '
+                     'stage of them, into the working tree.')
     parser.add_argument('--root', default='.', help='repo root (default .)')
     parser.add_argument('gear', help='gear name, e.g. spurgear')
     sub = parser.add_subparsers(dest='target', required=True)
@@ -464,7 +507,64 @@ def build_parser():
     module.add_argument('--dry-run', action='store_true',
                          help='validate and report; write nothing')
 
+    compile_ = sub.add_parser(
+        'compile',
+        help='place the compile stage: steps then proof, refusing both if either refuses')
+    compile_.add_argument('--no-index', action='store_true',
+                           help='skip `git add -A -- proof/<gear>`')
+    compile_.add_argument('--force', action='store_true',
+                           help='overwrite a destination file that is not clean or ours')
+    compile_.add_argument('--dry-run', action='store_true',
+                           help='validate and report; write nothing')
+
     return parser
+
+
+def run_compile(root, args):
+    """The `compile` target: place `steps` and `proof` together, or neither.
+
+    Every child is planned before any of them writes, so a refusal in either
+    one leaves the working tree exactly as it was. Once writing starts, a
+    failure in the second child rolls the first one back as well, and the
+    receipts and the proof indexing are the same ones the two single-target
+    commands write, so a later single-target run still recognises its own
+    output.
+    """
+    try:
+        planned = [plan_target(root, args.gear, target, args.force)
+                   for target in COMPILE_TARGETS]
+    except Refusal as exc:
+        print("stage: %s" % exc, file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        for item in planned:
+            report(item.plan, item.actions, True, item.sources)
+        return 0
+
+    applied = []
+    for item in planned:
+        try:
+            apply_actions(item.plan, item.actions, item.sources, item.existing)
+        except Exception as exc:
+            for done in reversed(applied):
+                rollback_target(done)
+            print("stage: compile: %s placement failed and the whole compile placement "
+                  "was rolled back (%s)" % (item.plan.target, exc), file=sys.stderr)
+            return 2
+        applied.append(item)
+
+    for item in planned:
+        save_receipt(root, args.gear, item.plan.target, item.sources)
+
+    for item in planned:
+        if item.plan.target == 'proof' and not getattr(args, 'no_index', False):
+            index_paths(root, item.plan)
+
+    for item in planned:
+        report(item.plan, item.actions, False, item.sources)
+    print("stage: compile OK (steps + proof)")
+    return 0
 
 
 def main(argv):
@@ -472,14 +572,12 @@ def main(argv):
     args = parser.parse_args(argv[1:])
     root = args.root
 
+    if args.target == 'compile':
+        return run_compile(root, args)
+
     try:
-        plan = gear_paths(root, args.gear, args.target)
-        sources = read_sources(plan)
-        existing = existing_destination(plan)
-        extras = destination_extras(plan)
-        receipt = load_receipt(root, args.gear, plan.target)
-        classify_destination(plan, existing, receipt, args.force, root)
-        actions = plan_actions(sources, existing)._replace(extra=extras)
+        plan, sources, existing, actions = plan_target(
+            root, args.gear, args.target, args.force)
     except Refusal as exc:
         print("stage: %s" % exc, file=sys.stderr)
         return 2

--- a/.claude/skills/generate-gear/test_stage.py
+++ b/.claude/skills/generate-gear/test_stage.py
@@ -437,5 +437,171 @@ class RunIndexDryRunTests(unittest.TestCase):
             self.assertEqual(err_dry.strip(), err_real.strip())
 
 
+class CompileTargetTests(unittest.TestCase):
+    """The `compile` target places the step list and the proof, or neither."""
+
+    def test_compile_places_steps_and_proof_in_one_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'package spurgear_test\n',
+                                          'b_test.go': 'package spurgear_test\n'},
+                              steps='# steps\n')
+            code, out, _ = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'spec' / 'spurgear' / 'steps.md').read_text(), '# steps\n')
+            dest = root / 'proof' / 'spurgear'
+            self.assertEqual((dest / 'a_test.go').read_text(), 'package spurgear_test\n')
+            self.assertEqual((dest / 'b_test.go').read_text(), 'package spurgear_test\n')
+            self.assertIn('stage: steps OK', out)
+            self.assertIn('stage: proof OK', out)
+            self.assertIn('stage: compile OK (steps + proof)', out)
+
+    def test_compile_rerun_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'}, steps='# steps\n')
+            code1, _, _ = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code1, 0)
+            code2, out2, _ = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code2, 0)
+            self.assertNotIn('wrote', out2)
+            self.assertIn('stage: unchanged %s' % (root / 'spec' / 'spurgear' / 'steps.md'),
+                          out2)
+            self.assertIn('stage: unchanged %s'
+                          % (root / 'proof' / 'spurgear' / 'a_test.go'), out2)
+            self.assertIn('stage: compile OK (steps + proof)', out2)
+
+    def test_compile_refuses_when_steps_draft_missing_and_writes_no_proof_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'})
+            code, _, err = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 2)
+            self.assertIn('spurgear.steps.md', err)
+            self.assertFalse((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+
+    def test_compile_refuses_when_proof_draft_missing_and_leaves_steps_untouched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, steps='# steps\n')
+            code, _, err = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 2)
+            self.assertIn('spurgear-proof', err)
+            self.assertFalse((root / 'spec' / 'spurgear' / 'steps.md').exists())
+
+    def test_compile_dirty_steps_destination_refuses_before_any_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-2\n'}, steps='# steps-2\n')
+            (root / 'spec' / 'spurgear' / 'steps.md').write_text('# steps-1\n')
+            git_init(root)
+            git_commit_all(root)
+            (root / 'spec' / 'spurgear' / 'steps.md').write_text('hand-edited\n')
+
+            code, _, err = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 2)
+            self.assertIn('steps.md', err)
+            self.assertEqual((root / 'spec' / 'spurgear' / 'steps.md').read_text(),
+                             'hand-edited\n')
+            self.assertFalse((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+
+    def test_compile_force_overwrites_both(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'draft-2\n'},
+                              placed={'a_test.go': 'draft-1\n'}, steps='# steps-2\n')
+            (root / 'spec' / 'spurgear' / 'steps.md').write_text('# steps-1\n')
+            git_init(root)
+            git_commit_all(root)
+            (root / 'spec' / 'spurgear' / 'steps.md').write_text('hand-edited\n')
+            (root / 'proof' / 'spurgear' / 'a_test.go').write_text('hand-edited\n')
+
+            code, _, _ = run_stage(root, 'spurgear', 'compile', '--force')
+            self.assertEqual(code, 0)
+            self.assertEqual((root / 'spec' / 'spurgear' / 'steps.md').read_text(),
+                             '# steps-2\n')
+            self.assertEqual((root / 'proof' / 'spurgear' / 'a_test.go').read_text(),
+                             'draft-2\n')
+
+    def test_compile_dry_run_reports_both_and_touches_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'}, steps='# steps\n')
+            code, out, _ = run_stage(root, 'spurgear', 'compile', '--dry-run')
+            self.assertEqual(code, 0)
+            self.assertEqual(out.count('would write'), 2)
+            self.assertIn('steps.md', out)
+            self.assertIn('a_test.go', out)
+            self.assertFalse((root / 'spec' / 'spurgear' / 'steps.md').exists())
+            self.assertFalse((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+            self.assertFalse((root / '.tmp' / 'stage').exists())
+
+    def test_compile_writes_both_receipts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'}, steps='# steps\n')
+            code, _, _ = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 0)
+            self.assertTrue((root / '.tmp' / 'stage' / 'spurgear.steps.json').exists())
+            self.assertTrue((root / '.tmp' / 'stage' / 'spurgear.proof.json').exists())
+
+            code_steps, out_steps, _ = run_stage(root, 'spurgear', 'steps')
+            self.assertEqual(code_steps, 0)
+            self.assertIn('unchanged', out_steps)
+            self.assertNotIn('wrote', out_steps)
+
+    def test_compile_indexes_proof_unless_no_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'},
+                              placed={'stale_test.go': 'stale\n'}, steps='# steps\n')
+            git_init(root)
+            git_commit_all(root)
+
+            code, _, _ = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 0)
+            staged = subprocess.run(
+                ['git', 'diff', '--cached', '--name-only'], cwd=str(root),
+                capture_output=True, text=True, check=True).stdout
+            self.assertIn('proof/spurgear/a_test.go', staged)
+            self.assertIn('proof/spurgear/stale_test.go', staged)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'}, steps='# steps\n')
+            git_init(root)
+            git_commit_all(root)
+
+            code, _, _ = run_stage(root, 'spurgear', 'compile', '--no-index')
+            self.assertEqual(code, 0)
+            staged = subprocess.run(
+                ['git', 'diff', '--cached', '--name-only'], cwd=str(root),
+                capture_output=True, text=True, check=True).stdout
+            self.assertEqual(staged.strip(), '')
+
+    def test_compile_proof_failure_rolls_back_placed_steps(self):
+        real_replace = os.replace
+
+        def fail_on_proof(src, dst):
+            if os.sep + 'proof' + os.sep in str(dst):
+                raise OSError('synthetic proof failure')
+            return real_replace(src, dst)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'}, steps='# steps-2\n')
+            (root / 'spec' / 'spurgear' / 'steps.md').write_text('# steps-1\n')
+            with mock.patch.object(MODULE.os, 'replace', side_effect=fail_on_proof):
+                code, _, err = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 2)
+            self.assertTrue(err.strip())
+            self.assertEqual((root / 'spec' / 'spurgear' / 'steps.md').read_text(),
+                             '# steps-1\n')
+            self.assertFalse((root / 'proof' / 'spurgear' / 'a_test.go').exists())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'new\n'}, steps='# steps-2\n')
+            with mock.patch.object(MODULE.os, 'replace', side_effect=fail_on_proof):
+                code, _, err = run_stage(root, 'spurgear', 'compile')
+            self.assertEqual(code, 2)
+            self.assertFalse((root / 'spec' / 'spurgear' / 'steps.md').exists())
+
+    def test_run_flag_rejected_for_compile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_root(tmp, draft={'a_test.go': 'x\n'}, steps='# steps\n')
+            with self.assertRaises(SystemExit) as cm:
+                MODULE.main(['stage.py', '--root', str(root), 'spurgear', 'compile', '--run'])
+            self.assertEqual(cm.exception.code, 2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- one command places the compile stage's step list and proof, refusing both if either would refuse
- #52's step 4 staged only the proof, so `check_compile.py` read a stale or missing `spec/<gear>/steps.md` mid-loop
- a red round now leaves the drafted step list placed, contained by the dirty-destination refusal
