### PR TITLE
fold the two fixed pre-steps into their scripts

### DIFF
--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -18,36 +18,34 @@ the pipeline exists to make trustworthy.
 
 1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Run
    `python3 .claude/skills/generate-gear/preflight.py <gear> --stage emit` and fix every `[FAIL]`
-   before drafting; it verifies the engines, the go toolchain and the API database so a broken
-   environment fails here instead of mid-run.
+   before drafting; it verifies the engines, the go toolchain and the API database, and runs
+   `check_compile.py <gear>` as its `steps-current` row, so a broken environment or a stale
+   step list fails here instead of mid-run. If `steps-current` fails, run `/compile-gear <gear>`
+   first.
 
-2. **Check the inputs are current.** Run
-   `python3 .claude/skills/generate-gear/check_compile.py <gear>`. Emitting from a stale step list
-   wastes the round. If it fails, run `/compile-gear <gear>` first.
-
-3. **Draft.** Spawn a subagent with the standard drafting prompt: run
+2. **Draft.** Spawn a subagent with the standard drafting prompt: run
    `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear>` and pass its printed
    output to the subagent unchanged. It writes `.tmp/<gear>.generated.py`. Add no per-gear
    hints; anything the drafter needs belongs in the step list.
 
-4. **Gate.** Run `python3 .claude/skills/generate-gear/run_gates.py <gear> > .tmp/<gear>.gates.txt`
+3. **Gate.** Run `python3 .claude/skills/generate-gear/run_gates.py <gear> > .tmp/<gear>.gates.txt`
    from the repo root and read the file for the verdict. The stored copy is also what a retry round
    hands back to the drafter. It runs all seven checks below plus the advisory novel-type report,
    and prints one verdict. Exit 0 = every gate that ran passed; exit 1 = a gate failed; exit 2 = a
    setup error (missing input, missing stubs, unreachable API database) that no new draft can fix.
 
-5. **Diagnose and loop.** The runner prints a first-pass fault classification; confirm the rows it
-   marks NEEDS JUDGMENT against the table below. An emit fault goes back to step 3, up to about
+4. **Diagnose and loop.** The runner prints a first-pass fault classification; confirm the rows it
+   marks NEEDS JUDGMENT against the table below. An emit fault goes back to step 2, up to about
    three rounds: re-render the prompt with `python3 .claude/skills/generate-gear/render_prompt.py
    emit-gear <gear> --failure-file .tmp/<gear>.gates.txt` and hand the printed output to the
    drafter unchanged. The renderer appends the stored gate report verbatim; never paste failure
    text into the prompt by hand. A compile fault, or an exit 2, stops the run.
 
-6. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> module` from
+5. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> module` from
    the repo root. It puts `.tmp/<gear>.generated.py` at `lib/geargen/<gear>.py` and reports what
    moved. This writes a file only; it does not commit, push, or touch Fusion's add-in directory.
 
-7. **Report.** State the gate results and every step that was thin or wrong.
+6. **Report.** State the gate results and every step that was thin or wrong.
 
 ## Gates
 

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -83,7 +83,10 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
      attributable to the spec, which is the whole point. When a regen reveals a gap, fix the
      **spec/playbook** and re-run the **same** standard prompt — never patch the prompt.
    - **Launch in the background and let the watcher do the waiting.** Clear the previous run's
-     telemetry first — `rm -f .tmp/<gear>.progress.log .tmp/<gear>.progress.log.watch` — then run
+     telemetry first — run
+     `python3 .claude/skills/generate-gear/watch_progress.py .tmp/<gear>.progress.log --clear`,
+     which removes the log and its `.watch` sidecar and refuses (exit 5) if the log was written in
+     the last minute, since that suggests a run still in flight — then run
      the subagent as a background task (the standard prompt makes it append one milestone line per
      phase). Do **not** poll the log by hand. Wait with one foreground call, Bash timeout 600000:
 
@@ -99,7 +102,8 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
      (e.g. an unanswered approval gate) — stop and surface it; **2** silent past the stall window —
      stop the run, relaunch once, and only then involve the user; **3** past the 45-minute ceiling
      with the run still alive — stop it and surface the elapsed time; **5** the progress log is not
-     in the state the watch assumed — inspect before relaunching. The script carries SKILL.md's
+     in the state the watch assumed — inspect before relaunching, and clear a confirmed-stale log
+     with the same script's `--clear` before the relaunch. The script carries SKILL.md's
      windows as its defaults (`--launch-window 300`, `--stall-window 600`, `--max-runtime 2700`);
      override one only with a stated reason.
 

--- a/.claude/skills/generate-gear/preflight.py
+++ b/.claude/skills/generate-gear/preflight.py
@@ -12,7 +12,10 @@ It reports, it does not repair. The only thing it writes is `.tmp/` under the ro
 every stage needs that directory and creating it is cheaper than reporting it missing. It
 never clones the stubs, never installs pyright, never runs `go test`, and never touches the
 network. A check that cannot be answered without doing one of those says so and leaves the
-work to the tool that owns it.
+work to the tool that owns it. The one heavier thing it runs is `check_compile.py`, on the emit
+stage only, because emitting from a stale step list wastes a whole drafting round and the tool
+that owns that verdict is cheap enough to consult here — it still needs no network and runs no
+`go test`.
 
 Resolution rules are borrowed, never re-derived: the engine directories resolve exactly as
 `proof/run.sh` resolves them ($SKETCH_DIR / $DECAD_DIR, else siblings of the main checkout),
@@ -42,6 +45,8 @@ if HERE not in sys.path:
 
 GEAR_NAME = re.compile(r'[a-z][a-z0-9_]*\Z')  # same spelling stage.py accepts
 TIMEOUT = 10  # seconds; every subprocess here is a version probe
+# The one exception: check_compile.py parses the proof and queries the API database.
+CHECK_COMPILE_TIMEOUT = 300
 
 OK = 'ok'
 WARN = 'warn'
@@ -84,16 +89,16 @@ class Context(object):
 
 
 # --- subprocess helpers --------------------------------------------------------------------
-def _run(argv, cwd=None):
+def _run(argv, cwd=None, timeout=TIMEOUT):
     """Run a probe. Returns (ok, first line of output or the reason it failed)."""
     try:
-        proc = subprocess.run(argv, capture_output=True, text=True, timeout=TIMEOUT, cwd=cwd)
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd)
     except FileNotFoundError:
         return False, '%s is not on PATH' % argv[0]
     except OSError as exc:
         return False, '%s could not be run (%s)' % (argv[0], exc)
     except subprocess.TimeoutExpired:
-        return False, '%s did not answer within %ds' % (argv[0], TIMEOUT)
+        return False, '%s did not answer within %ds' % (argv[0], timeout)
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or '').strip().splitlines()
         return False, '%s exited %d%s' % (
@@ -252,6 +257,56 @@ def check_steps(ctx):
     return FAIL, 'no step list at %s; run /compile-gear %s first' % (path, ctx.gear)
 
 
+def _first_line_with(text, needle):
+    """The first line holding `needle`, else the last nonempty line, else ''."""
+    lines = [l.strip() for l in (text or '').splitlines() if l.strip()]
+    for line in lines:
+        if needle in line:
+            return line
+    return lines[-1] if lines else ''
+
+
+def _run_check_compile(ctx):
+    """Run the freshness gate the way `/emit-gear` used to run it by hand.
+
+    `check_compile.py` resolves every path it reads against the working directory, so it must
+    be started from the repo root. It parses the proof and queries the API database, which the
+    10s probe timeout does not cover; this one is generous enough to fail rather than hang.
+    Kept as its own function so a test can stand in for the whole subprocess."""
+    return subprocess.run(
+        [sys.executable, os.path.join(HERE, 'check_compile.py'), ctx.gear],
+        capture_output=True, text=True, timeout=CHECK_COMPILE_TIMEOUT, cwd=ctx.root)
+
+
+def check_steps_current(ctx):
+    """Whether the step list still matches the spec it was compiled from.
+
+    This is the one row that runs a real tool rather than a version probe. It stands where
+    `/emit-gear` step 2 stood, and it costs the round nothing: that step ran the same command
+    a moment later anyway."""
+    if not os.path.isfile(ctx.spec('steps.md')):
+        return SKIP, 'no step list, which the steps row already reports'
+
+    try:
+        proc = _run_check_compile(ctx)
+    except subprocess.TimeoutExpired:
+        return FAIL, ('check_compile.py did not finish within %ds; run it by hand to see where it '
+                      'stopped' % CHECK_COMPILE_TIMEOUT)
+    except OSError as exc:
+        return FAIL, 'check_compile.py could not be run (%s)' % exc
+
+    if proc.returncode == 0:
+        return OK, 'check_compile.py: step list is current'
+    if proc.returncode == 1:
+        return FAIL, ('check_compile.py found BLOCKING findings (%s); run /compile-gear %s first'
+                      % (_first_line_with(proc.stdout, 'BLOCKING'), ctx.gear))
+    if proc.returncode == 2:
+        return FAIL, ('check_compile.py exit 2 (%s): an input is missing or unreadable'
+                      % _first_line_with(proc.stderr or proc.stdout, ''))
+    return FAIL, ('check_compile.py exited %d (%s), which is not one of its documented codes'
+                  % (proc.returncode, _first_line_with(proc.stderr or proc.stdout, '')))
+
+
 def check_proof_dir(ctx):
     path = ctx.path('proof', ctx.gear)
     if not os.path.isdir(path):
@@ -342,6 +397,7 @@ STAGES = {
     'emit': COMMON + (
         ('steps', check_steps, False),
         ('proof-dir', check_proof_dir, False),
+        ('steps-current', check_steps_current, False),
         ('api-db', check_api_db, False),
         ('contract-manifest', check_contract_manifest, False),
         ('framework', check_framework, False),

--- a/.claude/skills/generate-gear/run_gates.py
+++ b/.claude/skills/generate-gear/run_gates.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Run the whole gate battery for one gear and print one verdict.
 
-It serves both stages that validate a candidate module: `/emit-gear` step 4 and
+It serves both stages that validate a candidate module: `/emit-gear` step 3 and
 `/generate-gear` step 5. Both used to ask the orchestrating LLM to run the gate commands one
 at a time, then (at the emit stage) classify any failure by hand against the fault table in
 `.claude/skills/emit-gear/SKILL.md`. Every part of that is mechanical — the commands are

--- a/.claude/skills/generate-gear/test_preflight.py
+++ b/.claude/skills/generate-gear/test_preflight.py
@@ -55,6 +55,12 @@ def make_repo(root, gear=GEAR):
     return root
 
 
+def completed(returncode, stdout='', stderr=''):
+    """What the check_compile.py seam hands back, without running it."""
+    return subprocess.CompletedProcess(args=['check_compile.py'], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
 def stub_defs(root):
     """A directory that satisfies fusion_stubs.defs_at()."""
     defs = root / 'defs'
@@ -129,7 +135,8 @@ class EmitStageTests(Fixture):
         (self.root / 'spec' / GEAR / 'steps.md').write_text('# steps\n')
         (self.root / 'proof' / GEAR / 'x.go').write_text('package proof\n')
 
-        with mock.patch.dict(os.environ, self.resolved()):
+        with mock.patch.dict(os.environ, self.resolved()), \
+                mock.patch.object(MODULE, '_run_check_compile', return_value=completed(0)):
             code, out = self.run_cli(GEAR, '--stage', 'emit', '--root', str(self.root))
 
         self.assertEqual(code, 0, out)
@@ -148,6 +155,91 @@ class EmitStageTests(Fixture):
 
         self.assertEqual(status, MODULE.SKIP)
         self.assertIn('prose-checked', detail)
+
+
+class StepsCurrentTests(Fixture):
+    """The emit stage's freshness row: it stands where `/emit-gear` step 2 stood, so it must
+    reach the same verdicts check_compile.py reaches, and it must belong to no other stage."""
+
+    def steps(self):
+        (self.root / 'spec' / GEAR / 'steps.md').write_text('# steps\n')
+
+    def test_only_the_emit_stage_runs_it(self):
+        self.assertIn('steps-current', [k for k, _, _ in MODULE.plan('emit')])
+        self.assertNotIn('steps-current', [k for k, _, _ in MODULE.plan('compile')])
+        self.assertNotIn('steps-current', [k for k, _, _ in MODULE.plan('generate')])
+        self.assertIn('steps-current', [k for k, _, _ in MODULE.plan('all')])
+
+    def test_a_missing_step_list_is_skipped_here_and_failed_by_the_steps_row(self):
+        status, detail = MODULE.check_steps_current(self.ctx)
+
+        self.assertEqual(status, MODULE.SKIP)
+        self.assertIn('steps row', detail)
+
+        with mock.patch.dict(os.environ, self.resolved()):
+            results = MODULE.run_checks(self.ctx, 'emit')
+        by_key = {r['key']: r for r in results}
+        self.assertEqual(by_key['steps-current']['status'], MODULE.SKIP)
+        self.assertEqual(by_key['steps']['status'], MODULE.FAIL)
+
+    def test_exit_zero_is_ok(self):
+        self.steps()
+
+        with mock.patch.object(MODULE, '_run_check_compile',
+                               return_value=completed(0, 'compile check: OK (12 steps)\n')):
+            status, detail = MODULE.check_steps_current(self.ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertIn('current', detail)
+
+    def test_blocking_findings_fail_and_name_the_drift(self):
+        self.steps()
+        report = ('coverage: spec/x.md — 3/4 lines claimed by a step\n'
+                  'compile check: BLOCKING (1)\n'
+                  '  spec/testgear/instructions.md has changed since the step list was compiled\n')
+
+        with mock.patch.object(MODULE, '_run_check_compile', return_value=completed(1, report)):
+            status, detail = MODULE.check_steps_current(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('compile check: BLOCKING (1)', detail)
+        self.assertIn('run /compile-gear %s' % GEAR, detail)
+        self.assertNotIn('coverage:', detail)
+
+    def test_exit_two_fails_as_a_setup_error(self):
+        self.steps()
+
+        with mock.patch.object(MODULE, '_run_check_compile',
+                               return_value=completed(2, '', 'no spec/testgear/steps.md\n')):
+            status, detail = MODULE.check_steps_current(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('exit 2', detail)
+        self.assertIn('no spec/testgear/steps.md', detail)
+
+    def test_a_timeout_fails_the_row_rather_than_raising(self):
+        self.steps()
+        timed_out = subprocess.TimeoutExpired(cmd='check_compile.py',
+                                              timeout=MODULE.CHECK_COMPILE_TIMEOUT)
+
+        with mock.patch.object(MODULE, '_run_check_compile', side_effect=timed_out):
+            status, detail = MODULE.check_steps_current(self.ctx)
+
+        self.assertEqual(status, MODULE.FAIL)
+        self.assertIn('did not finish', detail)
+
+    def test_the_command_runs_the_skill_s_script_from_the_repo_root(self):
+        self.steps()
+
+        with mock.patch.object(MODULE.subprocess, 'run', return_value=completed(0)) as run:
+            MODULE.check_steps_current(self.ctx)
+
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[0], MODULE.sys.executable)
+        self.assertEqual(argv[1], os.path.join(MODULE.HERE, 'check_compile.py'))
+        self.assertEqual(argv[2], GEAR)
+        self.assertEqual(run.call_args[1]['cwd'], str(self.root))
+        self.assertEqual(run.call_args[1]['timeout'], MODULE.CHECK_COMPILE_TIMEOUT)
 
 
 class TmpDirTests(Fixture):

--- a/.claude/skills/generate-gear/test_watch_progress.py
+++ b/.claude/skills/generate-gear/test_watch_progress.py
@@ -449,5 +449,124 @@ class RenderAndMainTests(unittest.TestCase):
         self.assertEqual(code, MODULE.EXIT_DONE)
 
 
+class ClearTests(unittest.TestCase):
+    """`--clear` replaces the `rm -f` /generate-gear step 4 used to prescribe: it must be
+    safe to run when there is nothing to clear, and refuse when a run may still be live."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.dir = self._tmpdir.name
+        self.log_path = os.path.join(self.dir, 'sample.progress.log')
+        self.anchor = MODULE.anchor_path(self.log_path)
+
+    def _write_with_mtime(self, lines, mtime):
+        with open(self.log_path, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        os.utime(self.log_path, (mtime, mtime))
+
+    def _write_anchor(self, epoch):
+        with open(self.anchor, 'w') as f:
+            f.write('%d\n' % epoch)
+
+    def test_52_clear_removes_an_old_log_and_its_sidecar(self):
+        clock = FakeClock(start=1755990000)
+        self._write_with_mtime(['%d start' % (clock.t - 3600)], clock.t - 3600)
+        self._write_anchor(int(clock.t) - 3600)
+
+        out = io.StringIO()
+        code = MODULE.clear(self.log_path, clock, out)
+
+        self.assertEqual(code, MODULE.EXIT_DONE)
+        self.assertFalse(os.path.exists(self.log_path))
+        self.assertFalse(os.path.exists(self.anchor))
+        self.assertIn('removed: %s' % self.log_path, out.getvalue())
+        self.assertIn('removed: %s' % self.anchor, out.getvalue())
+
+    def test_53_clearing_a_clean_state_succeeds(self):
+        clock = FakeClock(start=1755990000)
+        out = io.StringIO()
+
+        code = MODULE.clear(self.log_path, clock, out)
+
+        self.assertEqual(code, MODULE.EXIT_DONE)
+        self.assertIn('absent:  %s' % self.log_path, out.getvalue())
+        self.assertIn('absent:  %s' % self.anchor, out.getvalue())
+
+    def test_54_orphan_sidecar_is_removed(self):
+        clock = FakeClock(start=1755990000)
+        self._write_anchor(int(clock.t) - 3600)
+
+        out = io.StringIO()
+        code = MODULE.clear(self.log_path, clock, out)
+
+        self.assertEqual(code, MODULE.EXIT_DONE)
+        self.assertFalse(os.path.exists(self.anchor))
+
+    def test_55_a_fresh_log_is_refused(self):
+        clock = FakeClock(start=1755990000)
+        self._write_with_mtime(['%d start' % clock.t], clock.t)
+        self._write_anchor(int(clock.t))
+
+        out = io.StringIO()
+        code = MODULE.clear(self.log_path, clock, out)
+
+        self.assertEqual(code, MODULE.EXIT_ANOMALY)
+        self.assertTrue(os.path.exists(self.log_path))
+        self.assertTrue(os.path.exists(self.anchor))
+        self.assertIn('--force', out.getvalue())
+
+    def test_56_force_clears_a_fresh_log(self):
+        clock = FakeClock(start=1755990000)
+        self._write_with_mtime(['%d start' % clock.t], clock.t)
+        self._write_anchor(int(clock.t))
+
+        out = io.StringIO()
+        code = MODULE.main([self.log_path, '--clear', '--force'], clock=clock, out=out)
+
+        self.assertEqual(code, MODULE.EXIT_DONE)
+        self.assertFalse(os.path.exists(self.log_path))
+        self.assertFalse(os.path.exists(self.anchor))
+
+    def test_57_watch_only_flags_are_a_usage_error(self):
+        for extra in (['--since', '123'], ['--reset'], ['--allow-stale'], ['--once']):
+            with self.subTest(extra=extra[0]):
+                self._write_with_mtime(['1 start'], 1)
+                err = io.StringIO()
+                with mock.patch.object(MODULE.sys, 'stderr', err):
+                    code = MODULE.main([self.log_path, '--clear'] + extra,
+                                       clock=FakeClock(start=1755990000), out=io.StringIO())
+
+                self.assertEqual(code, MODULE.EXIT_USAGE)
+                self.assertTrue(err.getvalue())
+                self.assertTrue(os.path.exists(self.log_path))
+
+    def test_58_cleared_stale_log_no_longer_makes_the_next_watch_anomalous(self):
+        # The original bug: a forgotten `rm -f` left last round's log in place, and the
+        # next watch read it as a stale pre-existing log and returned ANOMALY.
+        anchor_epoch = 1755990000
+        clock = FakeClock(start=anchor_epoch)
+        stale_epoch = anchor_epoch - 3600
+        self._write_with_mtime(['%d start' % stale_epoch, '%d done' % stale_epoch], stale_epoch)
+        self._write_anchor(stale_epoch)
+
+        self.assertEqual(MODULE.main([self.log_path, '--clear'], clock=clock, out=io.StringIO()),
+                         MODULE.EXIT_DONE)
+
+        with mock.patch.object(MODULE.time, 'sleep') as real_sleep:
+            # The watch that follows writes a fresh anchor and finds nothing stale to trip on.
+            first = MODULE.watch(self.log_path, windows(launch=300, budget=0), clock,
+                                 io.StringIO())
+            self.assertNotEqual(first, MODULE.EXIT_ANOMALY)
+            self.assertEqual(first, MODULE.EXIT_RUNNING)
+
+            clock.t += 400
+            second = MODULE.watch(self.log_path, windows(launch=300, budget=0), clock,
+                                  io.StringIO())
+
+        self.assertEqual(second, MODULE.EXIT_NO_START)
+        self.assertFalse(real_sleep.called)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/.claude/skills/generate-gear/watch_progress.py
+++ b/.claude/skills/generate-gear/watch_progress.py
@@ -10,6 +10,14 @@ poll it by hand: call it once after launching the subagent, and if it exits
 with status RUNNING, call the identical command again — one foreground call
 per wait, repeated until the exit code is not RUNNING.
 
+`--clear` is the other half of that contract, and it does not watch anything. A
+previous round leaves its log and its `.watch` sidecar behind, and a watch that
+meets one reports ANOMALY, so the skill has to clear both before it launches.
+Run `watch_progress.py <log> --clear` to remove the pair. Clearing an already
+clean state is a success, so the skill can run it unconditionally; a log written
+within the last minute is refused instead, because it probably belongs to a run
+still in flight, and `--force` is the override.
+
 Exit codes:
   0  DONE         a `done` heartbeat is present; the subagent finished.
   1  NO_START     no heartbeat at all, and the launch window has passed.
@@ -20,6 +28,14 @@ Exit codes:
   5  ANOMALY      the log vanished/became unreadable mid-watch, or a stale
                   pre-existing log was detected at first read.
   64 USAGE        bad arguments.
+
+In `--clear` mode only three of those codes can appear:
+  0  the log and its sidecar are gone, whether this call removed them or they
+     were already absent.
+  5  refused: the log was written within the last minute, so a run may still be
+     using it. Re-run with `--force` once that is ruled out.
+  64 usage: `--clear` given with an argument that only a watch can act on
+     (`--since`, `--reset`, `--allow-stale`, `--once`).
 """
 import argparse
 import collections
@@ -220,6 +236,40 @@ def reset_anchor(log_path):
         pass
 
 
+def _remove(path, out):
+    """Remove one path and say what happened. Never raises."""
+    try:
+        os.remove(path)
+    except OSError:
+        out.write('absent:  %s\n' % path)
+        return
+    out.write('removed: %s\n' % path)
+
+
+def clear(log_path, clock, out, force=False):
+    """Delete the progress log and its anchor sidecar, so the next watch starts clean.
+
+    A log touched within STALE_SLACK of now is refused rather than deleted: it most
+    likely belongs to a run still in flight, and taking its log away is the one way
+    this mode could destroy something. `--force` says the freshness is understood."""
+    try:
+        mtime = os.stat(log_path).st_mtime
+    except OSError:
+        mtime = None
+
+    if mtime is not None and not force:
+        age = clock.now() - mtime
+        if age <= STALE_SLACK:
+            out.write('watch_progress: refusing to clear %s — written %ds ago, so a run may still '
+                      'be appending to it; re-run with --force if it is not.\n'
+                      % (log_path, max(0, int(age))))
+            return EXIT_ANOMALY
+
+    _remove(log_path, out)
+    _remove(anchor_path(log_path), out)
+    return EXIT_DONE
+
+
 def is_stale_log(state, summary, reference):
     """A leftover log from a previous run predates this watch. Pure."""
     if not state.exists or not state.lines:
@@ -408,6 +458,8 @@ def build_parser():
     parser.add_argument('--since', type=int, default=None)
     parser.add_argument('--reset', action='store_true')
     parser.add_argument('--allow-stale', action='store_true')
+    parser.add_argument('--clear', action='store_true')
+    parser.add_argument('--force', action='store_true')
     return parser
 
 
@@ -429,6 +481,19 @@ def main(argv, clock=None, out=None):
         if value < 0:
             sys.stderr.write('watch_progress: %s must not be negative\n' % name)
             return EXIT_USAGE
+
+    if args.clear:
+        # Everything below only means something inside a watch; silently ignoring one of
+        # these would leave the caller believing a watch option took effect.
+        conflicting = [name for name, given in (('--since', args.since is not None),
+                                                ('--reset', args.reset),
+                                                ('--allow-stale', args.allow_stale),
+                                                ('--once', args.once)) if given]
+        if conflicting:
+            sys.stderr.write('watch_progress: --clear does not watch, so %s cannot apply\n'
+                             % ' and '.join(conflicting))
+            return EXIT_USAGE
+        return clear(args.log, clock, out, force=args.force)
 
     budget = 0 if args.once else args.budget
 


### PR DESCRIPTION
- A pre-step run by hand is a pre-step that eventually gets skipped, so both become tested script behavior.
- `watch_progress.py --clear` takes over generate-gear step 4's `rm -f`, refusing a log written in the last minute.
- `preflight.py --stage emit` runs `check_compile.py` as a `steps-current` row, retiring emit-gear step 2.
