### PR TITLE
fail loudly when the provenance hasher cannot run

### DIFF
--- a/.claude/skills/generate-gear/check_compile.py
+++ b/.claude/skills/generate-gear/check_compile.py
@@ -62,7 +62,8 @@ sys.path.insert(0, HERE)
 import fusion_api  # noqa: E402  (sibling module; sys.path is fixed up just above)
 from call_parser import call_shapes  # noqa: E402
 from provenance import (  # noqa: E402  (sibling module; sys.path is fixed up just above)
-    DOCUMENT_REF, STAMPED_ROW, blob_hash, provenance_inputs, read, referenced_documents)
+    DOCUMENT_REF, STAMPED_ROW, ProvenanceError, blob_hash, provenance_inputs, read,
+    referenced_documents)
 
 PATH_REF = r'[\w./-]+\.(?:md|go|py|json|sh)'
 PATH_TOKEN = re.compile(r'`(%s)`' % PATH_REF)
@@ -1546,6 +1547,20 @@ def step_list_annotations(steps, arities):
 
 
 def main(argv):
+    """Run the gate, turning an unusable provenance hasher into exit 2.
+
+    A `git hash-object` that cannot run is a broken environment, the same class of failure as an
+    unreadable harness or a missing API database. It is reported here at exit 2 so a drafter is
+    never handed a git problem dressed up as a fault in the step list.
+    """
+    try:
+        return check(argv)
+    except ProvenanceError as exc:
+        print('check_compile: %s' % exc, file=sys.stderr)
+        return 2
+
+
+def check(argv):
     if len(argv) != 2:
         print('usage: check_compile.py <gear>', file=sys.stderr)
         return 2

--- a/.claude/skills/generate-gear/provenance.py
+++ b/.claude/skills/generate-gear/provenance.py
@@ -61,20 +61,34 @@ def read(path):
         return fh.read()
 
 
-def blob_hash(path):
-    return subprocess.run(['git', 'hash-object', path],
-                          capture_output=True, text=True).stdout.strip()
-
-
-HEADING = '## Provenance'
-TABLE_HEADER = ('| file | `git hash-object` |', '|---|---|')
 BLOB_HASH = re.compile(r'^[0-9a-f]{40}$')
-STAMPED_ROW = re.compile(r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|')
-SECTION_END = re.compile(r'^##\s', re.M)
 
 
 class ProvenanceError(Exception):
     """A provenance input cannot be hashed, or a step list has nowhere to put the table."""
+
+
+def blob_hash(path):
+    """The 40-character blob hash of one file.
+
+    Raises ProvenanceError when `git hash-object` cannot run or returns anything else. An empty
+    string returned here instead would match no stamped row, and the gate above would blame the
+    step list for a git problem that has nothing to do with it.
+    """
+    result = subprocess.run(['git', 'hash-object', path],
+                            capture_output=True, text=True)
+    digest = result.stdout.strip()
+    if result.returncode != 0 or not BLOB_HASH.match(digest):
+        raise ProvenanceError(
+            'git hash-object failed for %s (exit %d): %s'
+            % (path, result.returncode, result.stderr.strip() or 'no hash on stdout'))
+    return digest
+
+
+HEADING = '## Provenance'
+TABLE_HEADER = ('| file | `git hash-object` |', '|---|---|')
+STAMPED_ROW = re.compile(r'\|\s*`([\w./-]+)`\s*\|\s*`([0-9a-f]{40})`\s*\|')
+SECTION_END = re.compile(r'^##\s', re.M)
 
 
 def ordered_provenance_inputs(gear):

--- a/.claude/skills/generate-gear/test_check_compile.py
+++ b/.claude/skills/generate-gear/test_check_compile.py
@@ -21,6 +21,17 @@ from unittest import mock
 
 COMPILE_CHECKER_PATH = Path(__file__).with_name('check_compile.py')
 PROVENANCE_MODULE_PATH = Path(__file__).with_name('provenance.py')
+
+# `provenance` is registered in sys.modules before the checker is loaded, so check_compile.py's own
+# `from provenance import (...)` binds these exact objects rather than a second copy. A test that
+# raises `PROVENANCE.ProvenanceError` at the checker relies on that: two copies of the module would
+# be two distinct exception classes, and the checker's `except` would not see the one raised here.
+PROVENANCE_MODULE_SPEC = importlib.util.spec_from_file_location(
+    'provenance', PROVENANCE_MODULE_PATH)
+PROVENANCE = importlib.util.module_from_spec(PROVENANCE_MODULE_SPEC)
+sys.modules['provenance'] = PROVENANCE
+PROVENANCE_MODULE_SPEC.loader.exec_module(PROVENANCE)
+
 COMPILE_MODULE_SPEC = importlib.util.spec_from_file_location('check_compile', COMPILE_CHECKER_PATH)
 COMPILE_CHECKER = importlib.util.module_from_spec(COMPILE_MODULE_SPEC)
 COMPILE_MODULE_SPEC.loader.exec_module(COMPILE_CHECKER)
@@ -304,6 +315,26 @@ class CheckCompileTest(unittest.TestCase):
         'spec/gear/fusion.md',
         '.claude/skills/generate-gear/PLAYBOOK.md',
     )
+
+    @classmethod
+    def setUpClass(cls):
+        """Prove ambient `git hash-object` works before any fixture stamps a provenance table.
+
+        Almost every fixture here builds its rows with `blob_hash`, and a run where git cannot be
+        called would fail those tests on their own assertions — including the one pinning an exact
+        BLOCKING count, which any extra problem breaks. Skipping with the real reason keeps a
+        broken environment from reading as a broken gate.
+        """
+        with tempfile.TemporaryDirectory() as probe:
+            sample = os.path.join(probe, 'probe.md')
+            with open(sample, 'w') as fh:
+                fh.write('probe\n')
+            try:
+                COMPILE_CHECKER.blob_hash(sample)
+            except Exception as exc:
+                raise unittest.SkipTest(
+                    'git hash-object is unusable here, so provenance fixtures cannot be built: %s'
+                    % exc)
 
     def provenance_rows(self, root, paths=None):
         paths = paths or self.SOURCE_PATHS
@@ -1907,6 +1938,26 @@ class CheckCompileTest(unittest.TestCase):
 
         self.assertEqual(result, 1, output)
         self.assertIn('compile check: BLOCKING (1)', output)
+
+    def test_a_broken_provenance_hasher_is_a_setup_error_not_a_content_failure(self):
+        """A hasher that cannot run is exit 2, so a drafter is never handed a git problem.
+
+        The rows are written out here rather than built by the fixture: `provenance_rows` hashes
+        the fixture's own files, and the patch below has to be in force before the checker reads
+        them.
+        """
+        rows = '\n'.join('| `%s` | `%s` |' % (path, 'a' * 40) for path in self.SOURCE_PATHS)
+        err = io.StringIO()
+        with mock.patch.object(COMPILE_CHECKER, 'blob_hash',
+                               side_effect=PROVENANCE.ProvenanceError('boom')), \
+                contextlib.redirect_stderr(err):
+            result, output = self.run_checker(
+                provenance=rows,
+                step_body=self.call_step('thing.frobnicate(1)'),
+                api_lookup={'frobnicate': []})
+        self.assertEqual(result, 2, output)
+        self.assertIn('check_compile: boom', err.getvalue())
+        self.assertNotIn('BLOCKING', output)
 
 
 # The proof-side probe. The gate's answers about where a line may start are only worth anything

--- a/.claude/skills/generate-gear/test_stage.py
+++ b/.claude/skills/generate-gear/test_stage.py
@@ -380,12 +380,12 @@ class RunIndexDryRunTests(unittest.TestCase):
     def test_run_flag_rejected_for_steps_and_module(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = make_root(tmp, steps='# steps\n', module='# gen\n')
-            with self.assertRaises(SystemExit) as cm:
-                MODULE.main(['stage.py', '--root', str(root), 'spurgear', 'steps', '--run'])
-            self.assertEqual(cm.exception.code, 2)
-            with self.assertRaises(SystemExit) as cm:
-                MODULE.main(['stage.py', '--root', str(root), 'spurgear', 'module', '--run'])
-            self.assertEqual(cm.exception.code, 2)
+            for target in ('steps', 'module'):
+                err = io.StringIO()
+                with self.assertRaises(SystemExit) as cm, contextlib.redirect_stderr(err):
+                    MODULE.main(['stage.py', '--root', str(root), 'spurgear', target, '--run'])
+                self.assertEqual(cm.exception.code, 2)
+                self.assertIn('unrecognized arguments: --run', err.getvalue())
 
     def test_proof_indexes_writes_and_prunes_unless_no_index(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -598,9 +598,11 @@ class CompileTargetTests(unittest.TestCase):
     def test_run_flag_rejected_for_compile(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = make_root(tmp, draft={'a_test.go': 'x\n'}, steps='# steps\n')
-            with self.assertRaises(SystemExit) as cm:
+            err = io.StringIO()
+            with self.assertRaises(SystemExit) as cm, contextlib.redirect_stderr(err):
                 MODULE.main(['stage.py', '--root', str(root), 'spurgear', 'compile', '--run'])
             self.assertEqual(cm.exception.code, 2)
+            self.assertIn('unrecognized arguments: --run', err.getvalue())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- No commit ever fixed the intermittent blocking-count failure; a silently-empty `blob_hash` did it.
- Concurrent git from parallel agents was the trigger, so an unusable hasher is now exit 2, not exit 1.
- The `--run` rejection tests were right all along, and only needed stderr captured and the reason asserted.
