### PR TITLE
gate playbook citations and fix receiver walk

### DIFF
--- a/.claude/skills/compile-gear/SKILL.md
+++ b/.claude/skills/compile-gear/SKILL.md
@@ -99,21 +99,31 @@ proof is where the next reader is looking for the missing check.
    Then run `python3 .claude/skills/generate-gear/run_compile_gates.py <gear> >
    .tmp/<gear>.compile-gates.txt` from the repo root and read the file for the verdict. The stored
    copy is also what a retry round hands back to the drafter.
-   It runs `bash proof/run.sh`, then `check_compile.py <gear>`, then — only when
-   `lib/geargen/<gear>.py` exists — `check_step_calls.py`, in that order, and prints one verdict
+   It runs `bash proof/run.sh`, then `check_compile.py <gear>`, then
+   `extract_playbook.py <gear> --min-anchors 1`, then — only when `lib/geargen/<gear>.py`
+   exists — `check_step_calls.py`, in that order, and prints one verdict
    plus a first-pass fault classification. The proof wrapper enters the `proof/` module and
    configures the local engine replacements; the proof must pass with nothing waived. Exit 1 means
    a gate failed on content; exit 2 is a setup error, and a setup error never goes back to the
    drafter.
 
-5. **Check.** The runner already ran both checks. `check_compile.py` gates citations,
+5. **Check.** The runner already ran every check. `check_compile.py` gates spec citations,
    step-to-proof agreement, the reality of every named API call, and the provenance hashes. It
    also prints the spec lines no step claims, and every call on the unverified watchlist the step
    list makes; both are worth reading and neither gates.
 
+   `extract_playbook.py` builds the playbook slice `/emit-gear` will read and, with
+   `--min-anchors 1`, refuses a step list that cites no `[PB-…]` anchor. That extract is the only
+   playbook text the emit drafter sees, so a step list citing nothing leaves it with the core
+   sections and nothing else — about 8% of the file. The failure is the drafter's: send the report
+   back and let it cite the rules the steps lean on. The stage exits 1 for one other reason, an
+   anchor cited that the playbook does not define, which is either an invented anchor or a
+   playbook edited since the step list was drafted; the printed fault line says which of the two
+   it read.
+
    `check_step_calls.py` runs **only if `lib/geargen/<gear>.py` already exists**, and the runner
    reports it as skipped when it does not. That gate runs in CI against the checked-in module, so a
-   recompiled step list that disagrees with it breaks the build even though both other checks are
+   recompiled step list that disagrees with it breaks the build even though the other checks are
    green. On a failure, run `python3 .claude/skills/generate-gear/check_step_calls.py
    spec/<gear>/steps.md lib/geargen/<gear>.py --names`, which prints exactly the missing call
    names, one per line; classify each name and pass only the names back to the drafter: a name the
@@ -164,6 +174,8 @@ proof is where the next reader is looking for the missing check.
 | A step names a call the module is not required to make | Draft fault |
 | A named API call does not exist, and the spec did not name it | Draft fault |
 | A provenance hash does not match | A source changed after the table was stamped; re-run `gen_provenance.py` and check again |
+| The step list cites no playbook anchor | Draft fault |
+| A cited `[PB-…]` anchor is defined nowhere in the playbook | Draft fault, unless the playbook changed after the step list was drafted |
 | The scaffolder refuses an annotation, or the registration check names a mismatch | Draft fault |
 | **A named API call does not exist, and the spec named it** | **Prose fault** |
 | **The proof cannot fully constrain after three rounds** | **Prose fault** |

--- a/.claude/skills/compile-gear/prompt.md
+++ b/.claude/skills/compile-gear/prompt.md
@@ -37,6 +37,14 @@ instructions themselves, a `**From:**` line naming the spec files and line range
 from, and every Fusion API call it requires written inside a code span. A `[GO]` step also names
 the proof function that realises it and carries the `proof-run` annotation described below.
 
+**Cite by anchor every playbook rule a step relies on.** Write the anchor in the step, as
+`[PB-SKETCH-FIRST]`, wherever the step's instructions only make sense because of a rule the
+playbook states. You are the only stage that reads `PLAYBOOK.md`: `/emit-gear` is handed an
+extract built from your citations alone, so a rule you leaned on without naming is a rule the
+transcriber never sees. Cite a per-gear `fusion.md` anchor the same way; those resolve to nothing
+in the extract, and it says so, but the citation still records where the instruction came from.
+A gate refuses a step list that cites no playbook anchor at all.
+
 **A call span in a step is a call the module must make.** A later gate reads every call written
 in a code span and requires the generated module to make it. A name a step mentions without
 requiring it therefore has to be marked: a method the module defines for the framework to call, a

--- a/.claude/skills/generate-gear/check_api_calls.py
+++ b/.claude/skills/generate-gear/check_api_calls.py
@@ -326,9 +326,16 @@ def imported_framework_modules(tree, exports):
     return modules
 
 
-def imported_class_methods(tree, root, inherited_methods):
-    """Resolve methods only for classes explicitly imported by the target."""
-    imported_paths = []
+def imported_module_trees(tree, root):
+    """Parse every sibling module the target imports, following imports transitively.
+
+    These are the gear modules — `spurgear.py`, `helicalgear.py` — that a derived gear inherits
+    from.  They are neither the target nor shared framework, so nothing else here reads them, and
+    a gear two levels down its family (`herringbonegear` -> `helicalgear` -> `spurgear` ->
+    `Generator`) has its class hierarchy broken in the middle without them.
+    """
+    pending = []
+    seen = set()
 
     def module_path(module):
         candidates = (
@@ -345,38 +352,56 @@ def imported_class_methods(tree, root, inherited_methods):
             if module:
                 path = module_path(module)
                 if path is not None:
-                    imported_paths.append(path)
+                    pending.append(path)
             else:
-                imported_paths.extend(
+                pending.extend(
                     path for path in (module_path(alias.name) for alias in node.names)
                     if path is not None)
 
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ImportFrom):
-            continue
-        module = node.module.rsplit('.', 1)[-1] if node.module else None
-        if module:
-            path = module_path(module)
-            if path is not None:
-                imported_paths.append(path)
-        else:
-            imported_paths.extend(
-                path for path in (module_path(alias.name) for alias in node.names)
-                if path is not None)
+    add_imports(tree)
 
-    own = {}
-    bases = {}
-    seen_paths = set()
-    while imported_paths:
-        path = imported_paths.pop()
-        if path in seen_paths:
+    trees = []
+    while pending:
+        path = pending.pop()
+        if path in seen:
             continue
-        seen_paths.add(path)
+        seen.add(path)
         try:
             source = ast.parse(read_source(path))
         except (OSError, SyntaxError):
             continue
+        trees.append(source)
         add_imports(source)
+    return trees
+
+
+def imported_class_bases(trees):
+    """Base classes declared by the imported sibling modules, at module level."""
+    bases = {}
+    for source in trees:
+        for class_node in source.body:
+            if not isinstance(class_node, ast.ClassDef):
+                continue
+            bases[class_node.name] = {
+                base.id if isinstance(base, ast.Name) else base.attr
+                for base in class_node.bases
+                if isinstance(base, (ast.Name, ast.Attribute))
+            }
+    return bases
+
+
+def imported_method_returns(trees, known_classes):
+    """Method return types declared by the imported sibling modules."""
+    returns = {}
+    for source in trees:
+        returns.update(method_returns_from_tree(source, known_classes))
+    return returns
+
+
+def imported_class_methods(trees, inherited_methods):
+    """Resolve methods only for classes explicitly imported by the target."""
+    own = {}
+    for source in trees:
         for class_node in source.body:
             if not isinstance(class_node, ast.ClassDef):
                 continue
@@ -384,11 +409,7 @@ def imported_class_methods(tree, root, inherited_methods):
                 child.name for child in class_node.body
                 if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
             }
-            bases[class_node.name] = {
-                base.id if isinstance(base, ast.Name) else base.attr
-                for base in class_node.bases
-                if isinstance(base, (ast.Name, ast.Attribute))
-            }
+    bases = imported_class_bases(trees)
 
     resolved = {}
 
@@ -913,16 +934,24 @@ def main():
     framework_paths = framework_files(args.framework)
     framework_class_methods = framework_methods(framework_paths)
     framework_module_exports = framework_exports(framework_paths)
-    imported_methods = imported_class_methods(
-        tree, args.framework, framework_class_methods)
+    imported_trees = imported_module_trees(tree, args.framework)
+    imported_methods = imported_class_methods(imported_trees, framework_class_methods)
     inherited_methods = dict(framework_class_methods)
     inherited_methods.update(imported_methods)
     target_class_methods = target_methods(tree, inherited_methods)
     known_class_methods = dict(inherited_methods)
     known_class_methods.update(target_class_methods)
+    # The imported gear modules go between the framework and the target in all three maps, so a
+    # derived gear's class chain reaches the framework's annotated methods. Without them
+    # `HerringboneGearGenerator -> HelicalGearGenerator` is where the walk stops, and
+    # `self.getComponent()` — declared on `Generator` two links further up, annotated
+    # `-> adsk.fusion.Component` — resolves to nothing, so every call chained off it is reported
+    # as having an unknown receiver.
     bases = framework_bases(framework_paths)
+    bases.update(imported_class_bases(imported_trees))
     bases.update(class_bases_from_tree(tree))
     method_returns = framework_method_returns(framework_paths, known_class_methods)
+    method_returns.update(imported_method_returns(imported_trees, known_class_methods))
     method_returns.update(method_returns_from_tree(tree, known_class_methods))
     containing_classes = call_classes(tree)
     framework_modules = imported_framework_modules(tree, framework_module_exports)

--- a/.claude/skills/generate-gear/extract_playbook.py
+++ b/.claude/skills/generate-gear/extract_playbook.py
@@ -34,13 +34,27 @@ files the emit stage is forbidden to read, so they were unresolvable at emit
 time before this script existed and remain so after. The generated header names
 them, so a drafter meeting one knows why it cannot be looked up.
 
+`--min-anchors N` turns the extractor into a gate as well as a slicer. A step
+list that cites no playbook anchor at all extracts cleanly today: the header says
+every cited anchor was found, and the emit drafter is handed the core sections
+and nothing else. That is not a slice of the playbook, it is the absence of one,
+and it happened twice while bevelgear was being compiled. `--min-anchors 1` makes
+it a failure at compile time instead of a silent 8% extract at emit time.
+`run_compile_gates.py` passes it, and so does the `gates` job of
+`.github/workflows/3d-proof.yml`, so a step list cannot reach `main` without a
+citation either. The emit stage does not pass it: by then the step list is
+already committed and the gate belongs upstream of it.
+
 Usage:
     python3 extract_playbook.py <gear> [--steps PATH] [--playbook PATH] [--out PATH]
+                                       [--min-anchors N]
 
 Run from the repo root. Exit 0 = written; 1 = a cited `PB-…` anchor (or a core
-section) has no definition in the playbook; 2 = a missing or unreadable input.
+section) has no definition in the playbook, or fewer than `--min-anchors`
+playbook anchors are cited; 2 = a missing or unreadable input.
 """
 import argparse
+import collections
 import os
 import re
 import sys
@@ -83,6 +97,14 @@ OPENING_DEF_RE = re.compile(
 # Definition ranks, strongest first: a heading owns a whole section, a bold span
 # opening a line owns the block it starts, an inline mention owns nothing better.
 RANK_HEADING, RANK_OPENING, RANK_INLINE = 3, 2, 1
+
+
+# What one extraction measured. `cited` counts every anchor the step list names;
+# `playbook_cited` counts only the ones the playbook defines, which is the number
+# `--min-anchors` gates on, because a per-gear sidecar anchor resolves to nothing
+# here and so buys the emit drafter no rule.
+Summary = collections.namedtuple(
+    "Summary", ("cited", "playbook_cited", "blocks", "playbook_bytes"))
 
 
 class InputError(Exception):
@@ -334,7 +356,7 @@ def extract(gear, steps_path, playbook_path, core_sections=None):
     header = build_header(gear, playbook_rel.replace(os.sep, "/"), unresolved)
     text = render(playbook_lines, blocks, header)
     playbook_bytes = len(("\n".join(playbook_lines) + "\n").encode("utf-8"))
-    return text, (len(cites), len(blocks), playbook_bytes)
+    return text, Summary(len(cites), len(cited_here), len(blocks), playbook_bytes)
 
 
 def main(argv, core_sections=None):
@@ -345,10 +367,18 @@ def main(argv, core_sections=None):
     parser.add_argument("--steps", help="step list (default spec/<gear>/steps.md)")
     parser.add_argument("--playbook", help="playbook (default the one beside this script)")
     parser.add_argument("--out", help="output (default .tmp/<gear>.playbook-extract.md)")
+    parser.add_argument("--min-anchors", type=int, default=0, metavar="N",
+                        help="fail with exit 1 when the step list cites fewer than N "
+                             "playbook-defined anchors (default 0, which gates nothing)")
     args = parser.parse_args(argv[1:])
 
     if not GEAR_RE.match(args.gear):
         print("extract_playbook: not a gear name: %r" % args.gear, file=sys.stderr)
+        return 2
+
+    if args.min_anchors < 0:
+        print("extract_playbook: --min-anchors cannot be negative: %d" % args.min_anchors,
+              file=sys.stderr)
         return 2
 
     steps = args.steps or os.path.join(REPO_ROOT, "spec", args.gear, "steps.md")
@@ -356,8 +386,7 @@ def main(argv, core_sections=None):
     out = args.out or os.path.join(REPO_ROOT, ".tmp", "%s.playbook-extract.md" % args.gear)
 
     try:
-        text, (cited, blocks, playbook_bytes) = extract(
-            args.gear, steps, playbook, core_sections)
+        text, summary = extract(args.gear, steps, playbook, core_sections)
     except InputError as exc:
         print("extract_playbook: %s" % exc, file=sys.stderr)
         return 2
@@ -375,10 +404,20 @@ def main(argv, core_sections=None):
         print("extract_playbook: cannot write %s: %s" % (out, exc), file=sys.stderr)
         return 2
 
+    playbook_bytes = summary.playbook_bytes
     share = 100.0 * len(text.encode("utf-8")) / playbook_bytes if playbook_bytes else 0.0
-    print("extract_playbook: %s: %d anchors cited, %d blocks written, %d bytes vs %d "
-          "playbook bytes (%.0f%%) -> %s"
-          % (args.gear, cited, blocks, len(text.encode("utf-8")), playbook_bytes, share, out))
+    print("playbook-extract check: %s: %d anchors cited (%d defined in the playbook), "
+          "%d blocks written, %d bytes vs %d playbook bytes (%.0f%%) -> %s"
+          % (args.gear, summary.cited, summary.playbook_cited, summary.blocks,
+             len(text.encode("utf-8")), playbook_bytes, share, out))
+
+    if summary.playbook_cited < args.min_anchors:
+        print("extract_playbook: the step list cites %d playbook anchor(s); at least %d is "
+              "required." % (summary.playbook_cited, args.min_anchors), file=sys.stderr)
+        print("extract_playbook: a step list that cites nothing hands the emit drafter only the "
+              "core sections, so every rule the build depends on goes unstated. Cite the "
+              "playbook rule each step relies on by its `[PB-…]` anchor.", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/.claude/skills/generate-gear/run_compile_gates.py
+++ b/.claude/skills/generate-gear/run_compile_gates.py
@@ -17,7 +17,15 @@ standalone: it imports nothing from that script.
 
 What it does not do: it never copies, moves, or indexes a file. The proof is expected to be in
 `proof/<gear>/` already — `stage.py <gear> proof` puts it there — because a runner that also
-placed artifacts would hide a failed placement behind a failed gate.
+placed artifacts would hide a failed placement behind a failed gate. The one file it writes is
+the `playbook` stage's scratch extract under `.tmp/`, which is the extractor's own default
+output path and is read by nothing this stage does.
+
+The `playbook` stage is here because a step list that cites no `[PB-…]` anchor used to pass
+every compile gate. `check_compile.py` gates the spec lines a step cites, not the playbook rules
+it leans on, so a citation-free step list looked clean at compile time and handed the emit
+drafter an extract holding the core sections and nothing else. This runner calls
+`extract_playbook.py --min-anchors 1`, which turns that into a compile-time failure.
 
 Usage:
     run_compile_gates.py <gear> [options]
@@ -28,7 +36,7 @@ positional:
 
 options:
   --root PATH            repo root. Default: three levels above this script.
-  --only KEY[,KEY...]    run only these stages. Keys: proof, compile, step_calls.
+  --only KEY[,KEY...]    run only these stages. Keys: proof, compile, playbook, step_calls.
                          Unselected stages are reported with status "skip",
                          reason "not selected". An unknown key is a usage error.
   --fail-fast            stop scheduling stages after the first failure. Off by default, so
@@ -59,8 +67,15 @@ from dataclasses import dataclass
 # --- constants ---------------------------------------------------------------------------
 SCHEMA = 1
 DEFAULT_TIMEOUT = 900
-STAGE_ORDER = ("proof", "compile", "step_calls")
+STAGE_ORDER = ("proof", "compile", "playbook", "step_calls")
 JSON_MARKER = "COMPILE_GATES_JSON: "
+
+# The floor the `playbook` stage holds the step list to. One is deliberately the lowest number
+# that still refuses the failure this stage was added for: a step list citing nothing, whose
+# extract is the 8% of the playbook the core sections alone make up. A higher floor would be a
+# guess about how many rules a gear ought to need, and the three compiled gears cite 25, 9 and 39
+# playbook-defined anchors, so nothing near a real step list is being defended here.
+MIN_PLAYBOOK_ANCHORS = 1
 
 # The same gear-name rule stage.py and the other per-gear scripts use.
 GEAR_NAME = re.compile(r'[a-z][a-z0-9_]*\Z')
@@ -68,11 +83,13 @@ GEAR_NAME = re.compile(r'[a-z][a-z0-9_]*\Z')
 STAGE_TITLES = {
     "proof": "Proof",
     "compile": "Compile check",
+    "playbook": "Playbook extract",
     "step_calls": "Step calls",
 }
 
 STAGE_SCRIPTS = {
     "compile": "check_compile.py",
+    "playbook": "extract_playbook.py",
     "step_calls": "check_step_calls.py",
 }
 
@@ -86,6 +103,9 @@ HEADLINE_PATTERN = re.compile(r'^\S.*check.*:')
 API_CALL_NAME_RE = re.compile(r"names '(\w+)\(', which the Fusion API database does not have")
 PROVENANCE_DRIFT_RE = re.compile(r'has changed since the step list was compiled')
 
+# extract_playbook's own wording for the too-few-anchors defect, as opposed to its other exit-1.
+PLAYBOOK_UNCITED_RE = re.compile(r'playbook anchor\(s\); at least \d+ is required')
+
 # The fault sentences, one per row of SKILL.md's "Telling a draft fault from a prose fault".
 FAULT_PROOF = 'DRAFT FAULT by default ("The proof fails to build")'
 FAULT_DRAFT = "DRAFT FAULT"
@@ -94,6 +114,10 @@ FAULT_JUDGMENT = ("NEEDS JUDGMENT: a call the spec itself names is a PROSE FAULT
                   "drafter invented is a DRAFT FAULT")
 FAULT_STEP_CALLS = ("NEEDS CLASSIFICATION: read the output as call names and pass only the "
                     "names back to the drafter (SKILL.md step 5)")
+FAULT_PLAYBOOK_UNCITED = ("DRAFT FAULT: the step list cites no playbook rule, so the emit "
+                          "drafter would be handed the core sections and nothing else")
+FAULT_PLAYBOOK_UNDEFINED = ("DRAFT FAULT, or someone edited the playbook: the step list cites "
+                            "a [PB-...] anchor the playbook does not define")
 FAULT_SETUP = "SETUP ERROR: fix the environment or inputs; never retry the drafter"
 
 # Why a missing module is a skip rather than a failure. The wording is fixed because the
@@ -226,7 +250,10 @@ def setup_errors(paths, args):
 
     keys = set(active_keys(args))
 
-    if keys & {"compile", "step_calls"}:
+    # The playbook stage needs `PLAYBOOK.md` as well, and it is not checked here: the extractor
+    # resolves that path itself and exits 2 on an unreadable one, which this runner already
+    # reports as a setup error. Repeating the test would only let the two disagree.
+    if keys & {"compile", "playbook", "step_calls"}:
         if not os.path.isfile(_abs(paths.root, paths.steps)):
             errors.append("step list not found: %s -- draft it before checking it" % paths.steps)
 
@@ -266,6 +293,9 @@ def stage_command(key, paths):
         return ["bash", PROOF_RUNNER]
     if key == "compile":
         return [sys.executable, _script_path("check_compile.py", paths), paths.gear]
+    if key == "playbook":
+        return [sys.executable, _script_path("extract_playbook.py", paths), paths.gear,
+                "--min-anchors", str(MIN_PLAYBOOK_ANCHORS)]
     if key == "step_calls":
         return [sys.executable, _script_path("check_step_calls.py", paths),
                 paths.steps, paths.module]
@@ -372,6 +402,19 @@ def classify_compile(stdout):
     return FAULT_DRAFT
 
 
+def classify_playbook(stderr):
+    """Which of `extract_playbook.py`'s two exit-1 defects a failed playbook stage hit.
+
+    Both are the drafter's, so the distinction is only about what to tell it. The
+    too-few-anchors message is matched on the phrase the extractor prints; anything else
+    exit 1 can mean is the undefined-anchor defect, which is also what a playbook edit made
+    after the step list was drafted looks like from here.
+    """
+    if PLAYBOOK_UNCITED_RE.search(stderr or ""):
+        return FAULT_PLAYBOOK_UNCITED
+    return FAULT_PLAYBOOK_UNDEFINED
+
+
 def classify(results):
     """One fault sentence per stage that did not pass, mirroring SKILL.md's "Telling a draft
     fault from a prose fault" table. Pure function of the results, so it is directly testable."""
@@ -384,6 +427,8 @@ def classify(results):
                 faults[r.key] = FAULT_PROOF
             elif r.key == "compile":
                 faults[r.key] = classify_compile(r.stdout)
+            elif r.key == "playbook":
+                faults[r.key] = classify_playbook(r.stderr)
             elif r.key == "step_calls":
                 faults[r.key] = FAULT_STEP_CALLS
     return faults

--- a/.claude/skills/generate-gear/test_check_api_calls.py
+++ b/.claude/skills/generate-gear/test_check_api_calls.py
@@ -130,6 +130,80 @@ class CheckApiReceiverOwnershipTest(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertIn("calls 'getParameterValue('", output)
 
+    # `HerringboneGearGenerator` reaches `Generator.getComponent` only through two gear modules
+    # that are neither the target nor shared framework. Before those modules' base classes and
+    # return annotations were read, the walk stopped at the first of them and every call chained
+    # off `self.getComponent()` was reported as having an unknown receiver.
+    DERIVED_GEAR_FRAMEWORK = {
+        'base.py': (
+            "class Generator:\n"
+            "    def getComponent(self) -> adsk.fusion.Component:\n"
+            "        return self.component\n"
+        ),
+        'spurgear.py': (
+            "from .base import Generator\n"
+            "\n"
+            "class SpurGearGenerator(Generator):\n"
+            "    def buildTooth(self, ctx):\n"
+            "        pass\n"
+        ),
+        'helicalgear.py': (
+            "from .spurgear import SpurGearGenerator\n"
+            "\n"
+            "class HelicalGearGenerator(SpurGearGenerator):\n"
+            "    def loftTooth(self, ctx):\n"
+            "        pass\n"
+        ),
+    }
+
+    DERIVED_GEAR_MEMBERS = {
+        ('Component', 'features'): api_member('Features', kind='property'),
+        ('Features', 'mirrorFeatures'): api_member('MirrorFeatures', kind='property'),
+        ('MirrorFeatures', 'createInput'): api_member('MirrorFeatureInput'),
+    }
+
+    def test_receiver_resolves_through_two_imported_gear_modules(self):
+        result, output = self.run_checker(
+            """
+            from .helicalgear import HelicalGearGenerator
+
+            class HerringboneGearGenerator(HelicalGearGenerator):
+                def buildTooth(self, ctx):
+                    return self.getComponent().features.mirrorFeatures.createInput(
+                        ctx.entities, ctx.helixPlane)
+            """,
+            api_names={'createInput'},
+            members=self.DERIVED_GEAR_MEMBERS,
+            framework_files=self.DERIVED_GEAR_FRAMEWORK)
+
+        self.assertEqual(result, 0, output)
+        self.assertNotIn('receiver ownership is required', output)
+
+    def test_a_broken_middle_module_still_reports_the_unknown_receiver(self):
+        # The negative control for the test above: with `helicalgear` naming a base nothing
+        # defines, the chain to `Generator` really is broken and the finding must come back.
+        framework = dict(self.DERIVED_GEAR_FRAMEWORK)
+        framework['helicalgear.py'] = (
+            "class HelicalGearGenerator(NoSuchBase):\n"
+            "    def loftTooth(self, ctx):\n"
+            "        pass\n"
+        )
+        result, output = self.run_checker(
+            """
+            from .helicalgear import HelicalGearGenerator
+
+            class HerringboneGearGenerator(HelicalGearGenerator):
+                def buildTooth(self, ctx):
+                    return self.getComponent().features.mirrorFeatures.createInput(
+                        ctx.entities, ctx.helixPlane)
+            """,
+            api_names={'createInput'},
+            members=self.DERIVED_GEAR_MEMBERS,
+            framework_files=framework)
+
+        self.assertEqual(result, 1)
+        self.assertIn('receiver ownership is required', output)
+
     def test_valid_fusion_chain_and_exact_unverified_receiver_are_allowed(self):
         result, output = self.run_checker(
             """

--- a/.claude/skills/generate-gear/test_extract_playbook.py
+++ b/.claude/skills/generate-gear/test_extract_playbook.py
@@ -60,7 +60,7 @@ class ExtractorTestCase(unittest.TestCase):
     """Drive `main` against a fixture playbook in a temporary directory."""
 
     def run_main(self, cites, playbook=FIXTURE_PLAYBOOK, core_sections=(),
-                 write_steps=True):
+                 write_steps=True, min_anchors=None):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             steps = root / 'steps.md'
@@ -75,6 +75,8 @@ class ExtractorTestCase(unittest.TestCase):
                 '--playbook', str(book),
                 '--out', str(out_path),
             ]
+            if min_anchors is not None:
+                argv += ['--min-anchors', str(min_anchors)]
             stdout, stderr = io.StringIO(), io.StringIO()
             with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
                 code = EXTRACTOR.main(argv, core_sections=core_sections)
@@ -170,6 +172,41 @@ class ExtractorTestCase(unittest.TestCase):
         self.assertEqual(out, '')
         self.assertIn('## No Such Section', err)
         self.assertNotIn('## Alpha', err)
+
+
+class MinAnchorsTest(ExtractorTestCase):
+    """`--min-anchors` refuses a step list that cites nothing from the playbook."""
+
+    def test_no_floor_by_default(self):
+        code, _text, out, err = self.run_main('a step that cites nothing at all\n')
+        self.assertEqual(code, 0, err)
+        self.assertIn('0 anchors cited (0 defined in the playbook)', out)
+
+    def test_uncited_step_list_fails_the_floor(self):
+        code, _text, out, err = self.run_main(
+            'a step that cites nothing at all\n', min_anchors=1)
+        self.assertEqual(code, 1)
+        self.assertIn('cites 0 playbook anchor(s); at least 1 is required', err)
+        # The summary still prints, so the count that failed is visible beside the refusal.
+        self.assertIn('0 anchors cited (0 defined in the playbook)', out)
+
+    def test_one_citation_clears_a_floor_of_one(self):
+        code, _text, out, err = self.run_main('cites [PB-ONE]\n', min_anchors=1)
+        self.assertEqual(code, 0, err)
+        self.assertIn('1 anchors cited (1 defined in the playbook)', out)
+
+    def test_a_sidecar_anchor_alone_does_not_clear_the_floor(self):
+        # `[SPUR-F-X]` resolves to nothing in the extract, so it buys the emit drafter no rule
+        # and must not be counted toward the floor.
+        code, _text, _out, err = self.run_main('cites [SPUR-F-X] only\n', min_anchors=1)
+        self.assertEqual(code, 1)
+        self.assertIn('cites 0 playbook anchor(s)', err)
+
+    def test_a_negative_floor_is_a_usage_error(self):
+        code, _text, out, err = self.run_main('cites [PB-ONE]\n', min_anchors=-1)
+        self.assertEqual(code, 2)
+        self.assertEqual(out, '')
+        self.assertIn('--min-anchors cannot be negative', err)
 
 
 class CommittedRepoTest(unittest.TestCase):

--- a/.claude/skills/generate-gear/test_run_compile_gates.py
+++ b/.claude/skills/generate-gear/test_run_compile_gates.py
@@ -27,6 +27,8 @@ GEAR = 'spurgear'
 
 STUB_HEADLINE = {
     'compile': 'compile check: OK (12 steps, 4 proof functions, 3 spec files stamped)',
+    'playbook': ('playbook-extract check: spurgear: 38 anchors cited (25 defined in the '
+                 'playbook), 27 blocks written'),
     'step_calls': 'step-call check: OK (0 named calls present, no stubs, no shared-point misuse)',
 }
 
@@ -275,6 +277,65 @@ class CompileClassificationTests(BaseRunnerTest):
         self.assertEqual(exit_code, 1)
         self.assertEqual(self.by_key(parsed)['step_calls']['fault'], RUNNER.FAULT_STEP_CALLS)
         self.assertIn('NEEDS CLASSIFICATION', text)
+
+
+class PlaybookStageTests(BaseRunnerTest):
+    """The stage that refuses a step list citing no playbook rule."""
+
+    def _run_playbook_failure(self, stderr):
+        root = make_repo(self.tmp)
+        make_stubs(self.scripts, overrides={
+            'playbook': dict(exit_code=1, stdout='', stderr=stderr),
+        })
+        make_proof_runner(root)
+        return run(root, self.scripts, GEAR)
+
+    def test_stage_gets_the_gear_name_and_the_anchor_floor(self):
+        root = make_repo(self.tmp)
+        marker = os.path.join(self.tmp, 'playbook-argv.json')
+        make_stubs(self.scripts, overrides={'playbook': dict(argv_marker=marker)})
+        make_proof_runner(root)
+        exit_code, _text, _parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 0)
+        with open(marker) as fh:
+            self.assertEqual(json.load(fh),
+                             [GEAR, '--min-anchors', str(RUNNER.MIN_PLAYBOOK_ANCHORS)])
+
+    def test_stage_runs_even_without_a_module(self):
+        root = make_repo(self.tmp)  # no lib/geargen/<gear>.py
+        make_stubs(self.scripts)
+        make_proof_runner(root)
+        _exit_code, _text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(self.by_key(parsed)['playbook']['status'], 'pass')
+
+    def test_uncited_step_list_is_a_draft_fault(self):
+        exit_code, text, parsed = self._run_playbook_failure(
+            'extract_playbook: the step list cites 0 playbook anchor(s); at least 1 is required.')
+        self.assertEqual(exit_code, 1)
+        stage = self.by_key(parsed)['playbook']
+        self.assertEqual(stage['status'], 'fail')
+        self.assertEqual(stage['fault'], RUNNER.FAULT_PLAYBOOK_UNCITED)
+        self.assertIn('cites no playbook rule', text)
+
+    def test_undefined_anchor_is_the_other_fault(self):
+        exit_code, _text, parsed = self._run_playbook_failure(
+            'extract_playbook: cited but defined nowhere in the playbook: PB-MADE-UP')
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(self.by_key(parsed)['playbook']['fault'],
+                         RUNNER.FAULT_PLAYBOOK_UNDEFINED)
+
+    def test_unreadable_playbook_is_a_setup_error_not_a_draft_fault(self):
+        root = make_repo(self.tmp)
+        make_stubs(self.scripts, overrides={
+            'playbook': dict(exit_code=2,
+                             stderr='extract_playbook: cannot read playbook PLAYBOOK.md'),
+        })
+        make_proof_runner(root)
+        exit_code, _text, parsed = run(root, self.scripts, GEAR)
+        self.assertEqual(exit_code, 2)
+        stage = self.by_key(parsed)['playbook']
+        self.assertEqual(stage['status'], 'error')
+        self.assertEqual(stage['fault'], RUNNER.FAULT_SETUP)
 
 
 class SelectionTests(BaseRunnerTest):

--- a/.github/workflows/3d-proof.yml
+++ b/.github/workflows/3d-proof.yml
@@ -5,7 +5,8 @@ name: 3D proof
 #
 #   checkers  the gate scripts' own regression tests, which are gear-independent
 #   proof     proof/run.sh, which builds every gear's proof against pinned engine revisions
-#   gates     one leg per gear, running that gear's compile check and gate battery
+#   gates     one leg per gear, running that gear's compile check, playbook-citation check and
+#             gate battery
 #
 # The gates matrix covers every gear /compile-gear has produced a step list for. Add a gear to it
 # when it gains a spec/<gear>/steps.md; check_step_calls.py's WorkflowGateWiringTest fails the
@@ -172,6 +173,16 @@ jobs:
 
       - name: Check the ${{ matrix.gear }} step list is current
         run: python3 .claude/skills/generate-gear/check_compile.py ${{ matrix.gear }}
+        working-directory: gears
+
+      # The step list is the only thing that decides which playbook rules /emit-gear gets to
+      # read. One citing nothing extracts to the core sections alone, which is 8% of the file,
+      # and every other compile gate passes it. /compile-gear's runner gates this too; the step
+      # is repeated here so a step list cannot reach main without it.
+      - name: Check the ${{ matrix.gear }} step list cites the playbook
+        run: |
+          python3 .claude/skills/generate-gear/extract_playbook.py ${{ matrix.gear }} \
+            --min-anchors 1
         working-directory: gears
 
       - name: Gate the ${{ matrix.gear }} candidate


### PR DESCRIPTION
- A step list citing no playbook rule now fails at compile time and in CI.
- The compile drafting prompt asks for the anchor citations the gate requires.
- A derived gear reaches its framework base through the modules it imports.
