### PR TITLE
route compiled gears to emit, shrink its model

### DIFF
--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -29,6 +29,12 @@ the pipeline exists to make trustworthy.
    `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear>` and pass its printed
    output to the subagent unchanged. It writes `.tmp/<gear>.generated.py`. Add no per-gear
    hints; anything the drafter needs belongs in the step list.
+   Spawn the drafter on a small model — pass the Agent tool's `model` option (e.g. `haiku`)
+   when the harness offers one, and skip the option where it does not. This stage is
+   transcription against a fixed API, and step 4's gates, not the drafter, judge the output.
+   If small-model drafts fail the gates with emit faults in two consecutive rounds, respawn
+   the next round on the session's default model. The compile-gear drafter stays on the
+   default model; that stage interprets prose, only this one transcribes.
 
 4. **Gate.** Run `python3 .claude/skills/generate-gear/run_gates.py <gear>`. It runs all seven
    checks below plus the advisory novel-type report, and prints one verdict. Exit 0 = every gate

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generate-gear
-description: Generate (or regenerate) a gear generator implementation `lib/geargen/<gear>.py` from its natural-language spec `spec/<gear>/instructions.md` plus the shared `PLAYBOOK.md`, using the spec as the SOLE source of truth — no reference implementation is consulted during generation. Use when asked to (re)generate gear code from a spec, or to check that a spec is complete enough to drive generation on its own. Args: optional `<gear>` name (default `spurgear`).
+description: Generate (or regenerate) a gear generator implementation `lib/geargen/<gear>.py` from its natural-language spec `spec/<gear>/instructions.md` plus the shared `PLAYBOOK.md`, using the spec as the SOLE source of truth — no reference implementation is consulted during generation. Use when asked to (re)generate gear code from a spec, or to check that a spec is complete enough to drive generation on its own. For a gear that already has a compiled step list `spec/<gear>/steps.md`, use `/compile-gear` + `/emit-gear` instead; this skill is for gears without one, or when named explicitly. Args: optional `<gear>` name (default `spurgear`).
 ---
 
 # Generate gear code from a spec
@@ -8,6 +8,13 @@ description: Generate (or regenerate) a gear generator implementation `lib/gearg
 This repo generates gear implementations from natural-language design docs:
 `spec/<gear>/instructions.md` (the spec) → `lib/geargen/<gear>.py` (the implementation). This skill
 runs that generation as a repeatable, agent-driven workflow.
+
+**Check for a compiled step list first.** If `spec/<gear>/steps.md` exists, stop and use the
+compile+emit pipeline instead: `/emit-gear <gear>` when
+`python3 .claude/skills/generate-gear/check_compile.py <gear>` passes, `/compile-gear <gear>`
+first when it does not. That pipeline transcribes from the checked step list rather than
+re-interpreting the prose spec and playbook every round. Proceed with this skill only when no
+step list exists, or when the user asked for this skill by name.
 
 **The spec is the sole source of truth.** Generation reads only the spec, the shared playbook,
 and the framework files. It does **not** read any existing `lib/geargen/<gear>.py` — if a spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@ Gear implementations in `lib/geargen/` are generated from the specs in `spec/`. 
 `.claude/skills/` own how that generation runs. This file covers the one thing that happens
 outside a skill run.
 
+## Which skill regenerates a gear
+
+A gear that has a compiled step list `spec/<gear>/steps.md` is regenerated with the
+compile+emit pipeline: run `/emit-gear <gear>` when
+`python3 .claude/skills/generate-gear/check_compile.py <gear>` passes, and `/compile-gear <gear>`
+first when it does not. `/generate-gear` re-interprets the full prose spec and playbook on
+every round, so it is only for a gear with no step list yet, or when the user asks for it by
+name.
+
 ## When Fusion gives a verdict
 
 Loading a gear into Fusion is the only check that sees the real thing, and it happens with no


### PR DESCRIPTION
- A gear with a compiled `spec/<gear>/steps.md` regenerates via `/compile-gear` + `/emit-gear`, not `/generate-gear`.
- The emit drafter spawns on a small model, reverting to the default after two rounds of emit faults.
- Docs only: no script, prompt template, or gate changed.

## Merge order

- Batch-mate PRs edit other steps of these same SKILL.md files, so whichever merges later should rebase first.
