### PR TITLE
continue the same drafter on fix rounds

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -117,11 +117,22 @@ proof is where the next reader is looking for the missing check.
    has to be able to compile a gear that has no implementation yet.
 
 6. **Diagnose and loop.** Classify any failure with the table below. A draft fault goes back to
-   step 3, up to about three rounds: re-render the prompt with
-   `python3 .claude/skills/generate-gear/render_prompt.py compile-gear <gear> --failure-file
-   .tmp/<gear>.compile-gates.txt` and hand the printed output to the drafter unchanged. The
-   renderer appends the stored gate report verbatim; never paste failure text into the prompt by
-   hand. A prose fault stops the run.
+   the drafter, up to about three rounds in total. A prose fault stops the run.
+
+   A draft fault does not change any input file, so the drafter that produced it still holds
+   every input in context. Send it the stored gate report `.tmp/<gear>.compile-gates.txt`
+   verbatim with `SendMessage` and let it revise `.tmp/<gear>.steps.md` and
+   `.tmp/<gear>-proof/`; never paste failure text edited by hand, and do not tell the drafter to
+   re-read inputs it has already read.
+
+   Spawn a fresh drafting subagent (a full step 3) only when one of these holds: this is the
+   first round; an input file (the spec, `fusion.md`, the playbook, or a harness package)
+   changed since the drafter read it; the same check fails on the same step in two consecutive
+   continued rounds; or the drafter is no longer reachable. A fresh retry round re-renders the
+   prompt with `python3 .claude/skills/generate-gear/render_prompt.py compile-gear <gear>
+   --failure-file .tmp/<gear>.compile-gates.txt`, which appends the stored gate report verbatim;
+   hand the printed output to the drafter unchanged. The first round's prompt is always the
+   rendered standard prompt with no failure file.
 
 7. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> compile`
    from the repo root. It repeats step 4's placement of the step list and the proof, so it

--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -41,11 +41,23 @@ the pipeline exists to make trustworthy.
    setup error (missing input, missing stubs, unreachable API database) that no new draft can fix.
 
 4. **Diagnose and loop.** The runner prints a first-pass fault classification; confirm the rows it
-   marks NEEDS JUDGMENT against the table below. An emit fault goes back to step 2, up to about
-   three rounds: re-render the prompt with `python3 .claude/skills/generate-gear/render_prompt.py
-   emit-gear <gear> --failure-file .tmp/<gear>.gates.txt` and hand the printed output to the
-   drafter unchanged. The renderer appends the stored gate report verbatim; never paste failure
-   text into the prompt by hand. A compile fault, or an exit 2, stops the run.
+   marks NEEDS JUDGMENT against the table below. An emit fault goes back to the drafter, up to
+   about three rounds in total. A compile fault, or an exit 2, stops the run.
+
+   An emit fault does not change any input file, so the drafter that produced it still holds the
+   step list, the proof and the framework in context. Send it the stored gate report
+   `.tmp/<gear>.gates.txt` verbatim with `SendMessage` and let it revise
+   `.tmp/<gear>.generated.py`; never paste failure text edited by hand, and do not tell the
+   drafter to re-read inputs it has already read.
+
+   Spawn a fresh drafting subagent (a full step 2) only when one of these holds: this is the
+   first round; an input file (`steps.md`, the proof, the playbook, or a framework module)
+   changed since the drafter read it; the same gate fails in two consecutive continued rounds;
+   or the drafter is no longer reachable. A fresh retry round re-renders the prompt with
+   `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear> --failure-file
+   .tmp/<gear>.gates.txt`, which appends the stored gate report verbatim; hand the printed
+   output to the drafter unchanged. The first round's prompt is always the rendered standard
+   prompt with no failure file.
 
 5. **Place.** On success, run `python3 .claude/skills/generate-gear/stage.py <gear> module` from
    the repo root. It puts `.tmp/<gear>.generated.py` at `lib/geargen/<gear>.py` and reports what

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -160,8 +160,17 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 
 6. **Iterate.** A failed gate, a missing contract item, or an unresolved dependency means the
    **spec or playbook** is incomplete or wrong — fix it there (never hand-edit the generated file,
-   never copy from an existing implementation) and regenerate from the Generate step (step 4).
-   Repeat up to ~3 rounds. Converges when the output parses and satisfies the full declared contract.
+   never copy from an existing implementation) and regenerate from the Generate step (step 4) with
+   a fresh subagent, because the edit made the context the previous drafter read stale. Repeat up
+   to ~3 rounds. Converges when the output parses and satisfies the full declared contract.
+
+   One failure class skips the fresh spawn: a mechanical slip no spec wording caused (a syntax
+   error, a typo in a name the spec spells correctly). No input file changed, so send the check
+   output to the same drafting subagent with `SendMessage` and let it fix
+   `.tmp/<gear>.generated.py` in place. Skip step 4's telemetry reset and the watcher for such a
+   round — the fix runs without re-reading inputs, and completion arrives as the subagent's
+   reply. If no reply comes within about ten minutes, or the same check fails again, treat the
+   failure as a spec/playbook gap and take the fresh-spawn path above.
 
 7. **Install (on approval).** The generated file is the product. With the user's approval, copy
    `.tmp/<gear>.generated.py` to `lib/geargen/<gear>.py`. Without approval, leave it in `.tmp/`.


### PR DESCRIPTION
- Fix rounds continue the loaded drafter with only the check output, not a respawn.
- Fresh spawns stay for round 1, changed inputs, repeat failures, unreachable drafters.
- Gates, prompts, and fault tables are unchanged.

## Note

- A bare syntax error is now drafter behaviour; the rest keeps the spec-blame rule.
- Continued rounds skip the watcher, whose stale log would read as ANOMALY/DONE.

## Merge order

- `docs-orchestrator-lazy-reads` touches the same steps; the later merge must rebase.
