### PR TITLE
extract cited playbook rules for emit drafter

### DIFF
--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -23,7 +23,11 @@ the pipeline exists to make trustworthy.
    step list fails here instead of mid-run. If `steps-current` fails, run `/compile-gear <gear>`
    first.
 
-2. **Draft.** Spawn a subagent with the standard drafting prompt: run
+2. **Draft.** First run `python3 .claude/skills/generate-gear/extract_playbook.py <gear>` from the
+   repo root. It writes `.tmp/<gear>.playbook-extract.md`, the playbook rules the step list cites
+   by anchor plus the fixed core sections, which is the only playbook text the drafter reads. A
+   non-zero exit means the steps file and playbook disagree; run `check_anchors.py` and fix before
+   drafting. Then spawn a subagent with the standard drafting prompt: run
    `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear>` and pass its printed
    output to the subagent unchanged. It writes `.tmp/<gear>.generated.py`. Add no per-gear
    hints; anything the drafter needs belongs in the step list.

--- a/.claude/skills/emit-gear/prompt.md
+++ b/.claude/skills/emit-gear/prompt.md
@@ -4,8 +4,11 @@ only exist inside Fusion, so parsing is as far as it goes.
 
 **Read, in this order:** `spec/{{gear}}/steps.md`, which is your instruction set and which you work
 through in order; `proof/{{gear}}/`, the checked geometry, which steps tagged `[GO]` tell you to
-transliterate literally rather than re-derive; `.claude/skills/generate-gear/PLAYBOOK.md` for the
-rules the steps cite by anchor; and the framework you build on and must not reimplement, which is
+transliterate literally rather than re-derive; `.tmp/{{gear}}.playbook-extract.md`, the generated
+extract of the playbook rules the steps cite by anchor plus the shared core sections (it replaces
+reading `PLAYBOOK.md`, which you must not open — an anchor the extract lacks and the step list
+still needs is a defect to report, not a reason to go find the full playbook); and the framework
+you build on and must not reimplement, which is
 `lib/geargen/base.py`, `misc.py`, `utilities.py`, `spurproxy.py` and `lib/fusion360utils/`.
 
 **Do not read** `lib/geargen/{{gear}}.py`, `spec/{{gear}}/instructions.md`, `spec/{{gear}}/fusion.md`,

--- a/.claude/skills/generate-gear/extract_playbook.py
+++ b/.claude/skills/generate-gear/extract_playbook.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Extract the playbook rules a compiled step list actually cites.
+
+`emit-gear` hands its drafting subagent the whole 67 KB `PLAYBOOK.md` so it can
+resolve the two dozen `[PB-…]` anchors `spec/<gear>/steps.md` cites. Every other
+rule in that file is dead weight for a stage that only transcribes an already
+compiled step list: the emit drafter never chooses a new citation, so it never
+needs a rule the step list did not name.
+
+This script writes the cited rules — and only those, plus a small fixed core of
+sections every draft leans on — to `.tmp/<gear>.playbook-extract.md`. It is a
+deterministic text slice of the playbook, not a rewrite: every emitted line is a
+line of `PLAYBOOK.md`, so a rule reads in the extract exactly as it reads at its
+source.
+
+`compile-gear` still reads the full playbook, because that is the stage that
+decides which anchors a step list cites.
+
+Two anchor-definition forms exist, and this script honors both, the same two
+`check_anchors.py` encodes:
+
+  * a bold span opening a bullet or a paragraph — `**[PB-INPUT-READ] …`;
+  * an anchor anywhere on a markdown heading line — `## … ([PB-SKETCH-FIRST])`.
+
+A bold anchor's rule is the block it opens, up to the next definition at the
+same or shallower indent, the next heading, or the next top-level bullet.
+Nested anchors (`[PB-CIRCLE-CENTER]` inside `[PB-FULL-CONSTRAINT]`) therefore
+travel with their parent when the parent is cited, and extract alone when only
+the nested anchor is. A heading anchor's rule is its whole section.
+
+Anchors the step list cites that the playbook does not define — the per-gear
+`[SPUR-F-…]` sidecar anchors — are not errors. They live in `spec/<gear>/`
+files the emit stage is forbidden to read, so they were unresolvable at emit
+time before this script existed and remain so after. The generated header names
+them, so a drafter meeting one knows why it cannot be looked up.
+
+Usage:
+    python3 extract_playbook.py <gear> [--steps PATH] [--playbook PATH] [--out PATH]
+
+Run from the repo root. Exit 0 = written; 1 = a cited `PB-…` anchor (or a core
+section) has no definition in the playbook; 2 = a missing or unreadable input.
+"""
+import argparse
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_anchors  # noqa: E402  (sibling module; sys.path is fixed up just above)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, os.pardir))
+
+# The citation grammar is check_anchors.py's, imported rather than copied so the
+# extractor can never disagree with the gate about what counts as a citation.
+CITE_RE = check_anchors.CITE_RE
+BOLD_DEF_RE = check_anchors.BOLD_DEF_RE
+
+# Anchors under this prefix are the playbook's own; a cited one the playbook does
+# not define is a defect. Everything else is a per-gear sidecar anchor.
+PLAYBOOK_PREFIX = "PB-"
+
+# Sections every emitted module leans on whether or not a step cites them: the
+# module skeleton, the orchestration shape, the parameter mode, and the explicit
+# licence to vary what the spec does not pin. Matched by exact heading text.
+CORE_SECTIONS = (
+    "## Module layout & imports",
+    "## `generate` orchestration",
+    "## Parameters: live-expression mode vs all-Python-precomputed mode",
+    "## What the spec need not pin (free to vary)",
+)
+
+GEAR_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+HEADING_RE = re.compile(r"^(#{1,6})(?:\s|$)")
+# A bold anchor that OPENS its line, after an optional bullet or list marker.
+# `check_anchors.py` counts a bold anchor anywhere on a line as a definition, so
+# the playbook's own prose example ("stable IDs like `**[PB-RADIAL-DIM]**`") is a
+# definition to that gate. It is not the rule's home, and slicing a block there
+# would drop the real rule, so an opening match outranks an inline one.
+OPENING_DEF_RE = re.compile(
+    r"^(?:[-*+]\s+|\d+\.\s+)?\*\*\[(%s)\]" % check_anchors.ANCHOR)
+
+# Definition ranks, strongest first: a heading owns a whole section, a bold span
+# opening a line owns the block it starts, an inline mention owns nothing better.
+RANK_HEADING, RANK_OPENING, RANK_INLINE = 3, 2, 1
+
+
+class InputError(Exception):
+    """A missing or unreadable input file — exit 2, not a content defect."""
+
+
+class DefectError(Exception):
+    """The steps file and the playbook disagree — exit 1."""
+
+
+def read_lines(path, what):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read().splitlines()
+    except OSError as exc:
+        raise InputError("cannot read %s %s: %s" % (what, path, exc))
+
+
+def indent_of(line):
+    """Leading spaces; a `- ` bullet in column 0 has indent 0."""
+    return len(line) - len(line.lstrip(" "))
+
+
+def heading_level(line):
+    """`#` count for a heading line, else 0."""
+    match = HEADING_RE.match(line.lstrip())
+    return len(match.group(1)) if match else 0
+
+
+def line_definitions(line):
+    """Anchor ids this line defines, each with its rank.
+
+    Both of `check_anchors.py`'s forms count: a bold span, and any anchor on a
+    heading line. The rank records which of them, so a rule with more than one
+    mention is sliced at the mention that owns it.
+    """
+    found = {}
+    opening = OPENING_DEF_RE.match(line.lstrip(" "))
+    for match in BOLD_DEF_RE.finditer(line):
+        anchor = match.group(1)
+        rank = RANK_OPENING if opening and opening.group(1) == anchor else RANK_INLINE
+        found[anchor] = max(rank, found.get(anchor, 0))
+    if heading_level(line):
+        for match in CITE_RE.finditer(line):
+            found[match.group(1)] = RANK_HEADING
+    return found
+
+
+def collect_cites(lines):
+    """Cited ids in first-citation order."""
+    seen = []
+    for line in lines:
+        for match in CITE_RE.finditer(line):
+            if match.group(1) not in seen:
+                seen.append(match.group(1))
+    return seen
+
+
+def index_definitions(lines):
+    """Map anchor id -> (line index, rank, indent), strongest definition wins.
+
+    An id defined more than once resolves to its strongest mention, first one
+    of those if several tie. `[PB-VALIDATE-INPUTS]` sits on its `###` heading
+    and opens the paragraph below it, so it resolves to the heading, whose
+    section contains that paragraph anyway.
+    """
+    defs = {}
+    for index, line in enumerate(lines):
+        for anchor, rank in line_definitions(line).items():
+            existing = defs.get(anchor)
+            if existing is None or rank > existing[1]:
+                defs[anchor] = (index, rank, indent_of(line))
+    return defs
+
+
+def section_end(lines, start):
+    """End (exclusive) of the section opened by the heading at `start`."""
+    level = heading_level(lines[start])
+    for index in range(start + 1, len(lines)):
+        candidate = heading_level(lines[index])
+        if candidate and candidate <= level:
+            return index
+    return len(lines)
+
+
+def bold_block_end(lines, start):
+    """End (exclusive) of the rule block opened by the bold anchor at `start`."""
+    base = indent_of(lines[start])
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if heading_level(line):
+            return index
+        current = indent_of(line)
+        if line_definitions(line) and current <= base:
+            return index
+        if line.strip() and current == 0 and line.startswith("- "):
+            return index
+    return len(lines)
+
+
+def block_for(lines, definition):
+    start, rank, _ = definition
+    if rank == RANK_HEADING:
+        return (start, section_end(lines, start))
+    return (start, bold_block_end(lines, start))
+
+
+def find_core_blocks(lines, core_sections):
+    """Locate each core section by exact heading text; a missing one is a defect."""
+    positions = {}
+    for index, line in enumerate(lines):
+        if heading_level(line) and line.rstrip() not in positions:
+            positions[line.rstrip()] = index
+
+    blocks, missing = [], []
+    for heading in core_sections:
+        index = positions.get(heading)
+        if index is None:
+            missing.append(heading)
+            continue
+        blocks.append((index, section_end(lines, index)))
+    if missing:
+        raise DefectError(
+            "core section(s) missing from the playbook: %s" % ", ".join(missing))
+    return blocks
+
+
+def preamble_block(lines):
+    """Everything before the first `##` — title, purpose, anchor convention."""
+    for index, line in enumerate(lines):
+        if heading_level(line) >= 2:
+            return (0, index)
+    return (0, len(lines))
+
+
+def dedupe_blocks(blocks):
+    """Drop repeats and any block fully contained in another kept block."""
+    kept, reach = [], -1
+    for start, end in sorted(set(blocks), key=lambda b: (b[0], -b[1])):
+        if end <= reach:
+            continue
+        kept.append((start, end))
+        reach = end
+    return kept
+
+
+def heading_trail(lines, start):
+    """Section headings still open above `start`, outermost first.
+
+    A block that opens with a heading of its own gets only that heading's
+    ancestors, never the sibling section that happens to precede it. The file's
+    `#` title is left out: it is already the first line of the always-included
+    preamble.
+    """
+    limit = heading_level(lines[start]) or 7
+    trail = []
+    for index in range(start - 1, -1, -1):
+        level = heading_level(lines[index])
+        if level < 2 or level >= limit:
+            continue
+        trail.insert(0, lines[index])
+        limit = level
+        if level == 2:
+            break
+    return trail
+
+
+def strip_trailing_blanks(chunk):
+    while chunk and not chunk[-1].strip():
+        chunk.pop()
+    return chunk
+
+
+def build_header(gear, playbook_rel, unresolved):
+    lines = [
+        "# Playbook extract for `%s` — generated, do not edit" % gear,
+        "",
+        "This file is generated by `extract_playbook.py` from `%s`" % playbook_rel,
+        "for `%s`. Do not edit it: edit the playbook and re-run the extractor." % gear,
+        "",
+        "It holds the fixed core sections plus every rule the step list cites by anchor. The",
+        "playbook's other rules were omitted deliberately — their absence is a choice, not a gap,",
+        "and this extract replaces reading `PLAYBOOK.md` for this stage.",
+        "",
+    ]
+    if unresolved:
+        lines += [
+            "The step list also cites the anchors below. They are defined in the per-gear spec",
+            "sidecars this stage does not read, so they are intentionally unresolved here:",
+            "",
+        ]
+        lines += ["- `[%s]`" % anchor for anchor in unresolved]
+        lines.append("")
+    else:
+        lines += [
+            "Every anchor the step list cites is defined in the playbook and appears below.",
+            "",
+        ]
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def render(lines, blocks, header):
+    out = list(header)
+    emitted_trail = []
+    for start, end in blocks:
+        trail = heading_trail(lines, start)
+        shared = 0
+        while (shared < len(trail) and shared < len(emitted_trail)
+               and trail[shared] == emitted_trail[shared]):
+            shared += 1
+        for heading in trail[shared:]:
+            out.append(heading)
+            out.append("")
+        emitted_trail = trail
+        out.extend(strip_trailing_blanks(list(lines[start:end])))
+        out.append("")
+    return "\n".join(out).rstrip("\n") + "\n"
+
+
+def extract(gear, steps_path, playbook_path, core_sections=None):
+    """Return the extract text plus a summary tuple. Raises on any defect."""
+    core_sections = CORE_SECTIONS if core_sections is None else core_sections
+    steps_lines = read_lines(steps_path, "steps file")
+    playbook_lines = read_lines(playbook_path, "playbook")
+
+    cites = collect_cites(steps_lines)
+    defs = index_definitions(playbook_lines)
+
+    cited_here, unresolved, undefined = [], [], []
+    for anchor in cites:
+        if anchor in defs:
+            cited_here.append(anchor)
+        elif anchor.startswith(PLAYBOOK_PREFIX):
+            undefined.append(anchor)
+        else:
+            unresolved.append(anchor)
+    if undefined:
+        raise DefectError(
+            "cited but defined nowhere in the playbook: %s" % ", ".join(sorted(undefined)))
+
+    blocks = [preamble_block(playbook_lines)]
+    blocks += find_core_blocks(playbook_lines, core_sections)
+    blocks += [block_for(playbook_lines, defs[a]) for a in cited_here]
+    blocks = dedupe_blocks(blocks)
+
+    playbook_rel = os.path.relpath(os.path.abspath(playbook_path), REPO_ROOT)
+    header = build_header(gear, playbook_rel.replace(os.sep, "/"), unresolved)
+    text = render(playbook_lines, blocks, header)
+    playbook_bytes = len(("\n".join(playbook_lines) + "\n").encode("utf-8"))
+    return text, (len(cites), len(blocks), playbook_bytes)
+
+
+def main(argv, core_sections=None):
+    parser = argparse.ArgumentParser(
+        prog="extract_playbook.py",
+        description="Write the playbook rules a gear's step list cites.")
+    parser.add_argument("gear", help="gear name, e.g. spurgear")
+    parser.add_argument("--steps", help="step list (default spec/<gear>/steps.md)")
+    parser.add_argument("--playbook", help="playbook (default the one beside this script)")
+    parser.add_argument("--out", help="output (default .tmp/<gear>.playbook-extract.md)")
+    args = parser.parse_args(argv[1:])
+
+    if not GEAR_RE.match(args.gear):
+        print("extract_playbook: not a gear name: %r" % args.gear, file=sys.stderr)
+        return 2
+
+    steps = args.steps or os.path.join(REPO_ROOT, "spec", args.gear, "steps.md")
+    playbook = args.playbook or os.path.join(HERE, "PLAYBOOK.md")
+    out = args.out or os.path.join(REPO_ROOT, ".tmp", "%s.playbook-extract.md" % args.gear)
+
+    try:
+        text, (cited, blocks, playbook_bytes) = extract(
+            args.gear, steps, playbook, core_sections)
+    except InputError as exc:
+        print("extract_playbook: %s" % exc, file=sys.stderr)
+        return 2
+    except DefectError as exc:
+        print("extract_playbook: %s" % exc, file=sys.stderr)
+        print("extract_playbook: run check_anchors.py and fix before drafting.", file=sys.stderr)
+        return 1
+
+    parent = os.path.dirname(os.path.abspath(out))
+    try:
+        os.makedirs(parent, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    except OSError as exc:
+        print("extract_playbook: cannot write %s: %s" % (out, exc), file=sys.stderr)
+        return 2
+
+    share = 100.0 * len(text.encode("utf-8")) / playbook_bytes if playbook_bytes else 0.0
+    print("extract_playbook: %s: %d anchors cited, %d blocks written, %d bytes vs %d "
+          "playbook bytes (%.0f%%) -> %s"
+          % (args.gear, cited, blocks, len(text.encode("utf-8")), playbook_bytes, share, out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/skills/generate-gear/test_extract_playbook.py
+++ b/.claude/skills/generate-gear/test_extract_playbook.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Regressions for the cited-rules playbook extractor."""
+import contextlib
+import importlib.util
+import io
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+
+EXTRACTOR_PATH = Path(__file__).with_name('extract_playbook.py')
+MODULE_SPEC = importlib.util.spec_from_file_location('extract_playbook', EXTRACTOR_PATH)
+EXTRACTOR = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(EXTRACTOR)
+
+GENERATE_GEAR = EXTRACTOR_PATH.resolve().parent
+REPO_ROOT = GENERATE_GEAR.parent.parent.parent
+
+# One small playbook standing in for the real one: a preamble, two `##` sections
+# of bullet rules (one nest included), a heading-defined anchor with a `###`
+# subsection under it, and a trailing section to prove a block stops.
+FIXTURE_PLAYBOOK = """# Fixture Playbook
+
+Preamble text that every extract carries.
+
+## Alpha
+
+Intro prose for alpha.
+
+- **[PB-ONE] Rule one opener.** First body line of rule one.
+  Continuation line of rule one.
+- a plain bullet that anchors nothing
+- **[PB-TWO] Rule two opener.** Body of rule two.
+
+- **[PB-PARENT] Parent rule opener.** Body of the parent rule.
+  - **[PB-CHILD-A] Child A opener.** Body of child A.
+  - **[PB-CHILD-B] Child B opener.** Body of child B.
+- **[PB-AFTER] After rule opener.** Body of the after rule.
+
+## Beta
+
+Body of beta.
+
+## Gamma the heading anchor ([PB-GAMMA])
+
+Body of gamma.
+
+### Gamma subsection
+
+Body of the gamma subsection.
+
+## Delta
+
+Body of delta.
+"""
+
+
+class ExtractorTestCase(unittest.TestCase):
+    """Drive `main` against a fixture playbook in a temporary directory."""
+
+    def run_main(self, cites, playbook=FIXTURE_PLAYBOOK, core_sections=(),
+                 write_steps=True):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            steps = root / 'steps.md'
+            if write_steps:
+                steps.write_text(cites, encoding='utf-8')
+            book = root / 'PLAYBOOK.md'
+            book.write_text(playbook, encoding='utf-8')
+            out_path = root / 'out' / 'extract.md'
+            argv = [
+                'extract_playbook.py', 'testgear',
+                '--steps', str(steps),
+                '--playbook', str(book),
+                '--out', str(out_path),
+            ]
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = EXTRACTOR.main(argv, core_sections=core_sections)
+            text = out_path.read_text(encoding='utf-8') if out_path.exists() else ''
+        return code, text, stdout.getvalue(), stderr.getvalue()
+
+    def test_bullet_anchor_stops_at_the_next_top_level_bullet(self):
+        code, text, _, err = self.run_main('step cites [PB-ONE]\n')
+        self.assertEqual(code, 0, err)
+        self.assertIn('First body line of rule one.', text)
+        self.assertIn('Continuation line of rule one.', text)
+        self.assertNotIn('a plain bullet that anchors nothing', text)
+        self.assertNotIn('Body of rule two.', text)
+
+    def test_parent_anchor_carries_its_nested_anchors(self):
+        code, text, _, err = self.run_main('step cites [PB-PARENT]\n')
+        self.assertEqual(code, 0, err)
+        self.assertIn('Body of the parent rule.', text)
+        self.assertIn('Body of child A.', text)
+        self.assertIn('Body of child B.', text)
+        self.assertNotIn('Body of the after rule.', text)
+
+    def test_nested_anchor_alone_extracts_only_its_sub_block(self):
+        code, text, _, err = self.run_main('step cites [PB-CHILD-A]\n')
+        self.assertEqual(code, 0, err)
+        self.assertIn('Body of child A.', text)
+        self.assertNotIn('Body of child B.', text)
+        self.assertNotIn('Body of the parent rule.', text)
+
+    def test_heading_anchor_takes_its_whole_section(self):
+        code, text, _, err = self.run_main('step cites [PB-GAMMA]\n')
+        self.assertEqual(code, 0, err)
+        self.assertIn('Body of gamma.', text)
+        self.assertIn('Body of the gamma subsection.', text)
+        self.assertNotIn('Body of delta.', text)
+
+    def test_core_sections_survive_a_steps_file_with_no_cites(self):
+        code, text, _, err = self.run_main(
+            'a step that cites nothing at all\n', core_sections=('## Beta',))
+        self.assertEqual(code, 0, err)
+        self.assertIn('Preamble text that every extract carries.', text)
+        self.assertIn('## Beta', text)
+        self.assertIn('Body of beta.', text)
+        self.assertNotIn('Body of delta.', text)
+
+    def test_non_playbook_cites_pass_and_are_named_in_the_header(self):
+        code, text, _, err = self.run_main('step cites [SPUR-F-X] and [PB-ONE]\n')
+        self.assertEqual(code, 0, err)
+        self.assertIn('[SPUR-F-X]', text)
+        self.assertIn('this stage does not read', text)
+        self.assertIn('First body line of rule one.', text)
+
+    def test_undefined_playbook_anchor_exits_1_and_names_it(self):
+        code, text, out, err = self.run_main('step cites [PB-NOWHERE]\n')
+        self.assertEqual(code, 1)
+        self.assertEqual(text, '')
+        self.assertEqual(out, '')
+        self.assertIn('PB-NOWHERE', err)
+
+    def test_missing_steps_file_exits_2(self):
+        code, text, out, err = self.run_main('', write_steps=False)
+        self.assertEqual(code, 2)
+        self.assertEqual(text, '')
+        self.assertEqual(out, '')
+        self.assertIn('steps file', err)
+
+    def test_repeated_and_contained_blocks_are_written_once(self):
+        code, text, _, err = self.run_main(
+            'cites [PB-ONE] then [PB-ONE] again, plus [PB-PARENT] and [PB-CHILD-A]\n')
+        self.assertEqual(code, 0, err)
+        self.assertEqual(text.count('First body line of rule one.'), 1)
+        self.assertEqual(text.count('Body of child A.'), 1)
+        self.assertEqual(text.count('Body of the parent rule.'), 1)
+
+    def test_playbook_order_is_preserved_with_one_heading_trail(self):
+        code, text, _, err = self.run_main(
+            'cites [PB-GAMMA] first, then [PB-TWO], then [PB-ONE]\n')
+        self.assertEqual(code, 0, err)
+        one = text.index('First body line of rule one.')
+        two = text.index('Body of rule two.')
+        gamma = text.index('Body of gamma.')
+        self.assertLess(one, two)
+        self.assertLess(two, gamma)
+        # both bullet blocks live under Alpha, so the trail is written once
+        self.assertEqual(text.count('## Alpha'), 1)
+        self.assertIn('## Gamma the heading anchor ([PB-GAMMA])', text)
+
+    def test_missing_core_section_exits_1_and_names_it(self):
+        code, text, out, err = self.run_main(
+            'cites [PB-ONE]\n', core_sections=('## Alpha', '## No Such Section'))
+        self.assertEqual(code, 1)
+        self.assertEqual(text, '')
+        self.assertEqual(out, '')
+        self.assertIn('## No Such Section', err)
+        self.assertNotIn('## Alpha', err)
+
+
+class CommittedRepoTest(unittest.TestCase):
+    """Run the extractor over the real spurgear step list and playbook."""
+
+    def test_spurgear_extract_covers_every_cited_playbook_anchor(self):
+        playbook = GENERATE_GEAR / 'PLAYBOOK.md'
+        steps = REPO_ROOT / 'spec' / 'spurgear' / 'steps.md'
+        book_lines = playbook.read_text(encoding='utf-8').splitlines()
+
+        with tempfile.TemporaryDirectory() as directory:
+            out_path = Path(directory) / 'spurgear.playbook-extract.md'
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = EXTRACTOR.main(
+                    ['extract_playbook.py', 'spurgear', '--out', str(out_path)])
+            self.assertEqual(code, 0, stderr.getvalue())
+            text = out_path.read_text(encoding='utf-8')
+
+        cited = {
+            anchor for anchor in
+            EXTRACTOR.collect_cites(steps.read_text(encoding='utf-8').splitlines())
+            if anchor.startswith(EXTRACTOR.PLAYBOOK_PREFIX)
+        }
+        self.assertGreater(len(cited), 15, 'the spur step list should cite many playbook rules')
+
+        defs = EXTRACTOR.index_definitions(book_lines)
+        for anchor in sorted(cited):
+            with self.subTest(anchor=anchor):
+                self.assertIn(anchor, defs, 'cited playbook anchor has no definition')
+                self.assertIn(book_lines[defs[anchor][0]], text,
+                              'the extract dropped the line defining this rule')
+
+        self.assertLess(
+            len(text.encode('utf-8')),
+            len(playbook.read_bytes()) // 2,
+            'the extract should be well under half the playbook')
+
+    def test_definition_index_agrees_with_check_anchors(self):
+        """Every anchor `check_anchors.py` sees defined in the playbook is indexed."""
+        playbook = GENERATE_GEAR / 'PLAYBOOK.md'
+        text = playbook.read_text(encoding='utf-8')
+        gate_defs = set()
+        for line in text.splitlines():
+            gate_defs.update(m.group(1) for m in EXTRACTOR.BOLD_DEF_RE.finditer(line))
+            if line.lstrip().startswith('#'):
+                gate_defs.update(m.group(1) for m in EXTRACTOR.CITE_RE.finditer(line))
+        self.assertEqual(gate_defs, set(EXTRACTOR.index_definitions(text.splitlines())))
+
+    def test_core_sections_exist_in_the_committed_playbook(self):
+        text = (GENERATE_GEAR / 'PLAYBOOK.md').read_text(encoding='utf-8')
+        headings = {line.rstrip() for line in text.splitlines()
+                    if re.match(r'#{1,6}\s', line)}
+        for heading in EXTRACTOR.CORE_SECTIONS:
+            with self.subTest(heading=heading):
+                self.assertIn(heading, headings)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Emit's drafter now reads a generated extract of the cited playbook rules, not the whole file.
- Spurgear's extract is 20,861 bytes against 66,908; emit never picks a new citation anyway.
- Sidecar anchors were unresolvable at emit time before and after; the header names them.

## Invariants

- compile-gear still reads the full playbook, and no gate script or gate input changed.

## Merge order

- #59 and `chore-query-api-show-first` edit other paragraphs of the emit prompt; later one rebases.
