### PR TITLE
describe the cycloidal ring as pinless

### DIFF
--- a/commands/cycloidaldrive/entry.py
+++ b/commands/cycloidaldrive/entry.py
@@ -5,7 +5,9 @@ from .._gear_command import GearCommand
 command = GearCommand(
     gear_type='CycloidalDrive',
     name='Cycloidal Drive Generator',
-    description='Generates a Cycloidal Drive speed reducer (disk(s), ring pins, eccentric, output)',
+    # The ring is a pinless casing, so the tooltip names the housing rather
+    # than discrete ring pins (see "Pinless ring casing" in the spec).
+    description='Generates a Cycloidal Drive speed reducer (disc(s), pinless ring housing, eccentric cam, output)',
     icon_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', ''),
     configurator=geargen.CycloidalDriveCommandInputsConfigurator,
     generator_class=geargen.CycloidalDriveGenerator,


### PR DESCRIPTION
- The command tooltip promised ring pins the generator has not built since the ring went pinless.
- A comment now records why, so the wording does not get reverted.
- Spec wording is untouched: it uses "ring pins" for the rollers the profile is traced against.
