### PR TITLE
bring the readme up to date with the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,41 +13,72 @@ On top of the above, there were also a few minor issues that I wanted to see hap
 
 # Supported Gears
 
-The add-in installs one command per gear type into the Fusion **SOLID > CREATE** panel:
+The add-in installs one command per generator into a **Gears** dropdown in the Fusion **SOLID > CREATE** panel:
 
 * **Spur Gear**
 * **Helical Gear**
 * **Herringbone Gear**
-* **Bevel Gear**
+* **Bevel Gear** - straight or spiral from the same command. *Mean Spiral Angle* selects between them (0 gives a straight bevel), and *Hand of Spiral* picks the direction.
+* **Cycloidal Drive** - a speed reducer rather than a single gear. It builds the lobed disc(s), the eccentric cam, a pinless ring housing and the output plate with its pins, each in its own sub-component.
 
 # INSTALLATION
 
 This is a standard Fusion 360 add-in. There is no Marketplace package yet, so install it manually:
 
-1. Get the source into Fusion's `AddIns` directory. Either clone directly into it, or clone elsewhere and copy/symlink the folder there. The folder **must** be named `Gear Generator` (it has to match `Gear Generator.py` / `Gear Generator.manifest`).
+1. Get the add-in into Fusion's `AddIns` directory, in a folder named exactly `Gear Generator` (it has to match `Gear Generator.py` / `Gear Generator.manifest`).
 
    * **Windows:** `%APPDATA%\Autodesk\Autodesk Fusion 360\API\AddIns`
    * **macOS:** `~/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns`
+
+   The simplest route is to clone straight into that folder:
 
    ```sh
    git clone https://github.com/lestrrat-3d/fusion360-gear-generator.git "Gear Generator"
    ```
 
+   If you keep your checkout somewhere else, run `./deploy.sh` from it instead. That script copies only
+   the files Fusion actually loads (`Gear Generator.py`, the manifest, `config.py`, `commands/`, `lib/`
+   and the `diag_*.py` helpers) and leaves the specs, proofs and tooling behind. It picks the
+   destination from `$FUSION_ADDIN_DIR`, then from an untracked `.deploy.conf` beside the script, then
+   by searching the standard locations listed above. Re-run it after every change.
+
+   WSL users need `deploy.sh`: Fusion's August 2026 update stopped loading add-ins from
+   `\\wsl.localhost` paths, so pointing the `AddIns` folder at a WSL checkout no longer works.
+
 2. In Fusion 360, open **Utilities > Scripts and Add-Ins** (shortcut: `Shift+S`).
 3. Switch to the **Add-Ins** tab. `Gear Generator` should appear in the list.
 4. Select it and click **Run** (tick *Run on Startup* if you want it loaded automatically).
 
-The gear commands then live under **SOLID > CREATE**.
+The commands then live under **SOLID > CREATE > Gears**.
 
 # USAGE
 
-Pick a gear command from the **CREATE** panel, fill in the dialog (module, tooth count, pressure angle, etc.), and pick the plane/point that places the gear. The pitch and base circles are drawn and annotated alongside the gear body, and every generated sketch is fully constrained.
+Pick a generator from the **Gears** dropdown, fill in the dialog (module, tooth count, pressure angle,
+etc.), and pick the plane/point that places the result. The generated sketches are fully constrained,
+the one exception being the bevel tooth-profile and spiral guide sketches, which are exempt for the
+reasons recorded in `spec/bevelgear/fusion.md`. The spur, helical and herringbone gears also draw the
+root, tip, base and pitch circles alongside the gear body and label each one with its radius. The
+Cycloidal Drive checks its inputs as you type and shows the problem next to the offending field,
+keeping OK disabled until the values work.
+
+# DEVELOPMENT
+
+The generators under `lib/geargen/` are build output, not hand-written source. Each one is generated
+from its natural-language spec in `spec/<gear>/`, driven by the skills in `.claude/skills/`. Geometry
+checking is uneven so far: the spur gear has Go proofs under `proof/spurgear/`, the helical sketch
+scheme has a bench at `spec/helicalgear/sketch/`, and the remaining gears are checked only by loading
+them into Fusion.
+
+So a fix goes into the spec, or into the shared `.claude/skills/generate-gear/PLAYBOOK.md` when the
+behaviour applies to every gear, and then you regenerate. Editing `lib/geargen/<gear>.py` directly
+leaves the spec and the proof describing a gear that no longer exists. `CLAUDE.md` covers which skill
+regenerates what.
 
 # TODO
 
 * Diametral Pitch handling: I personally just don't need it, but I think it's just a matter of having a conversion table. Patches welcome.
-* Error handling: I have a few, but I should add more.
-* User-friendly UI: Currently there's minimal UI. I suck at UI, so if you can help me, I'd be so happy.
+* Error handling: a failed generation now rolls the new component back and reports in a dialog, and the Cycloidal Drive validates as you type. The other gears still need that same live validation.
+* User-friendly UI: the dialogs are still plain value and selection inputs. I suck at UI, so if you can help me, I'd be so happy.
 * Distribution: I have no idea how to package and otherwise distribute these things on AutoDesk Marketplace. If you can help me with it, I'd be so happy.
 
 # LICENSE


### PR DESCRIPTION
- 100 commits on, the README still hid the Cycloidal Drive, the spiral bevel and the `Gears` dropdown.
- Installing from a WSL checkout needs `deploy.sh`, and nothing said so.
- `lib/geargen/` is generated from `spec/`, so say it before someone hand-edits it.
