### PR TITLE
trim orchestrator up-front reads to on-demand

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -50,9 +50,11 @@ proof is where the next reader is looking for the missing check.
 1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Run
    `python3 .claude/skills/generate-gear/preflight.py <gear> --stage compile` and fix every
    `[FAIL]` before drafting; it verifies the engines, the go toolchain and the API database so a
-   broken environment fails here instead of mid-run. Read this file,
-   `PLAYBOOK.md`, the gear's spec end to end, and both harness APIs, `proof/proofkit/` and
-   `proof/proofkit3d/`.
+   broken environment fails here instead of mid-run. Read this file end to end. Do **not** read
+   `PLAYBOOK.md`, the spec, or the harness APIs up front: the drafting subagent reads them in
+   full, and the orchestrator reads on demand — the drafted step list around each name step 5
+   classifies, the spec lines a `fault:` line names in step 6, and a harness or playbook section
+   only when a specific diagnosis calls for it.
 
 2. **Stamp provenance.** The provenance table is generated, never typed. After each drafting round
    in step 3, run `python3 .claude/skills/generate-gear/gen_provenance.py <gear> --write
@@ -114,10 +116,14 @@ proof is where the next reader is looking for the missing check.
    step list mentions without requiring takes the exemption directive, and a call the module
    genuinely fails to make is work for `/emit-gear`, not for this stage. Never hand the drafter
    anything the module does or does not contain, and never let it read the module — the pipeline
-   has to be able to compile a gear that has no implementation yet.
+   has to be able to compile a gear that has no implementation yet. Classify by reading the
+   drafted step list around each printed name in `.tmp/<gear>.steps.md`; that is the only text
+   the classification needs.
 
 6. **Diagnose and loop.** Classify any failure with the table below. A draft fault goes back to
-   the drafter, up to about three rounds in total. A prose fault stops the run.
+   the drafter, up to about three rounds in total. A prose fault stops the run. Read, at this
+   point, only what the failure names: the spec file and line a `fault: prose` line prints, the
+   step and proof text the failure quotes, and any playbook anchor the step cites.
 
    A draft fault does not change any input file, so the drafter that produced it still holds
    every input in context. Send it the stored gate report `.tmp/<gear>.compile-gates.txt`

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -46,11 +46,11 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 1. **Setup.** Work in a worktree (per the repo's CLAUDE.md — never the root checkout). Ensure
    `.tmp/` exists. Run `python3 .claude/skills/generate-gear/preflight.py <gear> --stage generate`
    and fix every `[FAIL]` before drafting; it verifies the engines, the go toolchain and the API
-   database so a broken environment fails here instead of mid-run. Read this skill, `PLAYBOOK.md`, and the spec end-to-end. Skim the shared
-   framework the output builds on: `lib/geargen/base.py`, `misc.py`, `utilities.py`, `solids.py`,
-   `spurproxy.py`, `lib/fusion360utils/`, and `commands/<gear>/entry.py` (the same file set the
-   standard generation prompt hands the subagent). Note the gear's sketch-first proof at
-   `spec/<gear>/sketch/` if present (run in step 3).
+   database so a broken environment fails here instead of mid-run. Read this skill end-to-end.
+   Do **not** read `PLAYBOOK.md`, the spec body, or the framework files up front: the generation
+   subagent reads all of them, and each orchestrator decision that needs a section names that
+   section in the step that makes the decision (steps 2, 3, 5, 6 and 8 below). Note the gear's
+   sketch-first proof at `spec/<gear>/sketch/` if present (run in step 3).
 
 2. **Extract the contract from the spec.** Read the spec's **Contract** sections (the classes,
    hook methods, generation-context fields, generation order, and exact input ids / parameter-name
@@ -72,7 +72,9 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
    (see `[PB-SKETCH-FIRST]`).
    If the proof does not yet exist for this gear, build it from the spec's sketch recipes (the spur
    `spec/spurgear/sketch/` is the worked example) — a scheme that cannot reach `DOF == 0` on the
-   bench is a spec/playbook defect to fix here, not to discover inside Fusion. Requires a local
+   bench is a spec/playbook defect to fix here, not to discover inside Fusion. Read the playbook's
+   `[PB-SKETCH-FIRST]` section here when interpreting the advisory signals, and the spec's
+   sketch-recipe sections only if the proof has to be built at this step. Requires a local
    checkout of the `sketch` engine (`$SKETCH_DIR` or a sibling `../sketch`).
 
 4. **Generate.** Spawn a subagent that writes `.tmp/<gear>.generated.py` from **the spec +
@@ -154,7 +156,9 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
    - **Helper shadowing:** the manifest gate catches a literal re-definition of a framework
      helper (PLAYBOOK "Shared geargen helper library"), but a private re-implementation under
      a different name still needs a prose check. A shadow means the spec/playbook failed to
-     direct the generator to the helper; fix there and regenerate.
+     direct the generator to the helper; fix there and regenerate. Perform the prose half by
+     reading the playbook's "Shared geargen helper library" section and the `def` names in
+     `lib/geargen/solids.py` at this point; no earlier read supports it.
    - **Dependency resolution:** `check_contract.py` verifies `lib/geargen/` imports
      mechanically; confirm any other imported surface the spec's Dependencies section names.
 
@@ -162,7 +166,9 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
    **spec or playbook** is incomplete or wrong — fix it there (never hand-edit the generated file,
    never copy from an existing implementation) and regenerate from the Generate step (step 4) with
    a fresh subagent, because the edit made the context the previous drafter read stale. Repeat up
-   to ~3 rounds. Converges when the output parses and satisfies the full declared contract.
+   to ~3 rounds. Converges when the output parses and satisfies the full declared contract. When
+   diagnosing, read only the spec or playbook sections the failure implicates; the diagnosis is
+   when they earn their read.
 
    One failure class skips the fresh spawn: a mechanical slip no spec wording caused (a syntax
    error, a typo in a name the spec spells correctly). No input file changed, so send the check
@@ -178,7 +184,9 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 8. **Report.** State whether the spec drove a complete, contract-satisfying generation, the
    spec/playbook edits made, and any **asserted-but-unproven** gaps (geometry the spec describes
    that no mechanical check can confirm — see the honesty note). Commit spec/playbook improvements
-   (and the installed `.py` if approved). No push without explicit approval.
+   (and the installed `.py` if approved). No push without explicit approval. Source the
+   asserted-but-unproven list from the subagent's own report plus a skim of the spec's geometry
+   sections at this step, not from an up-front spec read.
 
 ## Required spec sections (the contract surface)
 


### PR DESCRIPTION
- Cuts 30–50K duplicated tokens per run: the orchestrator re-read what the drafting subagent already reads.
- No gate or prose check is removed; each now names a narrower read at the step performing it.
- Conflicts with `docs-continue-drafter-fix-rounds`; whichever lands second rebases and re-anchors.
