### PR TITLE
harden the drafting prompts

### DIFF
--- a/.claude/skills/compile-gear/prompt.md
+++ b/.claude/skills/compile-gear/prompt.md
@@ -45,6 +45,22 @@ transcriber never sees. Cite a per-gear `fusion.md` anchor the same way; those r
 in the extract, and it says so, but the citation still records where the instruction came from.
 A gate refuses a step list that cites no playbook anchor at all.
 
+**Carry into the step every value the emit stage cannot look up.** `/emit-gear` reads your step
+list, the proof and a playbook extract, and nothing else — it is forbidden to open the prose spec.
+So a step that says "verbatim from the input table", "as the spec gives", or "per the table above"
+with no table following resolves to nothing, and the transcriber fills the gap with a plausible
+invention. Measured: a step list that pointed at the dialog's input table instead of reproducing it
+shipped nine of seventeen input ids wrong, because `boreEnable` reads more naturally as
+`enableBore`. Reproduce the whole table. The same holds for any id, label, tooltip, constant name
+and its value, unit string, tolerance, magic number or fixed string a step depends on. A `**From:**`
+citation records where a step came from; it is not a way for the reader to go and look.
+
+**Name the exact entity a call is made against.** Where the spec pins the operand, write it; never
+reduce it to "again", "the same as above", or "likewise". Two operands that describe the same
+geometry are not interchangeable as constraint arguments — measured, a step that said "collinear
+again" was transcribed against the shaft axis rather than the line the spec named, and Fusion
+refused the sketch with `VCS_SKETCH_OVER_CONSTRAINTS`.
+
 **A call span in a step is a call the module must make.** A later gate reads every call written
 in a code span and requires the generated module to make it. A name a step mentions without
 requiring it therefore has to be marked: a method the module defines for the framework to call, a

--- a/.claude/skills/emit-gear/prompt.md
+++ b/.claude/skills/emit-gear/prompt.md
@@ -30,6 +30,25 @@ then ask `members <Class>`, which lists everything the class offers, inherited m
 to find what the step list meant. If the step list names a call the API does not have, report it
 and do not quietly correct it.
 
+**Every literal the step list states is exact — copy it, never regularise it.** Input ids, label
+strings, tooltips, constant names and their values, unit strings and default expressions are
+contract surface: the step list carries them because nothing you can read recovers them. An id
+written `boreEnable` is `boreEnable`, not `enableBore`; `spiralAngle` is not `meanSpiralAngle`.
+The failure here is not carelessness but tidying, and it has already shipped a broken dialog once.
+If a value you need is genuinely absent from the step list, that is a defect to report, never a gap
+to fill with a plausible invention.
+
+**Where a step names the entity a call is made against, use that entity and no other.** A step that
+says a line is collinear with `A->E` means `A->E`, not the axis further up the same chain, even
+though both describe the same infinite line. Substituting a geometrically equivalent operand there
+has already drawn a Fusion `VCS_SKETCH_OVER_CONSTRAINTS` refusal.
+
+**Ask the database before calling a type complaint a stub artifact.** Where a complaint is about
+whether a member exists at all, `show <Class>.<member>` settles it in one call. Reasoning from what
+the type ought to be has already passed a real bug through: three assignments to `SketchLine.name`,
+a property that class does not declare, which Fusion refuses at runtime. Every required gate passed
+on that build, and only the advisory novel-type row caught it.
+
 **Do every step.** A step you cannot finish is a defect to report, never a comment left in the
 file and never a silent omission.
 


### PR DESCRIPTION
- A step list can no longer point at a table the emit stage cannot open.
- The emit stage is told that stated literals are exact, not to be tidied.
- A type complaint about a member existing is checked, not assumed to be noise.
