### PR TITLE
prefer show over members in the drafting prompts

### DIFF
--- a/.claude/skills/compile-gear/prompt.md
+++ b/.claude/skills/compile-gear/prompt.md
@@ -45,13 +45,15 @@ choose between are all mentions, not requirements. Mark each with the exemption 
 own line in the step that mentions it, `<!-- check-step-calls: ignore nameOne nameTwo -->`, and
 say in the step's prose why the mention is not a requirement.
 
-**Before naming any `adsk.*` call**, ask the `fusion:query-api` skill about it. Two questions
-carry most of the work: `members <Class>` lists everything a class offers, inherited members
-included, each with the class that declares it, which is how you find out whether the class you
-are calling on really has the member; and `show <Class>.<member>` gives one member's signature
-and documentation. Write the call with the arguments that signature asks for. If the spec names
-a call the API does not have, or passes an argument of the wrong type, say so in your report and
-do not quietly correct it.
+**Before naming any `adsk.*` call**, ask the `fusion:query-api` skill about it. One question
+carries most of the work: `show <Class>.<member>` confirms in a few lines that the class you are
+calling on really has the member — it resolves members declared on any base and names the class
+that declares each — and gives its signature and documentation. Write the call with the arguments
+that signature asks for. When `show` reports no match or returns a candidate list, the name as
+written does not exist; only then ask `members <Class>`, which lists everything the class offers,
+inherited members included, to find what the spec meant. If the spec names a call the API does
+not have, or passes an argument of the wrong type, say so in your report and do not quietly
+correct it.
 
 **The proof is a Go test** in package `{{gear}}_test`, spread over as many files as the split
 needs, with one function per step. Every step function, 2D or 3D alike, is declared as a

--- a/.claude/skills/emit-gear/prompt.md
+++ b/.claude/skills/emit-gear/prompt.md
@@ -12,14 +12,16 @@ rules the steps cite by anchor; and the framework you build on and must not reim
 or any previous draft. The step list is deliberately the only description of the gear you get. If
 a step is unclear, record it as a defect in your report and make your best attempt.
 
-**Before writing any `adsk.*` call**, ask the `fusion:query-api` skill about it. Two questions
-carry most of the work: `members <Class>` lists everything a class offers, inherited members
-included, each with the class that declares it, which is how you find out whether the class you
-are calling on really has the member; and `show <Class>.<member>` gives one member's signature
-and documentation. Pass what the signature asks for. Where it says `ValueInput`, a bare number
-raises. Where it says `ObjectCollection`, a Python list raises. Where it says `Point3D`, a
-`SketchPoint` raises. If the step list names a call the API does not have, report it and do not
-quietly correct it.
+**Before writing any `adsk.*` call**, ask the `fusion:query-api` skill about it. One question
+carries most of the work: `show <Class>.<member>` confirms in a few lines that the class you are
+calling on really has the member — it resolves members declared on any base and names the class
+that declares each — and gives its signature and documentation. Pass what the signature asks
+for. Where it says `ValueInput`, a bare number raises. Where it says `ObjectCollection`, a
+Python list raises. Where it says `Point3D`, a `SketchPoint` raises. When `show` reports no
+match or returns a candidate list, the name as written does not exist; only then ask
+`members <Class>`, which lists everything the class offers, inherited members included, to find
+what the step list meant. If the step list names a call the API does not have, report it and do
+not quietly correct it.
 
 **Do every step.** A step you cannot finish is a defect to report, never a comment left in the
 file and never a silent omission.


### PR DESCRIPTION
- Ask `show <Class>.<member>` per call in the compile and emit prompts; `members` is now the fallback.
- Shrinks per-call lookup output; `show` resolves inherited members, so existence checking holds.
- Every call is still queried; all gates unchanged.

## Notes

- Conflicts textually with the `refactor-emit-query-scope` PR over the same emit paragraph.
- Second merger must combine both: that PR's scoping opening plus this show-first guidance.
- `[PB-API-LOOKUP]` still lists `members` first; a follow-up carries the provenance re-stamp.
