### PR TITLE
resolve subagent model by role, not name

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -48,7 +48,8 @@ proof is where the next reader is looking for the missing check.
 ## Procedure
 
 1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Run
-   `python3 .claude/skills/generate-gear/preflight.py <gear> --stage compile` and fix every
+   `python3 .claude/skills/generate-gear/preflight.py <gear> --stage compile --default-model
+   <the session's default model>` and fix every
    `[FAIL]` before drafting; it verifies the engines, the go toolchain and the API database so a
    broken environment fails here instead of mid-run. Read this file end to end. Do **not** read
    `PLAYBOOK.md`, the spec, or the harness APIs up front: the drafting subagent reads them in
@@ -71,7 +72,10 @@ proof is where the next reader is looking for the missing check.
 3. **Draft.** Spawn a subagent with the standard drafting prompt: run
    `python3 .claude/skills/generate-gear/render_prompt.py compile-gear <gear>` and pass its
    printed output to the subagent unchanged. It writes `.tmp/<gear>.steps.md` and the proof
-   files under `.tmp/<gear>-proof/`. Do
+   files under `.tmp/<gear>-proof/`. This drafter takes the `design` role, because the stage
+   interprets prose, so it runs on the session's default model; resolve it with
+   `python3 .claude/skills/generate-gear/pick_model.py --role design --default <the session's
+   default model>` and see `.claude/skills/generate-gear/MODELS.md` for the rule. Do
    **not** add per-gear hints, gotcha reminders or "high-risk" lists to that prompt. A hand-tuned
    prompt varies run to run and hides gaps by spoon-feeding what the prose should have said, so a
    green run would no longer say anything about the spec.
@@ -134,7 +138,9 @@ proof is where the next reader is looking for the missing check.
    Spawn a fresh drafting subagent (a full step 3) only when one of these holds: this is the
    first round; an input file (the spec, `fusion.md`, the playbook, or a harness package)
    changed since the drafter read it; the same check fails on the same step in two consecutive
-   continued rounds; or the drafter is no longer reachable. A fresh retry round re-renders the
+   continued rounds; or the drafter is no longer reachable. A fresh spawn keeps the `design`
+   role, and a continued round changes no model, because a resumed agent keeps the one it was
+   spawned on. A fresh retry round re-renders the
    prompt with `python3 .claude/skills/generate-gear/render_prompt.py compile-gear <gear>
    --failure-file .tmp/<gear>.compile-gates.txt`, which appends the stored gate report verbatim;
    hand the printed output to the drafter unchanged. The first round's prompt is always the

--- a/.claude/skills/emit-gear/SKILL.md
+++ b/.claude/skills/emit-gear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: emit-gear
-description: Write `lib/geargen/<gear>.py` from a compiled step list `spec/<gear>/steps.md` and its proof `proof/<gear>/`, without reading the prose spec or any existing implementation. The interpretation already happened during `/compile-gear`, so this stage is transcription against a fixed API and a small model should manage it. Use after `/compile-gear`. Args: optional `<gear>` name (default `spurgear`).
+description: Write `lib/geargen/<gear>.py` from a compiled step list `spec/<gear>/steps.md` and its proof `proof/<gear>/`, without reading the prose spec or any existing implementation. The interpretation already happened during `/compile-gear`, so this stage is transcription against a fixed API and its drafter takes the mechanical model tier. Use after `/compile-gear`. Args: optional `<gear>` name (default `spurgear`).
 ---
 
 # Emit the add-in from a compiled step list
@@ -17,7 +17,8 @@ the pipeline exists to make trustworthy.
 ## Procedure
 
 1. **Setup.** Work in a worktree, never the root checkout. Ensure `.tmp/` exists. Run
-   `python3 .claude/skills/generate-gear/preflight.py <gear> --stage emit` and fix every `[FAIL]`
+   `python3 .claude/skills/generate-gear/preflight.py <gear> --stage emit --default-model <the
+   session's default model>` and fix every `[FAIL]`
    before drafting; it verifies the engines, the go toolchain and the API database, and runs
    `check_compile.py <gear>` as its `steps-current` row, so a broken environment or a stale
    step list fails here instead of mid-run. If `steps-current` fails, run `/compile-gear <gear>`
@@ -31,12 +32,14 @@ the pipeline exists to make trustworthy.
    `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear>` and pass its printed
    output to the subagent unchanged. It writes `.tmp/<gear>.generated.py`. Add no per-gear
    hints; anything the drafter needs belongs in the step list.
-   Spawn the drafter on a small model — pass the Agent tool's `model` option (e.g. `haiku`)
-   when the harness offers one, and skip the option where it does not. This stage is
-   transcription against a fixed API, and step 4's gates, not the drafter, judge the output.
-   If small-model drafts fail the gates with emit faults in two consecutive rounds, respawn
-   the next round on the session's default model. The compile-gear drafter stays on the
-   default model; that stage interprets prose, only this one transcribes.
+   This drafter takes the `mechanical` role: the stage is transcription against a fixed API,
+   and step 4's gates, not the drafter, judge the output. Resolve its model with
+   `python3 .claude/skills/generate-gear/pick_model.py --role mechanical --default <the
+   session's default model>` and pass the printed name as the Agent tool's `model` option,
+   skipping the option where the harness offers none. Never write a model name into this file;
+   `.claude/skills/generate-gear/MODELS.md` holds the ladder and the reason the tier is
+   relative. The compile-gear drafter takes the `design` role instead, because that stage
+   interprets prose and only this one transcribes.
 
 3. **Gate.** Run `python3 .claude/skills/generate-gear/run_gates.py <gear> > .tmp/<gear>.gates.txt`
    from the repo root and read the file for the verdict. The stored copy is also what a retry round
@@ -57,7 +60,12 @@ the pipeline exists to make trustworthy.
    Spawn a fresh drafting subagent (a full step 2) only when one of these holds: this is the
    first round; an input file (`steps.md`, the proof, the playbook, or a framework module)
    changed since the drafter read it; the same gate fails in two consecutive continued rounds;
-   or the drafter is no longer reachable. A fresh retry round re-renders the prompt with
+   or the drafter is no longer reachable. Resolve a fresh spawn's model the same way step 2
+   does, except where drafts have failed the gates with emit faults in two consecutive rounds:
+   add `--escalated` to the `pick_model.py` call, which steps the drafter back up to the
+   session's default model for the rounds that remain. A continued round changes no model,
+   because a resumed agent keeps the one it was spawned on. A fresh retry round re-renders the
+   prompt with
    `python3 .claude/skills/generate-gear/render_prompt.py emit-gear <gear> --failure-file
    .tmp/<gear>.gates.txt`, which appends the stored gate report verbatim; hand the printed
    output to the drafter unchanged. The first round's prompt is always the rendered standard

--- a/.claude/skills/generate-gear/MODELS.md
+++ b/.claude/skills/generate-gear/MODELS.md
@@ -1,0 +1,57 @@
+# Which model a spawned agent runs on
+
+Every skill in this directory spawns subagents. This file says which model each one gets, and
+it is the only place that says it — a SKILL.md names the *role* and lets the tier follow.
+
+## The rule
+
+| Role | Tier |
+|---|---|
+| The orchestrator itself | the session's default model |
+| A subagent that interprets prose or designs | the session's default model |
+| A subagent doing mechanical transcription | one step down the ladder |
+
+Work that interprets prose stays on the default model because getting it wrong produces a
+wrong artifact that reads as a right one. Mechanical transcription steps down because the
+gates, not the drafter, judge that output, so a cheaper model costs a round at worst.
+
+## The ladder
+
+Highest to lowest: `opus`, then `sonnet`, then `haiku`. `fable` is not on the ladder.
+
+Two fallbacks, both of which mean "run it on the default":
+
+- The default already sits at the bottom of the ladder, so there is no rung below it.
+- The default is not on the ladder at all. The ladder is allowed to lag the models a harness
+  offers, and an unfamiliar name must not fail a run.
+
+Where the harness offers no model option at all, skip the option and let the spawn take
+whatever it takes.
+
+## Resolving it
+
+Never work the ladder out by hand, and never write a model name into a SKILL.md. Ask:
+
+    python3 .claude/skills/generate-gear/pick_model.py --role <design|mechanical> --default <model>
+
+`--default` is the session's default model, which is the one fact the script cannot discover
+for itself. stdout is the model name and nothing else; the reason goes to stderr.
+
+    $ python3 .claude/skills/generate-gear/pick_model.py --role mechanical --default opus
+    sonnet
+
+Pass `--escalated` for a mechanical role that has already burned its rounds, and it returns the
+session default instead of a step down. That is how a skill's "respawn on the default model
+after two failed rounds" rule gets applied, rather than remembered.
+
+## What this does not cover
+
+A resumed agent keeps the model it was spawned on. The `SendMessage` continue-paths in these
+skills therefore make no tier decision, and there is nothing to resolve before sending one.
+
+## Why the role and not the model
+
+Naming a model outright is wrong the moment the session default moves. Pinned to `haiku`, an
+Opus session drops its mechanical drafter two rungs instead of one. That is not hypothetical:
+it is what a measured `/emit-gear spurgear` run did on 2026-08-24, and the extra distance cost
+a full retry round on gate failures the next rung up would likely have avoided.

--- a/.claude/skills/generate-gear/SKILL.md
+++ b/.claude/skills/generate-gear/SKILL.md
@@ -44,7 +44,8 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 ## Procedure
 
 1. **Setup.** Work in a worktree (per the repo's CLAUDE.md — never the root checkout). Ensure
-   `.tmp/` exists. Run `python3 .claude/skills/generate-gear/preflight.py <gear> --stage generate`
+   `.tmp/` exists. Run `python3 .claude/skills/generate-gear/preflight.py <gear> --stage generate
+   --default-model <the session's default model>`
    and fix every `[FAIL]` before drafting; it verifies the engines, the go toolchain and the API
    database so a broken environment fails here instead of mid-run. Read this skill end-to-end.
    Do **not** read `PLAYBOOK.md`, the spec body, or the framework files up front: the generation
@@ -79,7 +80,10 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 
 4. **Generate.** Spawn a subagent that writes `.tmp/<gear>.generated.py` from **the spec +
    playbook + the framework files + any declared dependency files only**. It MUST NOT read an
-   existing `lib/geargen/<gear>.py` if one is present.
+   existing `lib/geargen/<gear>.py` if one is present. This drafter takes the `design` role,
+   because it re-interprets the whole prose spec, so it runs on the session's default model;
+   resolve it with `python3 .claude/skills/generate-gear/pick_model.py --role design --default
+   <the session's default model>` and see `MODELS.md` (next to this file) for the rule.
    - **Use the standard generation prompt: run
      `python3 .claude/skills/generate-gear/render_prompt.py generate-gear <gear>` and pass its
      printed output to the subagent unchanged — do NOT improvise the prompt, and do NOT add
@@ -165,7 +169,9 @@ The spec + playbook together MUST be sufficient. If they are not, fix the spec o
 6. **Iterate.** A failed gate, a missing contract item, or an unresolved dependency means the
    **spec or playbook** is incomplete or wrong — fix it there (never hand-edit the generated file,
    never copy from an existing implementation) and regenerate from the Generate step (step 4) with
-   a fresh subagent, because the edit made the context the previous drafter read stale. Repeat up
+   a fresh subagent, because the edit made the context the previous drafter read stale. A fresh
+   spawn keeps the `design` role, and a continued round changes no model, because a resumed
+   agent keeps the one it was spawned on. Repeat up
    to ~3 rounds. Converges when the output parses and satisfies the full declared contract. When
    diagnosing, read only the spec or playbook sections the failure implicates; the diagnosis is
    when they earn their read.

--- a/.claude/skills/generate-gear/pick_model.py
+++ b/.claude/skills/generate-gear/pick_model.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Resolve which model a spawned subagent should run on.
+
+The skills spawn subagents for two kinds of work, and the tier follows the
+kind rather than a pinned model name:
+
+  * work that interprets prose or designs runs on the session's default
+    model, because getting it wrong costs a wrong artifact rather than a
+    failed gate;
+  * mechanical transcription runs one step down the ladder, because the
+    gates, not the drafter, judge that output.
+
+Naming a model outright ("spawn on haiku") gets this wrong the moment the
+session default moves: pinned to `haiku`, an Opus session drops the drafter
+two rungs instead of one. This script keeps the ladder and its floor in one
+tested place so a SKILL.md can state the *role* and let the tier follow.
+
+The session's default model is the one fact the script cannot discover — only
+the orchestrating agent knows it — so it is an argument, not a probe.
+
+Usage:  python3 pick_model.py --role <design|mechanical> --default <model>
+                              [--escalated]
+
+stdout is the model name and nothing else, so the caller can read one token.
+The one-line reason goes to stderr. Exit 0 = resolved; exit 2 = bad usage.
+"""
+import argparse
+import sys
+
+# Highest to lowest. A model absent from this list is off-ladder: legal to
+# pass, but there is no defined step below it.
+LADDER = ('opus', 'sonnet', 'haiku')
+
+DESIGN = 'design'
+MECHANICAL = 'mechanical'
+# The orchestrator is not spawned by anything, but naming its role lets
+# MODELS.md state one rule for every agent in the pipeline.
+ROLES = {DESIGN: DESIGN, 'orchestrator': DESIGN, MECHANICAL: MECHANICAL}
+
+USAGE_EXIT = 2
+
+
+def step_down(model):
+    """The rung below `model`, or None when there is not one.
+
+    None covers both floors: the bottom of the ladder, and a model that is
+    not on the ladder at all.
+    """
+    try:
+        index = LADDER.index(model)
+    except ValueError:
+        return None
+    if index + 1 >= len(LADDER):
+        return None
+    return LADDER[index + 1]
+
+
+def resolve(role, default, escalated=False):
+    """Return (model, reason) for a role against a session default.
+
+    Never raises on an unrecognised `default`: an off-ladder name is a
+    fallback case, not an error, because the ladder is allowed to lag the
+    set of models a harness offers.
+    """
+    canonical = ROLES[role]
+    if canonical == DESIGN:
+        return default, 'design role runs on the session default'
+    if escalated:
+        return default, 'escalated: mechanical role stepped back up to the session default'
+    lower = step_down(default)
+    if lower is None:
+        if default in LADDER:
+            return default, 'default %s is the bottom of the ladder; no step down' % default
+        return default, 'default %s is not on the ladder; no step down' % default
+    return lower, 'mechanical role steps %s down to %s' % (default, lower)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog='pick_model.py',
+        description='Resolve the model a spawned subagent should run on.')
+    parser.add_argument(
+        '--role', required=True, choices=sorted(ROLES),
+        help='what the subagent does: design (or orchestrator) interprets and '
+             'designs, mechanical transcribes')
+    parser.add_argument(
+        '--default', required=True, metavar='MODEL',
+        help="the session's default model, which only the orchestrator knows")
+    parser.add_argument(
+        '--escalated', action='store_true',
+        help='a mechanical role that has already failed its rounds; run it on '
+             'the session default instead of a step down')
+    return parser.parse_args(argv)
+
+
+def main(argv, out=sys.stdout, err=sys.stderr):
+    args = parse_args(argv)
+    model, reason = resolve(args.role, args.default, args.escalated)
+    out.write('%s\n' % model)
+    err.write('pick_model: %s\n' % reason)
+    return 0
+
+
+def cli():
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except SystemExit as exc:
+        # argparse already printed the complaint; normalise its exit code so a
+        # usage error is distinguishable from a resolved answer.
+        raise SystemExit(USAGE_EXIT if exc.code not in (0, None) else 0)
+
+
+if __name__ == '__main__':
+    cli()

--- a/.claude/skills/generate-gear/preflight.py
+++ b/.claude/skills/generate-gear/preflight.py
@@ -41,7 +41,8 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 if HERE not in sys.path:
-    sys.path.insert(0, HERE)  # fusion_api / fusion_stubs are siblings, imported lazily below
+    sys.path.insert(0, HERE)  # fusion_api / fusion_stubs / pick_model are siblings, imported
+    #                           lazily below
 
 GEAR_NAME = re.compile(r'[a-z][a-z0-9_]*\Z')  # same spelling stage.py accepts
 TIMEOUT = 10  # seconds; every subprocess here is a version probe
@@ -75,11 +76,18 @@ class Usage(Exception):
 
 
 class Context(object):
-    """What every check is handed: the absolute root and the gear under test."""
+    """What every check is handed: the absolute root and the gear under test.
 
-    def __init__(self, root, gear):
+    `default_model` is the session's default model when the caller passed one.
+    It is the only field no check can derive for itself — the orchestrating
+    agent is the only thing that knows it — so it stays None when unstated and
+    the row that reads it skips.
+    """
+
+    def __init__(self, root, gear, default_model=None):
         self.root = root
         self.gear = gear
+        self.default_model = default_model
 
     def path(self, *parts):
         return os.path.join(self.root, *parts)
@@ -236,6 +244,24 @@ def check_revision_pin(ctx):
     return OK, 'revisions pinned to $SKETCH_COMMIT and $DECAD_COMMIT'
 
 
+def check_model_tiers(ctx):
+    """Record which model each role resolves to for this session.
+
+    Informational only. An off-ladder default is legal (MODELS.md), so there is
+    nothing here that can fail a stage; the row exists so a run's report says
+    which tier its drafter ran on instead of leaving it to be reconstructed.
+    """
+    if not ctx.default_model:
+        return SKIP, 'no --default-model given, so the tiers cannot be resolved'
+    try:
+        import pick_model
+    except ImportError as exc:
+        return SKIP, 'the sibling module pick_model could not be imported (%s)' % exc
+    design, _ = pick_model.resolve('design', ctx.default_model)
+    mechanical, reason = pick_model.resolve('mechanical', ctx.default_model)
+    return OK, 'design=%s, mechanical=%s (%s)' % (design, mechanical, reason)
+
+
 def check_api_db(ctx):
     try:
         import fusion_api
@@ -382,6 +408,7 @@ COMMON = (
     ('git', check_git, False),
     ('tmp-dir', check_tmp_dir, False),
     ('worktree', check_worktree, False),
+    ('model-tiers', check_model_tiers, False),
 )
 
 STAGES = {
@@ -490,6 +517,10 @@ def parse_args(argv):
     parser.add_argument('--stage', choices=['compile', 'emit', 'generate', 'all'], default='all')
     parser.add_argument('--root', default=None)
     parser.add_argument('--format', choices=['text', 'json'], default='text')
+    parser.add_argument(
+        '--default-model', default=None, metavar='MODEL',
+        help="the session's default model; makes the model-tiers row report which model each "
+             'role resolves to (see MODELS.md)')
     return parser.parse_args(argv)
 
 
@@ -505,7 +536,7 @@ def main(argv):
     args = parse_args(argv)
     if not GEAR_NAME.match(args.gear):
         raise Usage("'%s' is not a gear name; expected %s" % (args.gear, GEAR_NAME.pattern))
-    ctx = Context(resolve_root(args.root), args.gear)
+    ctx = Context(resolve_root(args.root), args.gear, args.default_model)
     results = run_checks(ctx, args.stage)
     render = render_json if args.format == 'json' else render_text
     print(render(args.gear, args.stage, results))

--- a/.claude/skills/generate-gear/test_pick_model.py
+++ b/.claude/skills/generate-gear/test_pick_model.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression tests for pick_model.py.
+
+Two invariants the suite defends:
+
+  * the tier follows the role and the session default, never a pinned model
+    name — the whole reason the script exists is that "spawn on haiku" is
+    wrong on any session whose default is not one rung above haiku;
+  * stdout carries the model name and nothing else, because a SKILL.md tells
+    the orchestrator to read one token from it.
+"""
+import contextlib
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+
+
+def _load(name):
+    path = Path(__file__).with_name('%s.py' % name)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pick_model = _load('pick_model')
+
+
+def run(argv):
+    """Invoke main() and return (exit code, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    code = pick_model.main(argv, out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+class LadderTests(unittest.TestCase):
+    def test_step_down_walks_the_ladder(self):
+        self.assertEqual(pick_model.step_down('opus'), 'sonnet')
+        self.assertEqual(pick_model.step_down('sonnet'), 'haiku')
+
+    def test_step_down_at_the_bottom_is_none(self):
+        self.assertIsNone(pick_model.step_down('haiku'))
+
+    def test_step_down_off_the_ladder_is_none(self):
+        self.assertIsNone(pick_model.step_down('fable'))
+        self.assertIsNone(pick_model.step_down('something-unreleased'))
+
+    def test_ladder_runs_highest_to_lowest(self):
+        self.assertEqual(pick_model.LADDER[0], 'opus')
+        self.assertEqual(pick_model.LADDER[-1], 'haiku')
+
+
+class DesignRoleTests(unittest.TestCase):
+    def test_design_returns_the_default_untouched(self):
+        for default in ('opus', 'sonnet', 'haiku', 'fable'):
+            with self.subTest(default=default):
+                model, _ = pick_model.resolve('design', default)
+                self.assertEqual(model, default)
+
+    def test_orchestrator_is_an_alias_of_design(self):
+        self.assertEqual(pick_model.resolve('orchestrator', 'opus')[0], 'opus')
+        self.assertEqual(pick_model.resolve('orchestrator', 'haiku')[0], 'haiku')
+
+    def test_escalated_does_not_disturb_design(self):
+        model, _ = pick_model.resolve('design', 'opus', escalated=True)
+        self.assertEqual(model, 'opus')
+
+
+class MechanicalRoleTests(unittest.TestCase):
+    def test_mechanical_steps_down_one_rung(self):
+        self.assertEqual(pick_model.resolve('mechanical', 'opus')[0], 'sonnet')
+        self.assertEqual(pick_model.resolve('mechanical', 'sonnet')[0], 'haiku')
+
+    def test_mechanical_at_the_floor_keeps_the_default(self):
+        model, reason = pick_model.resolve('mechanical', 'haiku')
+        self.assertEqual(model, 'haiku')
+        self.assertIn('bottom of the ladder', reason)
+
+    def test_mechanical_off_the_ladder_keeps_the_default(self):
+        model, reason = pick_model.resolve('mechanical', 'fable')
+        self.assertEqual(model, 'fable')
+        self.assertIn('not on the ladder', reason)
+
+    def test_an_opus_session_never_lands_on_haiku(self):
+        # The bug this script was written for: a pinned `haiku` drops an Opus
+        # session two rungs instead of one.
+        self.assertNotEqual(pick_model.resolve('mechanical', 'opus')[0], 'haiku')
+
+    def test_escalated_returns_the_session_default(self):
+        model, reason = pick_model.resolve('mechanical', 'opus', escalated=True)
+        self.assertEqual(model, 'opus')
+        self.assertIn('escalated', reason)
+
+
+class StreamTests(unittest.TestCase):
+    def test_stdout_is_only_the_model_name(self):
+        code, out, _ = run(['--role', 'mechanical', '--default', 'opus'])
+        self.assertEqual(code, 0)
+        self.assertEqual(out, 'sonnet\n')
+
+    def test_the_reason_goes_to_stderr(self):
+        _, out, err = run(['--role', 'mechanical', '--default', 'opus'])
+        self.assertNotIn('steps', out)
+        self.assertIn('pick_model:', err)
+
+    def test_escalated_flag_reaches_the_resolution(self):
+        _, out, _ = run(['--role', 'mechanical', '--default', 'opus', '--escalated'])
+        self.assertEqual(out, 'opus\n')
+
+
+class UsageTests(unittest.TestCase):
+    def _usage_failure(self, argv):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            with self.assertRaises(SystemExit) as caught:
+                pick_model.parse_args(argv)
+        self.assertNotIn(caught.exception.code, (0, None))
+
+    def test_unknown_role_is_rejected(self):
+        self._usage_failure(['--role', 'bogus', '--default', 'opus'])
+
+    def test_missing_default_is_rejected(self):
+        self._usage_failure(['--role', 'mechanical'])
+
+    def test_missing_role_is_rejected(self):
+        self._usage_failure(['--default', 'opus'])
+
+    def test_an_unreleased_default_is_accepted(self):
+        # The ladder is allowed to lag the models a harness offers, so an
+        # unknown name must fall back rather than fail the run.
+        args = pick_model.parse_args(['--role', 'mechanical', '--default', 'newthing'])
+        self.assertEqual(args.default, 'newthing')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.claude/skills/generate-gear/test_preflight.py
+++ b/.claude/skills/generate-gear/test_preflight.py
@@ -431,6 +431,45 @@ class StubTests(Fixture):
         self.assertEqual(os.listdir(str(cache)), [])
 
 
+class ModelTierTests(Fixture):
+    """The row records the tiers; it never decides whether a stage may run."""
+
+    def test_the_row_skips_when_no_default_model_is_given(self):
+        status, detail = MODULE.check_model_tiers(self.ctx)
+
+        self.assertEqual(status, MODULE.SKIP)
+        self.assertIn('--default-model', detail)
+
+    def test_the_row_reports_both_roles(self):
+        ctx = MODULE.Context(str(self.root), GEAR, 'opus')
+
+        status, detail = MODULE.check_model_tiers(ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertIn('design=opus', detail)
+        self.assertIn('mechanical=sonnet', detail)
+
+    def test_an_off_ladder_default_still_passes(self):
+        ctx = MODULE.Context(str(self.root), GEAR, 'something-unreleased')
+
+        status, detail = MODULE.check_model_tiers(ctx)
+
+        self.assertEqual(status, MODULE.OK)
+        self.assertIn('not on the ladder', detail)
+
+    def test_the_flag_reaches_the_row(self):
+        with mock.patch.dict(os.environ, self.resolved()):
+            _, out = self.run_cli(GEAR, '--stage', 'emit', '--root', str(self.root),
+                                  '--default-model', 'opus')
+
+        self.assertIn('model-tiers: design=opus, mechanical=sonnet', out)
+
+    def test_every_stage_records_the_tiers(self):
+        for stage in MODULE.STAGE_ORDER:
+            with self.subTest(stage=stage):
+                self.assertIn('model-tiers', [key for key, _, _ in MODULE.STAGES[stage]])
+
+
 class ReportTests(Fixture):
     """The two output shapes, and the promise that warnings alone still exit 0."""
 


### PR DESCRIPTION
- A SKILL.md should name a subagent's role, not its model.
- Pinning `haiku` drops an Opus session two rungs instead of one.
- `emit-gear` step 4's fresh spawn stated no tier at all.
